### PR TITLE
fix(zigzag): default normalize to False to prevent label magnitude leak

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -98,7 +98,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     https://github.com/sponsors/robcaulk
     """
 
-    version = "3.11.7"
+    version = "3.11.8"
 
     _TEST_SIZE: Final[float] = 0.1
 
@@ -3592,7 +3592,6 @@ def label_objective(
         df,
         natr_period=label_period_candles,
         natr_multiplier=label_natr_multiplier,
-        normalize=False,
     )
 
     median_amplitude = np.nanmedian(np.asarray(pivots_amplitudes, dtype=float))

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -109,7 +109,7 @@ class QuickAdapterV3(IStrategy):
     _PLOT_EXTREMA_MIN_EPS: Final[float] = 0.01
 
     def version(self) -> str:
-        return "3.11.7"
+        return "3.11.8"
 
     timeframe = "5m"
     timeframe_minutes = timeframe_to_minutes(timeframe)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -1669,7 +1669,7 @@ def zigzag(
     df: pd.DataFrame,
     natr_period: int = 14,
     natr_multiplier: float = 9.0,
-    normalize: bool = True,
+    normalize: bool = False,
 ) -> tuple[
     list[int],
     list[float],


### PR DESCRIPTION
## Problem

`zigzag` defaulted to `normalize=True`, applying a global minmax scaling across all detected pivots to four metrics (`amplitudes`, `amplitude_threshold_ratios`, `volume_rates`, `speeds`).

When FreqAI's backtesting loop invokes `strategy.set_freqai_targets`, the dataframe passed to `_generate_extrema_label` is right-truncated to `tr_train.stopdt` but is **not** sliced to `train_period_days` until `dk.slice_dataframe` runs later. Pivots from outside the current training slice therefore contributed to the minmax statistics, contaminating the training-label magnitudes with out-of-train information. With `label_weighting.strategy="amplitude"` (production default), the contamination flowed directly into the `&s-extrema` labels via `apply_label_weighting`. Downstream `LabelTransformer.fit_transform` cannot recover from this because the values are already corrupted at label-creation time.

## Fix

Flip the `zigzag` default to `normalize=False` and drop the now-redundant `normalize=False` overrides at the two call sites (`_generate_extrema_label`, `label_objective`). Both callers want raw, unnormalized metrics; the only path that previously relied on the normalized output was the leak path.

Raw log-amplitude values `|log(P2/P1)|` are emitted instead, and any scaling is deferred to `LabelTransformer`, which is fitted strictly on the train slice and is therefore leak-free.

Strategy and regressor patch versions are bumped 3.11.7 → 3.11.8.

## Caveat

With `apply_label_weighting strategy="combined"`, the six metrics now sit on heterogeneous scales (raw log-amplitudes `~[0.005, 0.5]` mix with bounded ratios in `[0, 1]` like `efficiency_ratio`). Power-mean, `weighted_median` and `softmax` aggregations across these scales are no longer well-defined and require metric-specific rescaling on the train slice before aggregation. Direction-only (`strategy="none"`) and single-metric strategies (e.g. `strategy="amplitude"`) are unaffected.