### PR TITLE
feat(weights): per-label sample weights propagated to model.fit(sample_weight=...)

### DIFF
--- a/quickadapter/user_data/config-template.json
+++ b/quickadapter/user_data/config-template.json
@@ -109,6 +109,10 @@
       //   }
       // }
     },
+    "sample_weighting": {
+      "aggregation": "arithmetic_mean",
+      "softmax_temperature": 1.0
+    },
     "label_smoothing": {
       "method": "kaiser",
       "window_candles": 5,

--- a/quickadapter/user_data/config-template.json
+++ b/quickadapter/user_data/config-template.json
@@ -190,7 +190,7 @@
       "indicator_periods_candles": [8, 16, 32],
       "inlier_metric_window": 0,
       "noise_standard_deviation": 0.02,
-      "reverse_test_train_order": false,
+      "reverse_train_test_order": false,
       "plot_feature_importances": 0,
       "buffer_train_data_candles": 100
     },

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -102,6 +102,18 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     _TEST_SIZE: Final[float] = 0.1
 
+    _LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
+
+    @staticmethod
+    def _label_weight_column_name(label_col: str) -> str:
+        return f"{label_col}{QuickAdapterRegressorV3._LABEL_WEIGHT_SUFFIX}"
+
+    def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
+        dk.label_list = [
+            c for c in dk.label_list
+            if not c.endswith(self._LABEL_WEIGHT_SUFFIX)
+        ]
+
     _SQRT_2: Final[float] = np.sqrt(2.0)
 
     _OPTUNA_LABEL_N_OBJECTIVES: Final[int] = 7

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1576,7 +1576,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
                 ].to_numpy(dtype=float)
-        return compose_sample_weights(temporal, per_label)
+        aggregation = feat_dict.get("label_weights_aggregation", "arithmetic_mean")
+        softmax_temperature = feat_dict.get("label_weights_softmax_temperature", 1.0)
+        return compose_sample_weights(
+            temporal,
+            per_label,
+            aggregation=aggregation,
+            softmax_temperature=softmax_temperature,
+        )
 
     def _train_common(
         self,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -48,7 +48,6 @@ from Utils import (
     DEFAULT_FIT_LIVE_PREDICTIONS_CANDLES,
     DEFAULTS_LABEL_PREDICTION,
     LABEL_COLUMNS,
-    LABEL_WEIGHT_SUFFIX,
     REGRESSORS,
     Regressor,
     compose_sample_weights,
@@ -1354,8 +1353,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         :param dk: FreqaiDataKitchen object containing configuration
         :return: Trained model
         """
-        self._strip_label_weight_columns(dk)
-
         method = self.data_split_parameters.get(
             "method", QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT
         )
@@ -1383,9 +1380,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
-        return self._train_common(
-            unfiltered_df, pair, dk, dk.make_train_test_datasets, **kwargs
-        )
+        def split_fn(
+            features: pd.DataFrame,
+            labels: pd.DataFrame,
+            weights: NDArray[np.floating],
+        ) -> dict[str, Any]:
+            return self._make_default_split_datasets(features, labels, weights, dk)
+
+        return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
 
     def _train_timeseries_split(
         self,
@@ -1394,14 +1396,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
-        def split_fn(features: pd.DataFrame, labels: pd.DataFrame) -> dict[str, Any]:
-            feature_parameters = self.freqai_info.get("feature_parameters", {})
-            if feature_parameters.get("weight_factor", 0) > 0:
-                weights = np.asarray(
-                    dk.set_weights_higher_recent(len(features)), dtype=float
-                )
-            else:
-                weights = np.ones(len(features), dtype=float)
+        def split_fn(
+            features: pd.DataFrame,
+            labels: pd.DataFrame,
+            weights: NDArray[np.floating],
+        ) -> dict[str, Any]:
             return self._make_timeseries_split_datasets(features, labels, weights, dk)
 
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
@@ -1565,7 +1564,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         unfiltered_df: pd.DataFrame,
         pair: str,
         dk: FreqaiDataKitchen,
-        split_fn: Callable[[pd.DataFrame, pd.DataFrame], dict[str, Any]],
+        split_fn: Callable[
+            [pd.DataFrame, pd.DataFrame, NDArray[np.floating]], dict[str, Any]
+        ],
         **kwargs,
     ) -> Any:
         logger.info(
@@ -1578,6 +1579,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             dk.label_list,
             training_filter=True,
         )
+        weights = self._build_per_row_weights(features_filtered, unfiltered_df, dk)
         dates = ensure_datetime_series(unfiltered_df["date"])
         start_date = dates.iloc[0].strftime("%Y-%m-%d")
         end_date = dates.iloc[-1].strftime("%Y-%m-%d")
@@ -1585,16 +1587,21 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             f"-------------------- Training on data from {start_date} to "
             f"{end_date} --------------------"
         )
-        dd = split_fn(features_filtered, labels_filtered)
+        dd = split_fn(features_filtered, labels_filtered, weights)
         if not self.freqai_info.get("fit_live_predictions_candles", 0) or not self.live:
             dk.fit_labels()
-        dd = self._compose_train_weights(dd, unfiltered_df, dk)
         dd = self._apply_pipelines(dd, dk, pair)
+        if len(dd["train_features"]) != len(dd["train_weights"]):
+            raise RuntimeError(
+                f"Pipeline broke shape invariant: "
+                f"len(train_features)={len(dd['train_features'])} != "
+                f"len(train_weights)={len(dd['train_weights'])}"
+            )
         logger.info(
             f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
         )
         logger.info(f"Training model on {len(dd['train_features'])} data points")
-        model = self.fit(dd, dk)
+        model = self.fit(dd, dk, **kwargs)
         end_time = time.time()
         logger.info(
             f"-------------------- Done training {pair} "
@@ -1680,56 +1687,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         dk.data_dictionary = dd
 
-        return dd
-
-    @staticmethod
-    def _label_weight_column_name(label_col: str) -> str:
-        return f"{label_col}{LABEL_WEIGHT_SUFFIX}"
-
-    def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
-        dk.label_list = [
-            c for c in dk.label_list if not c.endswith(LABEL_WEIGHT_SUFFIX)
-        ]
-
-    @staticmethod
-    def _extract_split_weights(
-        weight_cols: dict[str, str],
-        split_index: pd.Index,
-        unfiltered_df: pd.DataFrame,
-    ) -> dict[str, NDArray]:
-        return {
-            label: unfiltered_df[weight_col]
-            .reindex(split_index, fill_value=1.0)
-            .to_numpy(dtype=float)
-            for label, weight_col in weight_cols.items()
-        }
-
-    def _compose_train_weights(
-        self,
-        dd: dict[str, Any],
-        unfiltered_df: pd.DataFrame,
-        dk: FreqaiDataKitchen,
-    ) -> dict[str, Any]:
-        weight_cols = {
-            label: self._label_weight_column_name(label)
-            for label in dk.label_list
-            if self._label_weight_column_name(label) in unfiltered_df.columns
-        }
-        if not weight_cols:
-            return dd
-        dd["train_weights"] = compose_sample_weights(
-            np.asarray(dd["train_weights"], dtype=float),
-            self._extract_split_weights(
-                weight_cols, dd["train_features"].index, unfiltered_df
-            ),
-        )
-        if dd.get("test_features") is not None and len(dd["test_features"]) > 0:
-            dd["test_weights"] = compose_sample_weights(
-                np.asarray(dd["test_weights"], dtype=float),
-                self._extract_split_weights(
-                    weight_cols, dd["test_features"].index, unfiltered_df
-                ),
-            )
         return dd
 
     def _make_timeseries_split_datasets(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1466,9 +1466,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             train_features = features
             train_labels = labels
             train_weights = weights
-            test_features = pd.DataFrame()
-            test_labels = np.zeros(2)
-            test_weights = np.zeros(2)
+            test_features = features.iloc[:0]
+            test_labels = labels.iloc[:0]
+            test_weights = weights[:0]
 
         if feat_dict.get("shuffle_after_split", False):
             parent_seed = sklearn_kwargs.get("random_state")

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -325,6 +325,21 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return set(QuickAdapterRegressorV3._POWER_MEAN_MAP.keys())
 
     @staticmethod
+    def _coerce_int(value: Any, name: str, *, minimum: int) -> int:
+        if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
+            raise ValueError(
+                f"Invalid data_split_parameters.{name} value {value!r}: "
+                f"must be int >= {minimum}"
+            )
+        return value
+
+    @staticmethod
+    def _coerce_optional_int(value: Any, name: str, *, minimum: int) -> Optional[int]:
+        if value is None:
+            return None
+        return QuickAdapterRegressorV3._coerce_int(value, name, minimum=minimum)
+
+    @staticmethod
     def _get_selection_category(method: str) -> Optional[str]:
         for (
             category,
@@ -1423,6 +1438,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             if k in QuickAdapterRegressorV3._SKLEARN_TRAIN_TEST_SPLIT_KEYS
         }
         test_size = dsp.get("test_size", QuickAdapterRegressorV3._TEST_SIZE)
+        if isinstance(test_size, bool) or not isinstance(test_size, (int, float)):
+            raise ValueError(
+                f"Invalid data_split_parameters.test_size value {test_size!r}: "
+                f"must be int or float"
+            )
 
         if test_size != 0:
             (
@@ -1519,7 +1539,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
         n_rows = len(features_filtered)
         feat_dict = self.freqai_info.get("feature_parameters", {})
-        if feat_dict.get("weight_factor", 0) > 0:
+        weight_factor = feat_dict.get("weight_factor", 0)
+        if (
+            not isinstance(weight_factor, bool)
+            and isinstance(weight_factor, (int, float))
+            and weight_factor > 0
+        ):
             temporal = np.asarray(dk.set_weights_higher_recent(n_rows), dtype=float)
         else:
             temporal = np.ones(n_rows, dtype=float)
@@ -1683,40 +1708,42 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         :param dk: FreqaiDataKitchen instance for data building
         :return: data_dictionary with train/test features/labels/weights
         """
-        n_splits = int(
+        n_splits = QuickAdapterRegressorV3._coerce_int(
             self.data_split_parameters.get(
                 "n_splits", QuickAdapterRegressorV3.TIMESERIES_N_SPLITS_DEFAULT
-            )
+            ),
+            "n_splits",
+            minimum=2,
         )
-        gap = int(
+        gap = QuickAdapterRegressorV3._coerce_int(
             self.data_split_parameters.get(
                 "gap", QuickAdapterRegressorV3.TIMESERIES_GAP_DEFAULT
-            )
+            ),
+            "gap",
+            minimum=0,
         )
-        max_train_size = self.data_split_parameters.get(
-            "max_train_size", QuickAdapterRegressorV3.TIMESERIES_MAX_TRAIN_SIZE_DEFAULT
+        max_train_size = QuickAdapterRegressorV3._coerce_optional_int(
+            self.data_split_parameters.get(
+                "max_train_size",
+                QuickAdapterRegressorV3.TIMESERIES_MAX_TRAIN_SIZE_DEFAULT,
+            ),
+            "max_train_size",
+            minimum=1,
         )
-        max_train_size = int(max_train_size) if max_train_size is not None else None
-
-        if n_splits < 2:
-            raise ValueError(
-                f"Invalid data_split_parameters.n_splits value {n_splits!r}: must be >= 2"
-            )
-        if gap < 0:
-            raise ValueError(
-                f"Invalid data_split_parameters.gap value {gap!r}: must be >= 0"
-            )
-        if max_train_size is not None and max_train_size < 1:
-            raise ValueError(
-                f"Invalid data_split_parameters.max_train_size value {max_train_size!r}: "
-                f"must be >= 1 or None"
-            )
 
         test_size = self.data_split_parameters.get("test_size", None)
         if test_size is not None:
-            if isinstance(test_size, float) and 0 < test_size < 1:
+            if (
+                not isinstance(test_size, bool)
+                and isinstance(test_size, float)
+                and 0 < test_size < 1
+            ):
                 test_size = int(len(filtered_dataframe) * test_size)
-            elif isinstance(test_size, int) and test_size >= 1:
+            elif (
+                not isinstance(test_size, bool)
+                and isinstance(test_size, int)
+                and test_size >= 1
+            ):
                 pass
             else:
                 raise ValueError(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1558,12 +1558,25 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             temporal = np.ones(n_rows, dtype=float)
 
         per_label: dict[str, NDArray[np.floating]] = {}
+        missing: list[str] = []
         for label in dk.label_list:
             col = label_weight_column_name(label)
             if col in unfiltered_df.columns:
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
                 ].to_numpy(dtype=float)
+            else:
+                missing.append(col)
+        if per_label:
+            logger.debug(
+                f"per-label weight columns active: {sorted(per_label)}"
+                + (f" (no weight column for: {sorted(missing)})" if missing else "")
+            )
+        else:
+            logger.warning(
+                f"no per-label weight columns found (expected: {sorted(missing)}); "
+                f"falling back to temporal weights only"
+            )
         sample_weighting = get_sample_weighting_config(
             self.freqai_info.get("sample_weighting", {}), logger
         )
@@ -1571,6 +1584,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return compose_sample_weights(
             temporal,
             per_label,
+            logger=logger,
             aggregation=sample_weighting_default["aggregation"],
             softmax_temperature=sample_weighting_default["softmax_temperature"],
         )

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -48,6 +48,7 @@ from Utils import (
     DEFAULT_FIT_LIVE_PREDICTIONS_CANDLES,
     DEFAULTS_LABEL_PREDICTION,
     LABEL_COLUMNS,
+    LABEL_WEIGHT_SUFFIX,
     REGRESSORS,
     Regressor,
     compose_sample_weights,
@@ -102,8 +103,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     version = "3.11.9"
 
     _TEST_SIZE: Final[float] = 0.1
-
-    _LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
 
     _SQRT_2: Final[float] = np.sqrt(2.0)
 
@@ -1521,12 +1520,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     @staticmethod
     def _label_weight_column_name(label_col: str) -> str:
-        return f"{label_col}{QuickAdapterRegressorV3._LABEL_WEIGHT_SUFFIX}"
+        return f"{label_col}{LABEL_WEIGHT_SUFFIX}"
 
     def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
         dk.label_list = [
             c for c in dk.label_list
-            if not c.endswith(self._LABEL_WEIGHT_SUFFIX)
+            if not c.endswith(LABEL_WEIGHT_SUFFIX)
         ]
 
     @staticmethod

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1394,6 +1394,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         :param dk: FreqaiDataKitchen object containing configuration
         :return: Trained model
         """
+        self._strip_label_weight_columns(dk)
+
         method = self.data_split_parameters.get(
             "method", QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT
         )
@@ -1407,7 +1409,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         logger.info(f"Using data split method: {method}")
 
         if method == QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT:
-            return super().train(unfiltered_df, pair, dk, **kwargs)
+            return self._train_default(unfiltered_df, pair, dk, **kwargs)
 
         elif (
             method == QuickAdapterRegressorV3._DATA_SPLIT_METHODS[1]
@@ -1443,6 +1445,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             ):
                 dk.fit_labels()
 
+            dd = self._compose_train_weights(dd, unfiltered_df, dk)
+
             dd = self._apply_pipelines(dd, dk, pair)
 
             logger.info(
@@ -1460,6 +1464,52 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
 
             return model
+
+    def _train_default(
+        self,
+        unfiltered_df: pd.DataFrame,
+        pair: str,
+        dk: FreqaiDataKitchen,
+        **kwargs,
+    ) -> Any:
+        logger.info(f"-------------------- Starting training {pair} --------------------")
+        start_time = time.time()
+
+        features_filtered, labels_filtered = dk.filter_features(
+            unfiltered_df,
+            dk.training_features_list,
+            dk.label_list,
+            training_filter=True,
+        )
+
+        dates = ensure_datetime_series(unfiltered_df["date"])
+        start_date = dates.iloc[0].strftime("%Y-%m-%d")
+        end_date = dates.iloc[-1].strftime("%Y-%m-%d")
+        logger.info(
+            f"-------------------- Training on data from {start_date} to "
+            f"{end_date} --------------------"
+        )
+
+        dd = dk.make_train_test_datasets(features_filtered, labels_filtered)
+        if not self.freqai_info.get("fit_live_predictions_candles", 0) or not self.live:
+            dk.fit_labels()
+
+        dd = self._compose_train_weights(dd, unfiltered_df, dk)
+
+        dd = self._apply_pipelines(dd, dk, pair)
+
+        logger.info(f"Training model on {len(dd['train_features'].columns)} features")
+        logger.info(f"Training model on {len(dd['train_features'])} data points")
+
+        model = self.fit(dd, dk, **kwargs)
+
+        end_time = time.time()
+        logger.info(
+            f"-------------------- Done training {pair} "
+            f"({end_time - start_time:.2f} secs) --------------------"
+        )
+
+        return model
 
     def _apply_pipelines(
         self,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1425,26 +1425,28 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         weights: NDArray[np.floating],
         dk: FreqaiDataKitchen,
     ) -> dict[str, Any]:
-        """Random train/test split via sklearn's ``train_test_split``.
+        """Train/test split via sklearn's ``train_test_split``.
 
         Routes ``data_split_parameters`` to sklearn through a whitelist of
         sklearn-recognized keys; project-custom keys (``method``,
         ``n_splits``, ``gap``, ``max_train_size``) are filtered out.
-        Honors ``feature_parameters.shuffle_after_split`` (deterministic
-        when ``random_state`` is set) and ``feature_parameters.reverse_train_test_order``.
+        ``shuffle`` and ``test_size`` default to ``False`` and ``_TEST_SIZE``
+        respectively when absent from ``data_split_parameters``. Honors
+        ``feature_parameters.shuffle_after_split`` (deterministic when
+        ``random_state`` is set) and ``feature_parameters.reverse_train_test_order``.
         Per-row sample weights are sliced positionally and propagate to both
         train and test sets.
         """
         feat_dict = self.freqai_info.get("feature_parameters", {})
         dsp = dict(self.data_split_parameters)
-        if "shuffle" not in dsp:
-            dsp["shuffle"] = False
+        dsp.setdefault("shuffle", False)
+        dsp.setdefault("test_size", QuickAdapterRegressorV3._TEST_SIZE)
         sklearn_kwargs = {
             k: v
             for k, v in dsp.items()
             if k in QuickAdapterRegressorV3._SKLEARN_TRAIN_TEST_SPLIT_KEYS
         }
-        test_size = dsp.get("test_size", QuickAdapterRegressorV3._TEST_SIZE)
+        test_size = dsp["test_size"]
         if isinstance(test_size, bool) or not isinstance(test_size, (int, float)):
             raise ValueError(
                 f"Invalid data_split_parameters.test_size value {test_size!r}: "

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -60,6 +60,7 @@ from Utils import (
     get_label_defaults,
     get_label_pipeline_config,
     get_label_prediction_config,
+    get_label_weighting_config,
     get_min_max_label_period_candles,
     get_optuna_study_model_parameters,
     label_weight_column,
@@ -1569,13 +1570,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
                 ].to_numpy(dtype=float)
-        aggregation = feat_dict.get("label_weights_aggregation", "arithmetic_mean")
-        softmax_temperature = feat_dict.get("label_weights_softmax_temperature", 1.0)
+        weighting_config = get_label_weighting_config(self.config, logger)
         return compose_sample_weights(
             temporal,
             per_label,
-            aggregation=aggregation,
-            softmax_temperature=softmax_temperature,
+            aggregation=weighting_config["aggregation"],
+            softmax_temperature=weighting_config["softmax_temperature"],
         )
 
     def _train_common(
@@ -1728,6 +1728,13 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         :param dk: FreqaiDataKitchen instance for data building
         :return: data_dictionary with train/test features/labels/weights
         """
+        feat_dict = self.freqai_info.get("feature_parameters", {})
+        if feat_dict.get("shuffle_after_split", False):
+            raise ValueError(
+                "feature_parameters.shuffle_after_split=True is incompatible "
+                "with data_split_parameters.method='timeseries_split': "
+                "chronological split must preserve temporal ordering"
+            )
         n_splits = QuickAdapterRegressorV3._coerce_int(
             self.data_split_parameters.get(
                 "n_splits", QuickAdapterRegressorV3.TIMESERIES_N_SPLITS_DEFAULT
@@ -1807,6 +1814,15 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         train_weights = sanitize_and_renormalize(weights[train_idx])
         test_weights = sanitize_and_renormalize(weights[test_idx])
 
+        if feat_dict.get("reverse_train_test_order", False):
+            return dk.build_data_dictionary(
+                test_features,
+                train_features,
+                test_labels,
+                train_labels,
+                test_weights,
+                train_weights,
+            )
         return dk.build_data_dictionary(
             train_features,
             test_features,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -325,6 +325,23 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return set(QuickAdapterRegressorV3._POWER_MEAN_MAP.keys())
 
     @staticmethod
+    def _shuffle_in_unison(
+        features: Any,
+        labels: Any,
+        weights: Any,
+        seed: int,
+    ) -> tuple[pd.DataFrame, pd.DataFrame, NDArray[np.floating]]:
+        features = features.sample(frac=1, random_state=seed).reset_index(drop=True)
+        labels = labels.sample(frac=1, random_state=seed).reset_index(drop=True)
+        weights = (
+            pd.DataFrame(weights)
+            .sample(frac=1, random_state=seed)
+            .reset_index(drop=True)
+            .to_numpy()[:, 0]
+        )
+        return features, labels, weights
+
+    @staticmethod
     def _renormalize_to_unit_mean(weights: Any) -> NDArray[np.floating]:
         arr = np.asarray(weights, dtype=float)
         if arr.size == 0:
@@ -1476,32 +1493,22 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             test_weights = np.zeros(2)
 
         if feat_dict.get("shuffle_after_split", False):
-            rint1 = random.randint(0, 100)
-            rint2 = random.randint(0, 100)
-            train_features = train_features.sample(
-                frac=1, random_state=rint1
-            ).reset_index(drop=True)
-            train_labels = train_labels.sample(frac=1, random_state=rint1).reset_index(
-                drop=True
-            )
-            train_weights = (
-                pd.DataFrame(train_weights)
-                .sample(frac=1, random_state=rint1)
-                .reset_index(drop=True)
-                .to_numpy()[:, 0]
+            train_features, train_labels, train_weights = (
+                QuickAdapterRegressorV3._shuffle_in_unison(
+                    train_features,
+                    train_labels,
+                    train_weights,
+                    random.randint(0, 100),
+                )
             )
             if test_size != 0:
-                test_features = test_features.sample(
-                    frac=1, random_state=rint2
-                ).reset_index(drop=True)
-                test_labels = test_labels.sample(
-                    frac=1, random_state=rint2
-                ).reset_index(drop=True)
-                test_weights = (
-                    pd.DataFrame(test_weights)
-                    .sample(frac=1, random_state=rint2)
-                    .reset_index(drop=True)
-                    .to_numpy()[:, 0]
+                test_features, test_labels, test_weights = (
+                    QuickAdapterRegressorV3._shuffle_in_unison(
+                        test_features,
+                        test_labels,
+                        test_weights,
+                        random.randint(0, 100),
+                    )
                 )
 
         train_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(train_weights)
@@ -1621,9 +1628,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 f"len(train_features)={len(dd['train_features'])} != "
                 f"len(train_weights)={len(dd['train_weights'])}"
             )
-        logger.info(
-            f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
-        )
+        logger.info(f"Training model on {len(dd['train_features'].columns)} features")
         logger.info(f"Training model on {len(dd['train_features'])} data points")
         model = self.fit(dd, dk, **kwargs)
         end_time = time.time()

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1483,12 +1483,18 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             test_weights = np.zeros(2)
 
         if feat_dict.get("shuffle_after_split", False):
+            parent_seed = sklearn_kwargs.get("random_state")
+            shuffle_rng = (
+                random.Random(parent_seed)
+                if parent_seed is not None
+                else random.Random()
+            )
             train_features, train_labels, train_weights = (
                 QuickAdapterRegressorV3._shuffle_in_unison(
                     train_features,
                     train_labels,
                     train_weights,
-                    random.randint(0, 2**31 - 1),
+                    shuffle_rng.randint(0, 2**31 - 1),
                 )
             )
             if test_size != 0:
@@ -1497,7 +1503,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                         test_features,
                         test_labels,
                         test_weights,
-                        random.randint(0, 2**31 - 1),
+                        shuffle_rng.randint(0, 2**31 - 1),
                     )
                 )
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -60,7 +60,7 @@ from Utils import (
     get_label_defaults,
     get_label_pipeline_config,
     get_label_prediction_config,
-    get_label_weighting_config,
+    get_sample_weighting_config,
     get_min_max_label_period_candles,
     get_optuna_study_model_parameters,
     label_weight_column_name,
@@ -1564,15 +1564,15 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
                 ].to_numpy(dtype=float)
-        weighting_config = get_label_weighting_config(
-            self.freqai_info.get("label_weighting", {}), logger
+        sample_weighting = get_sample_weighting_config(
+            self.freqai_info.get("sample_weighting", {}), logger
         )
-        weighting_default = weighting_config["default"]
+        sample_weighting_default = sample_weighting["default"]
         return compose_sample_weights(
             temporal,
             per_label,
-            aggregation=weighting_default["aggregation"],
-            softmax_temperature=weighting_default["softmax_temperature"],
+            aggregation=sample_weighting_default["aggregation"],
+            softmax_temperature=sample_weighting_default["softmax_temperature"],
         )
 
     def _train_common(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1425,29 +1425,15 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         weights: NDArray[np.floating],
         dk: FreqaiDataKitchen,
     ) -> dict[str, Any]:
-        """Mirror freqtrade's make_train_test_datasets accepting external weights.
+        """Random train/test split via sklearn's ``train_test_split``.
 
-        Reproduces upstream behavior (data_kitchen.py:126-209) with deviations:
-
-        1. Accepts pre-computed per-row weights (avoids re-deriving temporal-only).
-        2. Whitelists sklearn-safe kwargs from data_split_parameters; drops
-           project-custom keys (``method``, ``n_splits``, ``gap``,
-           ``max_train_size``).
-        3. Uses ``.get("shuffle_after_split", False)`` for safer default;
-           upstream uses bare key access which raises KeyError on configs
-           without the key (including this project's config-template.json).
-        4. Does not mutate ``self.config`` in-place; upstream injects
-           ``shuffle=False`` via ``dict.update`` on the live config.
-        5. Skips test-side shuffle when ``test_size==0``. Upstream shuffles
-           test unconditionally, but its synthetic ``test_labels=np.zeros(2)``
-           and ``test_weights=np.zeros(2)`` raise AttributeError on
-           ``.sample()``. This deviation only fires under ``test_size==0``
-           plus ``shuffle_after_split=True``, a configuration upstream itself
-           would crash on.
-
-        Per-label weights are propagated to BOTH ``train_weights`` AND
-        ``test_weights`` (matches existing PR #72 behavior; ``test_weights``
-        feed the HPO eval objective).
+        Routes ``data_split_parameters`` to sklearn through a whitelist of
+        sklearn-recognized keys; project-custom keys (``method``,
+        ``n_splits``, ``gap``, ``max_train_size``) are filtered out.
+        Honors ``feature_parameters.shuffle_after_split`` (deterministic
+        when ``random_state`` is set) and ``feature_parameters.reverse_train_test_order``.
+        Per-row sample weights are sliced positionally and propagate to both
+        train and test sets.
         """
         feat_dict = self.freqai_info.get("feature_parameters", {})
         dsp = dict(self.data_split_parameters)

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -325,6 +325,20 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return set(QuickAdapterRegressorV3._POWER_MEAN_MAP.keys())
 
     @staticmethod
+    def _renormalize_to_unit_mean(weights: Any) -> NDArray[np.floating]:
+        arr = np.asarray(weights, dtype=float)
+        if arr.size == 0:
+            return arr
+        total = float(np.sum(arr))
+        if total > 0 and np.isfinite(total):
+            ratio = arr.size / total
+            if np.isfinite(ratio):
+                scaled = arr * ratio
+                if np.all(np.isfinite(scaled)):
+                    return scaled
+        return np.ones_like(arr)
+
+    @staticmethod
     def _coerce_int(value: Any, name: str, *, minimum: int) -> int:
         if isinstance(value, bool) or not isinstance(value, int) or value < minimum:
             raise ValueError(
@@ -1490,6 +1504,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     .to_numpy()[:, 0]
                 )
 
+        train_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(train_weights)
+        if test_size != 0:
+            test_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
+                test_weights
+            )
+
         if feat_dict.get("reverse_train_test_order", False):
             return dk.build_data_dictionary(
                 test_features,
@@ -1631,6 +1651,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 dd["train_features"], dd["train_labels"], dd["train_weights"]
             )
         )
+        dd["train_weights"] = QuickAdapterRegressorV3._renormalize_to_unit_mean(
+            dd["train_weights"]
+        )
 
         dd["train_labels"], _, _ = dk.label_pipeline.fit_transform(dd["train_labels"])
 
@@ -1679,6 +1702,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     dk.feature_pipeline.transform(
                         dd["test_features"], dd["test_labels"], dd["test_weights"]
                     )
+                )
+                dd["test_weights"] = QuickAdapterRegressorV3._renormalize_to_unit_mean(
+                    dd["test_weights"]
                 )
                 dd["test_labels"], _, _ = dk.label_pipeline.transform(dd["test_labels"])
 
@@ -1780,8 +1806,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         test_features = filtered_dataframe.iloc[test_idx]
         train_labels = labels.iloc[train_idx]
         test_labels = labels.iloc[test_idx]
-        train_weights = weights[train_idx]
-        test_weights = weights[test_idx]
+        train_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
+            weights[train_idx]
+        )
+        test_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
+            weights[test_idx]
+        )
 
         return dk.build_data_dictionary(
             train_features,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -244,6 +244,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "timeseries_split",
     )
     DATA_SPLIT_METHOD_DEFAULT: Final[str] = _DATA_SPLIT_METHODS[0]
+    _DATA_SPLIT_DISPATCH: Final[dict[str, str]] = {
+        _DATA_SPLIT_METHODS[0]: "_train_default",
+        _DATA_SPLIT_METHODS[1]: "_train_timeseries_split",
+    }
     TIMESERIES_N_SPLITS_DEFAULT: Final[int] = 5
     TIMESERIES_GAP_DEFAULT: Final[int] = 0
     TIMESERIES_MAX_TRAIN_SIZE_DEFAULT: Final[int | None] = None
@@ -1357,21 +1361,26 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             "method", QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT
         )
 
-        if method not in QuickAdapterRegressorV3._data_split_methods_set():
+        if method not in QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH:
             raise ValueError(
                 f"Invalid data_split_parameters.method value {method!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._DATA_SPLIT_METHODS)}"
+                f"supported values are "
+                f"{', '.join(QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH)}"
+            )
+
+        weight_cols = {label_weight_column(label) for label in dk.label_list}
+        if len(weight_cols) != len(dk.label_list):
+            raise ValueError(
+                f"Duplicate weight column names from labels {dk.label_list}: "
+                f"each label must produce a unique weight_column_name"
             )
 
         logger.info(f"Using data split method: {method}")
 
-        if method == QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT:
-            return self._train_default(unfiltered_df, pair, dk, **kwargs)
-
-        elif (
-            method == QuickAdapterRegressorV3._DATA_SPLIT_METHODS[1]
-        ):  # timeseries_split
-            return self._train_timeseries_split(unfiltered_df, pair, dk, **kwargs)
+        handler = getattr(
+            self, QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH[method]
+        )
+        return handler(unfiltered_df, pair, dk, **kwargs)
 
     def _train_default(
         self,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3,6 +3,7 @@ import logging
 import random
 import time
 import warnings
+from collections import Counter
 from functools import lru_cache
 from pathlib import Path
 from typing import AbstractSet, Any, Callable, Final, Literal, Optional, Union, cast
@@ -1418,11 +1419,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         ) -> dict[str, Any]:
             return split_builder(features, labels, weights, dk)
 
-        weight_cols = {label_weight_column(label) for label in dk.label_list}
-        if len(weight_cols) != len(dk.label_list):
+        weight_col_counts = Counter(
+            label_weight_column(label) for label in dk.label_list
+        )
+        duplicates = {col: n for col, n in weight_col_counts.items() if n > 1}
+        if duplicates:
             raise ValueError(
-                f"Duplicate weight column names from labels {dk.label_list}: "
-                f"each label must produce a unique weight_column_name"
+                f"Duplicate weight column names {duplicates!r} from labels "
+                f"{dk.label_list}: each label must produce a unique weight_column_name"
             )
 
         logger.info(f"Using data split method: {method}")
@@ -1460,7 +1464,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         feed the HPO eval objective).
         """
         feat_dict = self.freqai_info.get("feature_parameters", {})
-        dsp = dict(self.config["freqai"]["data_split_parameters"])
+        dsp = dict(self.data_split_parameters)
         if "shuffle" not in dsp:
             dsp["shuffle"] = False
         sklearn_kwargs = {
@@ -1498,7 +1502,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     train_features,
                     train_labels,
                     train_weights,
-                    random.randint(0, 100),
+                    random.randint(0, 2**31 - 1),
                 )
             )
             if test_size != 0:
@@ -1507,7 +1511,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                         test_features,
                         test_labels,
                         test_weights,
-                        random.randint(0, 100),
+                        random.randint(0, 2**31 - 1),
                     )
                 )
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -51,6 +51,7 @@ from Utils import (
     REGRESSORS,
     Regressor,
     compose_sample_weights,
+    ensure_datetime_series,
     eval_set_and_weights,
     fit_regressor,
     format_dict,
@@ -121,9 +122,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         dk: FreqaiDataKitchen,
     ) -> dict[str, Any]:
         weight_cols = {
-            label: f"{label}{self._LABEL_WEIGHT_SUFFIX}"
+            label: self._label_weight_column_name(label)
             for label in dk.label_list
-            if f"{label}{self._LABEL_WEIGHT_SUFFIX}" in unfiltered_df.columns
+            if self._label_weight_column_name(label) in unfiltered_df.columns
         }
         if not weight_cols:
             return dd
@@ -1384,7 +1385,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         Filter the training data and train a model to it.
 
         Supports two data split methods:
-        - 'train_test_split' (default): Delegates to BaseRegressionModel.train()
+        - 'train_test_split' (default): Routes to :meth:`_train`, a mirror of
+          ``BaseRegressionModel.train`` augmented with per-label sample weight
+          composition.
         - 'timeseries_split': Chronological split with configurable gap. Uses the final
           fold from sklearn's TimeSeriesSplit.
 
@@ -1426,8 +1429,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 training_filter=True,
             )
 
-            start_date = unfiltered_df["date"].iloc[0].strftime("%Y-%m-%d")
-            end_date = unfiltered_df["date"].iloc[-1].strftime("%Y-%m-%d")
+            dates = ensure_datetime_series(unfiltered_df["date"])
+            start_date = dates.iloc[0].strftime("%Y-%m-%d")
+            end_date = dates.iloc[-1].strftime("%Y-%m-%d")
             logger.info(
                 f"-------------------- Training on data from {start_date} to "
                 f"{end_date} --------------------"
@@ -1470,12 +1474,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
-        """
-        Mirror of ``BaseRegressionModel.train`` with a single insertion: composition
-        of per-label sample weights via :meth:`_compose_train_weights` between the
-        train/test split and the pipeline application. Routed from :meth:`train`
-        when ``data_split_parameters.method`` is ``train_test_split``.
-        """
         logger.info(f"-------------------- Starting training {pair} --------------------")
 
         start_time = time.time()
@@ -1487,8 +1485,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             training_filter=True,
         )
 
-        start_date = unfiltered_df["date"].iloc[0].strftime("%Y-%m-%d")
-        end_date = unfiltered_df["date"].iloc[-1].strftime("%Y-%m-%d")
+        dates = ensure_datetime_series(unfiltered_df["date"])
+        start_date = dates.iloc[0].strftime("%Y-%m-%d")
+        end_date = dates.iloc[-1].strftime("%Y-%m-%d")
         logger.info(
             f"-------------------- Training on data from {start_date} to "
             f"{end_date} --------------------"

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -52,7 +52,7 @@ from Utils import (
     Regressor,
     compose_sample_weights,
     ensure_datetime_series,
-    eval_set_and_weights,
+    make_test_set_and_weights,
     fit_regressor,
     format_dict,
     format_number,
@@ -1528,7 +1528,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             test_weights,
         )
 
-    def _build_per_row_weights(
+    def _compose_per_row_weights(
         self,
         features_filtered: pd.DataFrame,
         unfiltered_df: pd.DataFrame,
@@ -1603,7 +1603,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             dk.label_list,
             training_filter=True,
         )
-        weights = self._build_per_row_weights(features_filtered, unfiltered_df, dk)
+        weights = self._compose_per_row_weights(features_filtered, unfiltered_df, dk)
         dates = ensure_datetime_series(unfiltered_df["date"])
         start_date = dates.iloc[0].strftime("%Y-%m-%d")
         end_date = dates.iloc[-1].strftime("%Y-%m-%d")
@@ -1892,7 +1892,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     **optuna_hp_params,
                 }
 
-        eval_set, eval_weights = eval_set_and_weights(
+        eval_set, eval_weights = make_test_set_and_weights(
             X_test,
             y_test,
             test_weights,
@@ -3740,7 +3740,7 @@ def hp_objective(
     )
     model_training_parameters = {**model_training_parameters, **study_model_parameters}
 
-    eval_set, eval_weights = eval_set_and_weights(
+    eval_set, eval_weights = make_test_set_and_weights(
         X_test, y_test, test_weights, test_size
     )
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -78,6 +78,7 @@ ClusterMethod = Literal["kmeans", "kmeans2", "kmedoids"]
 DensityMethod = Literal["knn", "medoid"]
 SelectionMethod = Union[DistanceMethod, ClusterMethod, DensityMethod]
 ValidationMode = Literal["warn", "raise", "none"]
+SplitFn = Callable[[pd.DataFrame, pd.DataFrame, NDArray[np.floating]], dict[str, Any]]
 warnings.simplefilter(action="ignore", category=FutureWarning)
 
 logger = logging.getLogger(__name__)
@@ -244,10 +245,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "timeseries_split",
     )
     DATA_SPLIT_METHOD_DEFAULT: Final[str] = _DATA_SPLIT_METHODS[0]
-    _DATA_SPLIT_DISPATCH: Final[dict[str, str]] = {
-        _DATA_SPLIT_METHODS[0]: "_train_default",
-        _DATA_SPLIT_METHODS[1]: "_train_timeseries_split",
-    }
     TIMESERIES_N_SPLITS_DEFAULT: Final[int] = 5
     TIMESERIES_GAP_DEFAULT: Final[int] = 0
     TIMESERIES_MAX_TRAIN_SIZE_DEFAULT: Final[int | None] = None
@@ -326,11 +323,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     @lru_cache(maxsize=None)
     def _power_mean_metrics_set() -> set[str]:
         return set(QuickAdapterRegressorV3._POWER_MEAN_MAP.keys())
-
-    @staticmethod
-    @lru_cache(maxsize=None)
-    def _data_split_methods_set() -> set[str]:
-        return set(QuickAdapterRegressorV3._DATA_SPLIT_METHODS)
 
     @staticmethod
     def _get_selection_category(method: str) -> Optional[str]:
@@ -1361,12 +1353,24 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             "method", QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT
         )
 
-        if method not in QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH:
-            raise ValueError(
-                f"Invalid data_split_parameters.method value {method!r}: "
-                f"supported values are "
-                f"{', '.join(QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH)}"
-            )
+        match method:
+            case "train_test_split":
+                split_builder = self._make_default_split_datasets
+            case "timeseries_split":
+                split_builder = self._make_timeseries_split_datasets
+            case _:
+                raise ValueError(
+                    f"Invalid data_split_parameters.method value {method!r}: "
+                    f"supported values are "
+                    f"{', '.join(QuickAdapterRegressorV3._DATA_SPLIT_METHODS)}"
+                )
+
+        def split_fn(
+            features: pd.DataFrame,
+            labels: pd.DataFrame,
+            weights: NDArray[np.floating],
+        ) -> dict[str, Any]:
+            return split_builder(features, labels, weights, dk)
 
         weight_cols = {label_weight_column(label) for label in dk.label_list}
         if len(weight_cols) != len(dk.label_list):
@@ -1376,42 +1380,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
 
         logger.info(f"Using data split method: {method}")
-
-        handler = getattr(
-            self, QuickAdapterRegressorV3._DATA_SPLIT_DISPATCH[method]
-        )
-        return handler(unfiltered_df, pair, dk, **kwargs)
-
-    def _train_default(
-        self,
-        unfiltered_df: pd.DataFrame,
-        pair: str,
-        dk: FreqaiDataKitchen,
-        **kwargs,
-    ) -> Any:
-        def split_fn(
-            features: pd.DataFrame,
-            labels: pd.DataFrame,
-            weights: NDArray[np.floating],
-        ) -> dict[str, Any]:
-            return self._make_default_split_datasets(features, labels, weights, dk)
-
-        return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
-
-    def _train_timeseries_split(
-        self,
-        unfiltered_df: pd.DataFrame,
-        pair: str,
-        dk: FreqaiDataKitchen,
-        **kwargs,
-    ) -> Any:
-        def split_fn(
-            features: pd.DataFrame,
-            labels: pd.DataFrame,
-            weights: NDArray[np.floating],
-        ) -> dict[str, Any]:
-            return self._make_timeseries_split_datasets(features, labels, weights, dk)
-
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
 
     def _make_default_split_datasets(
@@ -1479,9 +1447,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             train_features = train_features.sample(
                 frac=1, random_state=rint1
             ).reset_index(drop=True)
-            train_labels = train_labels.sample(
-                frac=1, random_state=rint1
-            ).reset_index(drop=True)
+            train_labels = train_labels.sample(frac=1, random_state=rint1).reset_index(
+                drop=True
+            )
             train_weights = (
                 pd.DataFrame(train_weights)
                 .sample(frac=1, random_state=rint1)
@@ -1552,9 +1520,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         n_rows = len(features_filtered)
         feat_dict = self.freqai_info.get("feature_parameters", {})
         if feat_dict.get("weight_factor", 0) > 0:
-            temporal = np.asarray(
-                dk.set_weights_higher_recent(n_rows), dtype=float
-            )
+            temporal = np.asarray(dk.set_weights_higher_recent(n_rows), dtype=float)
         else:
             temporal = np.ones(n_rows, dtype=float)
 
@@ -1562,10 +1528,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         for label in dk.label_list:
             col = label_weight_column(label)
             if col in unfiltered_df.columns:
-                per_label[label] = (
-                    unfiltered_df.loc[features_filtered.index, col]
-                    .to_numpy(dtype=float)
-                )
+                per_label[label] = unfiltered_df.loc[
+                    features_filtered.index, col
+                ].to_numpy(dtype=float)
         return compose_sample_weights(temporal, per_label)
 
     def _train_common(
@@ -1573,9 +1538,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         unfiltered_df: pd.DataFrame,
         pair: str,
         dk: FreqaiDataKitchen,
-        split_fn: Callable[
-            [pd.DataFrame, pd.DataFrame, NDArray[np.floating]], dict[str, Any]
-        ],
+        split_fn: SplitFn,
         **kwargs,
     ) -> Any:
         logger.info(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -105,50 +105,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     _LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
 
-    @staticmethod
-    def _label_weight_column_name(label_col: str) -> str:
-        return f"{label_col}{QuickAdapterRegressorV3._LABEL_WEIGHT_SUFFIX}"
-
-    def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
-        dk.label_list = [
-            c for c in dk.label_list
-            if not c.endswith(self._LABEL_WEIGHT_SUFFIX)
-        ]
-
-    def _compose_train_weights(
-        self,
-        dd: dict[str, Any],
-        unfiltered_df: pd.DataFrame,
-        dk: FreqaiDataKitchen,
-    ) -> dict[str, Any]:
-        weight_cols = {
-            label: self._label_weight_column_name(label)
-            for label in dk.label_list
-            if self._label_weight_column_name(label) in unfiltered_df.columns
-        }
-        if not weight_cols:
-            return dd
-        label_weights_map: dict[str, NDArray] = {}
-        for label, weight_col in weight_cols.items():
-            series = unfiltered_df[weight_col]
-            train_w = series.reindex(dd["train_features"].index, fill_value=1.0).to_numpy(dtype=float)
-            label_weights_map[label] = train_w
-        dd["train_weights"] = compose_sample_weights(
-            np.asarray(dd["train_weights"], dtype=float),
-            label_weights_map,
-        )
-        if dd.get("test_features") is not None and len(dd["test_features"]) > 0:
-            test_map: dict[str, NDArray] = {}
-            for label, weight_col in weight_cols.items():
-                series = unfiltered_df[weight_col]
-                test_w = series.reindex(dd["test_features"].index, fill_value=1.0).to_numpy(dtype=float)
-                test_map[label] = test_w
-            dd["test_weights"] = compose_sample_weights(
-                np.asarray(dd["test_weights"], dtype=float),
-                test_map,
-            )
-        return dd
-
     _SQRT_2: Final[float] = np.sqrt(2.0)
 
     _OPTUNA_LABEL_N_OBJECTIVES: Final[int] = 7
@@ -1385,9 +1341,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         Filter the training data and train a model to it.
 
         Supports two data split methods:
-        - 'train_test_split' (default): Routes to :meth:`_train`, a mirror of
-          ``BaseRegressionModel.train`` augmented with per-label sample weight
-          composition.
+        - 'train_test_split' (default): Delegates to BaseRegressionModel.train()
         - 'timeseries_split': Chronological split with configurable gap. Uses the final
           fold from sklearn's TimeSeriesSplit.
 
@@ -1411,80 +1365,56 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         logger.info(f"Using data split method: {method}")
 
         if method == QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT:
-            return self._train(unfiltered_df, pair, dk, **kwargs)
+            return self._train_default(unfiltered_df, pair, dk, **kwargs)
 
         elif (
             method == QuickAdapterRegressorV3._DATA_SPLIT_METHODS[1]
         ):  # timeseries_split
-            logger.info(
-                f"-------------------- Starting training {pair} --------------------"
-            )
+            return self._train_timeseries_split(unfiltered_df, pair, dk, **kwargs)
 
-            start_time = time.time()
-
-            features_filtered, labels_filtered = dk.filter_features(
-                unfiltered_df,
-                dk.training_features_list,
-                dk.label_list,
-                training_filter=True,
-            )
-
-            dates = ensure_datetime_series(unfiltered_df["date"])
-            start_date = dates.iloc[0].strftime("%Y-%m-%d")
-            end_date = dates.iloc[-1].strftime("%Y-%m-%d")
-            logger.info(
-                f"-------------------- Training on data from {start_date} to "
-                f"{end_date} --------------------"
-            )
-
-            dd = self._make_timeseries_split_datasets(
-                features_filtered, labels_filtered, dk
-            )
-
-            if (
-                not self.freqai_info.get("fit_live_predictions_candles", 0)
-                or not self.live
-            ):
-                dk.fit_labels()
-
-            dd = self._compose_train_weights(dd, unfiltered_df, dk)
-
-            dd = self._apply_pipelines(dd, dk, pair)
-
-            logger.info(
-                f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
-            )
-            logger.info(f"Training model on {len(dd['train_features'])} data points")
-
-            model = self.fit(dd, dk)
-
-            end_time = time.time()
-
-            logger.info(
-                f"-------------------- Done training {pair} "
-                f"({end_time - start_time:.2f} secs) --------------------"
-            )
-
-            return model
-
-    def _train(
+    def _train_default(
         self,
         unfiltered_df: pd.DataFrame,
         pair: str,
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
-        logger.info(f"-------------------- Starting training {pair} --------------------")
+        return self._train_common(
+            unfiltered_df, pair, dk, dk.make_train_test_datasets, **kwargs
+        )
 
+    def _train_timeseries_split(
+        self,
+        unfiltered_df: pd.DataFrame,
+        pair: str,
+        dk: FreqaiDataKitchen,
+        **kwargs,
+    ) -> Any:
+        def split_fn(
+            features: pd.DataFrame, labels: pd.DataFrame
+        ) -> dict[str, Any]:
+            return self._make_timeseries_split_datasets(features, labels, dk)
+
+        return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
+
+    def _train_common(
+        self,
+        unfiltered_df: pd.DataFrame,
+        pair: str,
+        dk: FreqaiDataKitchen,
+        split_fn: Callable[[pd.DataFrame, pd.DataFrame], dict[str, Any]],
+        **kwargs,
+    ) -> Any:
+        logger.info(
+            f"-------------------- Starting training {pair} --------------------"
+        )
         start_time = time.time()
-
         features_filtered, labels_filtered = dk.filter_features(
             unfiltered_df,
             dk.training_features_list,
             dk.label_list,
             training_filter=True,
         )
-
         dates = ensure_datetime_series(unfiltered_df["date"])
         start_date = dates.iloc[0].strftime("%Y-%m-%d")
         end_date = dates.iloc[-1].strftime("%Y-%m-%d")
@@ -1492,29 +1422,21 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             f"-------------------- Training on data from {start_date} to "
             f"{end_date} --------------------"
         )
-
-        dd = dk.make_train_test_datasets(features_filtered, labels_filtered)
+        dd = split_fn(features_filtered, labels_filtered)
         if not self.freqai_info.get("fit_live_predictions_candles", 0) or not self.live:
             dk.fit_labels()
-
         dd = self._compose_train_weights(dd, unfiltered_df, dk)
-
         dd = self._apply_pipelines(dd, dk, pair)
-
         logger.info(
             f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
         )
         logger.info(f"Training model on {len(dd['train_features'])} data points")
-
         model = self.fit(dd, dk)
-
         end_time = time.time()
-
         logger.info(
             f"-------------------- Done training {pair} "
             f"({end_time - start_time:.2f} secs) --------------------"
         )
-
         return model
 
     def _apply_pipelines(
@@ -1595,6 +1517,57 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         dk.data_dictionary = dd
 
+        return dd
+
+    @staticmethod
+    def _label_weight_column_name(label_col: str) -> str:
+        return f"{label_col}{QuickAdapterRegressorV3._LABEL_WEIGHT_SUFFIX}"
+
+    def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
+        dk.label_list = [
+            c for c in dk.label_list
+            if not c.endswith(self._LABEL_WEIGHT_SUFFIX)
+        ]
+
+    @staticmethod
+    def _extract_split_weights(
+        weight_cols: dict[str, str],
+        split_index: pd.Index,
+        unfiltered_df: pd.DataFrame,
+    ) -> dict[str, NDArray]:
+        return {
+            label: unfiltered_df[weight_col]
+            .reindex(split_index, fill_value=1.0)
+            .to_numpy(dtype=float)
+            for label, weight_col in weight_cols.items()
+        }
+
+    def _compose_train_weights(
+        self,
+        dd: dict[str, Any],
+        unfiltered_df: pd.DataFrame,
+        dk: FreqaiDataKitchen,
+    ) -> dict[str, Any]:
+        weight_cols = {
+            label: self._label_weight_column_name(label)
+            for label in dk.label_list
+            if self._label_weight_column_name(label) in unfiltered_df.columns
+        }
+        if not weight_cols:
+            return dd
+        dd["train_weights"] = compose_sample_weights(
+            np.asarray(dd["train_weights"], dtype=float),
+            self._extract_split_weights(
+                weight_cols, dd["train_features"].index, unfiltered_df
+            ),
+        )
+        if dd.get("test_features") is not None and len(dd["test_features"]) > 0:
+            dd["test_weights"] = compose_sample_weights(
+                np.asarray(dd["test_weights"], dtype=float),
+                self._extract_split_weights(
+                    weight_cols, dd["test_features"].index, unfiltered_df
+                ),
+            )
         return dd
 
     def _make_timeseries_split_datasets(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -50,6 +50,7 @@ from Utils import (
     LABEL_COLUMNS,
     REGRESSORS,
     Regressor,
+    compose_sample_weights,
     ensure_datetime_series,
     eval_set_and_weights,
     fit_regressor,
@@ -113,6 +114,40 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             c for c in dk.label_list
             if not c.endswith(self._LABEL_WEIGHT_SUFFIX)
         ]
+
+    def _compose_train_weights(
+        self,
+        dd: dict[str, Any],
+        unfiltered_df: pd.DataFrame,
+        dk: FreqaiDataKitchen,
+    ) -> dict[str, Any]:
+        weight_cols = {
+            label: f"{label}{self._LABEL_WEIGHT_SUFFIX}"
+            for label in dk.label_list
+            if f"{label}{self._LABEL_WEIGHT_SUFFIX}" in unfiltered_df.columns
+        }
+        if not weight_cols:
+            return dd
+        label_weights_map: dict[str, NDArray] = {}
+        for label, weight_col in weight_cols.items():
+            series = unfiltered_df[weight_col]
+            train_w = series.reindex(dd["train_features"].index, fill_value=1.0).to_numpy(dtype=float)
+            label_weights_map[label] = train_w
+        dd["train_weights"] = compose_sample_weights(
+            np.asarray(dd["train_weights"], dtype=float),
+            label_weights_map,
+        )
+        if dd.get("test_features") is not None and len(dd["test_features"]) > 0:
+            test_map: dict[str, NDArray] = {}
+            for label, weight_col in weight_cols.items():
+                series = unfiltered_df[weight_col]
+                test_w = series.reindex(dd["test_features"].index, fill_value=1.0).to_numpy(dtype=float)
+                test_map[label] = test_w
+            dd["test_weights"] = compose_sample_weights(
+                np.asarray(dd["test_weights"], dtype=float),
+                test_map,
+            )
+        return dd
 
     _SQRT_2: Final[float] = np.sqrt(2.0)
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1389,9 +1389,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
-        def split_fn(
-            features: pd.DataFrame, labels: pd.DataFrame
-        ) -> dict[str, Any]:
+        def split_fn(features: pd.DataFrame, labels: pd.DataFrame) -> dict[str, Any]:
             return self._make_timeseries_split_datasets(features, labels, dk)
 
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
@@ -1524,8 +1522,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     def _strip_label_weight_columns(self, dk: FreqaiDataKitchen) -> None:
         dk.label_list = [
-            c for c in dk.label_list
-            if not c.endswith(LABEL_WEIGHT_SUFFIX)
+            c for c in dk.label_list if not c.endswith(LABEL_WEIGHT_SUFFIX)
         ]
 
     @staticmethod

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -63,7 +63,7 @@ from Utils import (
     get_label_weighting_config,
     get_min_max_label_period_candles,
     get_optuna_study_model_parameters,
-    label_weight_column,
+    label_weight_column_name,
     migrate_config,
     optuna_load_best_params,
     optuna_save_best_params,
@@ -1388,7 +1388,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         match method:
             case "train_test_split":
-                split_builder = self._make_default_split_datasets
+                split_builder = self._make_train_test_split_datasets
             case "timeseries_split":
                 split_builder = self._make_timeseries_split_datasets
             case _:
@@ -1406,7 +1406,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return split_builder(features, labels, weights, dk)
 
         weight_col_counts = Counter(
-            label_weight_column(label) for label in dk.label_list
+            label_weight_column_name(label) for label in dk.label_list
         )
         duplicates = {col: n for col, n in weight_col_counts.items() if n > 1}
         if duplicates:
@@ -1418,7 +1418,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         logger.info(f"Using data split method: {method}")
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
 
-    def _make_default_split_datasets(
+    def _make_train_test_split_datasets(
         self,
         features: pd.DataFrame,
         labels: pd.DataFrame,
@@ -1543,7 +1543,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         runs before any shuffle/split on ``features_filtered.index``
         (a subset of ``unfiltered_df.index``) to avoid post-hoc reindex
         against shuffled data. Iterates ``dk.label_list`` and only includes
-        labels whose ``label_weight_column(label)`` exists on
+        labels whose ``label_weight_column_name(label)`` exists on
         ``unfiltered_df``.
         """
         if not unfiltered_df.index.is_unique:
@@ -1571,7 +1571,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         per_label: dict[str, NDArray[np.floating]] = {}
         for label in dk.label_list:
-            col = label_weight_column(label)
+            col = label_weight_column_name(label)
             if col in unfiltered_df.columns:
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
@@ -1707,8 +1707,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 )
                 dd["test_weights"] = sanitize_and_renormalize(dd["test_weights"])
                 dd["test_labels"], _, _ = dk.label_pipeline.transform(dd["test_labels"])
-
-        dk.data_dictionary = dd
 
         return dd
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1562,12 +1562,15 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 per_label[label] = unfiltered_df.loc[
                     features_filtered.index, col
                 ].to_numpy(dtype=float)
-        weighting_config = get_label_weighting_config(self.config, logger)
+        weighting_config = get_label_weighting_config(
+            self.freqai_info.get("label_weighting", {}), logger
+        )
+        weighting_default = weighting_config["default"]
         return compose_sample_weights(
             temporal,
             per_label,
-            aggregation=weighting_config["aggregation"],
-            softmax_temperature=weighting_config["softmax_temperature"],
+            aggregation=weighting_default["aggregation"],
+            softmax_temperature=weighting_default["softmax_temperature"],
         )
 
     def _train_common(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -98,7 +98,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     https://github.com/sponsors/robcaulk
     """
 
-    version = "3.11.8"
+    version = "3.11.9"
 
     _TEST_SIZE: Final[float] = 0.1
 

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -62,6 +62,7 @@ from Utils import (
     get_label_prediction_config,
     get_min_max_label_period_candles,
     get_optuna_study_model_parameters,
+    label_weight_column,
     migrate_config,
     optuna_load_best_params,
     optuna_save_best_params,
@@ -1393,6 +1394,54 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return self._make_timeseries_split_datasets(features, labels, dk)
 
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
+
+    def _build_per_row_weights(
+        self,
+        features_filtered: pd.DataFrame,
+        unfiltered_df: pd.DataFrame,
+        dk: FreqaiDataKitchen,
+    ) -> NDArray[np.floating]:
+        """Build a per-row sample weight vector aligned to features_filtered.index.
+
+        Combines freqtrade's temporal recency weight with the geometric mean
+        of all per-target weight columns present on ``unfiltered_df``.
+        Alignment is done BEFORE any shuffle/split, on
+        ``features_filtered.index`` (a subset of ``unfiltered_df.index``),
+        avoiding any post-hoc reindex against shuffled data.
+
+        Generic over N targets: iterates ``dk.label_list`` and only includes
+        labels whose ``label_weight_column(label)`` exists on
+        ``unfiltered_df``.
+        """
+        if not unfiltered_df.index.is_unique:
+            raise ValueError(
+                "unfiltered_df.index must be unique for label-based weight "
+                "alignment; received non-unique index"
+            )
+        if not features_filtered.index.isin(unfiltered_df.index).all():
+            raise ValueError(
+                "features_filtered.index must be a subset of "
+                "unfiltered_df.index (filter_features should preserve original "
+                "row labels)"
+            )
+        n_rows = len(features_filtered)
+        feat_dict = self.freqai_info.get("feature_parameters", {})
+        if feat_dict.get("weight_factor", 0) > 0:
+            temporal = np.asarray(
+                dk.set_weights_higher_recent(n_rows), dtype=float
+            )
+        else:
+            temporal = np.ones(n_rows, dtype=float)
+
+        per_label: dict[str, NDArray[np.floating]] = {}
+        for label in dk.label_list:
+            col = label_weight_column(label)
+            if col in unfiltered_df.columns:
+                per_label[label] = (
+                    unfiltered_df.loc[features_filtered.index, col]
+                    .to_numpy(dtype=float)
+                )
+        return compose_sample_weights(temporal, per_label)
 
     def _train_common(
         self,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -66,6 +66,7 @@ from Utils import (
     migrate_config,
     optuna_load_best_params,
     optuna_save_best_params,
+    sanitize_and_renormalize,
     soft_extremum,
     zigzag,
 )
@@ -327,9 +328,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     @staticmethod
     def _shuffle_in_unison(
-        features: Any,
-        labels: Any,
-        weights: Any,
+        features: pd.DataFrame,
+        labels: pd.DataFrame,
+        weights: NDArray[np.floating],
         seed: int,
     ) -> tuple[pd.DataFrame, pd.DataFrame, NDArray[np.floating]]:
         features = features.sample(frac=1, random_state=seed).reset_index(drop=True)
@@ -341,20 +342,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             .to_numpy()[:, 0]
         )
         return features, labels, weights
-
-    @staticmethod
-    def _renormalize_to_unit_mean(weights: Any) -> NDArray[np.floating]:
-        arr = np.asarray(weights, dtype=float)
-        if arr.size == 0:
-            return arr
-        total = float(np.sum(arr))
-        if total > 0 and np.isfinite(total):
-            ratio = arr.size / total
-            if np.isfinite(ratio):
-                scaled = arr * ratio
-                if np.all(np.isfinite(scaled)):
-                    return scaled
-        return np.ones_like(arr)
 
     @staticmethod
     def _coerce_int(value: Any, name: str, *, minimum: int) -> int:
@@ -1513,11 +1500,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     )
                 )
 
-        train_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(train_weights)
+        train_weights = sanitize_and_renormalize(train_weights)
         if test_size != 0:
-            test_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
-                test_weights
-            )
+            test_weights = sanitize_and_renormalize(test_weights)
 
         if feat_dict.get("reverse_train_test_order", False):
             return dk.build_data_dictionary(
@@ -1664,9 +1649,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 dd["train_features"], dd["train_labels"], dd["train_weights"]
             )
         )
-        dd["train_weights"] = QuickAdapterRegressorV3._renormalize_to_unit_mean(
-            dd["train_weights"]
-        )
+        dd["train_weights"] = sanitize_and_renormalize(dd["train_weights"])
 
         dd["train_labels"], _, _ = dk.label_pipeline.fit_transform(dd["train_labels"])
 
@@ -1716,9 +1699,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                         dd["test_features"], dd["test_labels"], dd["test_weights"]
                     )
                 )
-                dd["test_weights"] = QuickAdapterRegressorV3._renormalize_to_unit_mean(
-                    dd["test_weights"]
-                )
+                dd["test_weights"] = sanitize_and_renormalize(dd["test_weights"])
                 dd["test_labels"], _, _ = dk.label_pipeline.transform(dd["test_labels"])
 
         dk.data_dictionary = dd
@@ -1810,21 +1791,21 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             max_train_size=max_train_size,
             test_size=test_size,
         )
-        train_idx: np.ndarray = np.array([])
-        test_idx: np.ndarray = np.array([])
-        for train_idx, test_idx in tscv.split(filtered_dataframe):
-            pass
+        folds = list(tscv.split(filtered_dataframe))
+        if not folds:
+            raise ValueError(
+                f"TimeSeriesSplit yielded no folds for {len(filtered_dataframe)} "
+                f"samples (n_splits={n_splits}, gap={gap}, "
+                f"max_train_size={max_train_size}, test_size={test_size})"
+            )
+        train_idx, test_idx = folds[-1]
 
         train_features = filtered_dataframe.iloc[train_idx]
         test_features = filtered_dataframe.iloc[test_idx]
         train_labels = labels.iloc[train_idx]
         test_labels = labels.iloc[test_idx]
-        train_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
-            weights[train_idx]
-        )
-        test_weights = QuickAdapterRegressorV3._renormalize_to_unit_mean(
-            weights[test_idx]
-        )
+        train_weights = sanitize_and_renormalize(weights[train_idx])
+        test_weights = sanitize_and_renormalize(weights[test_idx])
 
         return dk.build_data_dictionary(
             train_features,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -51,7 +51,6 @@ from Utils import (
     REGRESSORS,
     Regressor,
     compose_sample_weights,
-    ensure_datetime_series,
     eval_set_and_weights,
     fit_regressor,
     format_dict,
@@ -1409,7 +1408,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         logger.info(f"Using data split method: {method}")
 
         if method == QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT:
-            return self._train_default(unfiltered_df, pair, dk, **kwargs)
+            return self._train(unfiltered_df, pair, dk, **kwargs)
 
         elif (
             method == QuickAdapterRegressorV3._DATA_SPLIT_METHODS[1]
@@ -1427,9 +1426,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 training_filter=True,
             )
 
-            dates = ensure_datetime_series(unfiltered_df["date"])
-            start_date = dates.iloc[0].strftime("%Y-%m-%d")
-            end_date = dates.iloc[-1].strftime("%Y-%m-%d")
+            start_date = unfiltered_df["date"].iloc[0].strftime("%Y-%m-%d")
+            end_date = unfiltered_df["date"].iloc[-1].strftime("%Y-%m-%d")
             logger.info(
                 f"-------------------- Training on data from {start_date} to "
                 f"{end_date} --------------------"
@@ -1450,11 +1448,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             dd = self._apply_pipelines(dd, dk, pair)
 
             logger.info(
-                f"Training model on {len(dd['train_features'].columns)} features"
+                f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
             )
             logger.info(f"Training model on {len(dd['train_features'])} data points")
 
-            model = self.fit(dd, dk, **kwargs)
+            model = self.fit(dd, dk)
 
             end_time = time.time()
 
@@ -1465,14 +1463,21 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
             return model
 
-    def _train_default(
+    def _train(
         self,
         unfiltered_df: pd.DataFrame,
         pair: str,
         dk: FreqaiDataKitchen,
         **kwargs,
     ) -> Any:
+        """
+        Mirror of ``BaseRegressionModel.train`` with a single insertion: composition
+        of per-label sample weights via :meth:`_compose_train_weights` between the
+        train/test split and the pipeline application. Routed from :meth:`train`
+        when ``data_split_parameters.method`` is ``train_test_split``.
+        """
         logger.info(f"-------------------- Starting training {pair} --------------------")
+
         start_time = time.time()
 
         features_filtered, labels_filtered = dk.filter_features(
@@ -1482,9 +1487,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             training_filter=True,
         )
 
-        dates = ensure_datetime_series(unfiltered_df["date"])
-        start_date = dates.iloc[0].strftime("%Y-%m-%d")
-        end_date = dates.iloc[-1].strftime("%Y-%m-%d")
+        start_date = unfiltered_df["date"].iloc[0].strftime("%Y-%m-%d")
+        end_date = unfiltered_df["date"].iloc[-1].strftime("%Y-%m-%d")
         logger.info(
             f"-------------------- Training on data from {start_date} to "
             f"{end_date} --------------------"
@@ -1498,12 +1502,15 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         dd = self._apply_pipelines(dd, dk, pair)
 
-        logger.info(f"Training model on {len(dd['train_features'].columns)} features")
+        logger.info(
+            f"Training model on {len(dk.data_dictionary['train_features'].columns)} features"
+        )
         logger.info(f"Training model on {len(dd['train_features'])} data points")
 
-        model = self.fit(dd, dk, **kwargs)
+        model = self.fit(dd, dk)
 
         end_time = time.time()
+
         logger.info(
             f"-------------------- Done training {pair} "
             f"({end_time - start_time:.2f} secs) --------------------"

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -21,7 +21,7 @@ from freqtrade.freqai.base_models.BaseRegressionModel import BaseRegressionModel
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from numpy.typing import NDArray
 from optuna.study.study import ObjectiveFuncType
-from sklearn.model_selection import TimeSeriesSplit
+from sklearn.model_selection import TimeSeriesSplit, train_test_split
 from sklearn.preprocessing import (
     MaxAbsScaler,
     MinMaxScaler,
@@ -104,6 +104,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     version = "3.11.9"
 
     _TEST_SIZE: Final[float] = 0.1
+
+    _SKLEARN_TRAIN_TEST_SPLIT_KEYS: Final[frozenset[str]] = frozenset(
+        {"test_size", "train_size", "random_state", "shuffle", "stratify"}
+    )
 
     _SQRT_2: Final[float] = np.sqrt(2.0)
 
@@ -1394,6 +1398,112 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return self._make_timeseries_split_datasets(features, labels, dk)
 
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
+
+    def _make_default_split_datasets(
+        self,
+        features: pd.DataFrame,
+        labels: pd.DataFrame,
+        weights: NDArray[np.floating],
+        dk: FreqaiDataKitchen,
+    ) -> dict[str, Any]:
+        """Mirror freqtrade's make_train_test_datasets accepting external weights.
+
+        Reproduces upstream behavior (data_kitchen.py:126-209) with deviations:
+
+        1. Accepts pre-computed per-row weights (avoids re-deriving temporal-only).
+        2. Whitelists sklearn-safe kwargs from data_split_parameters; drops
+           project-custom keys (``method``, ``n_splits``, ``gap``,
+           ``max_train_size``).
+        3. Uses ``.get("shuffle_after_split", False)`` for safer default;
+           upstream uses bare key access which raises KeyError on configs
+           without the key (including this project's config-template.json).
+        4. Does not mutate ``self.config`` in-place; upstream injects
+           ``shuffle=False`` via ``dict.update`` on the live config.
+        5. Skips test-side shuffle when ``test_size==0``. Upstream shuffles
+           test unconditionally, but its synthetic ``test_labels=np.zeros(2)``
+           and ``test_weights=np.zeros(2)`` raise AttributeError on
+           ``.sample()``. This deviation only fires under ``test_size==0``
+           plus ``shuffle_after_split=True``, a configuration upstream itself
+           would crash on.
+
+        Per-label weights are propagated to BOTH ``train_weights`` AND
+        ``test_weights`` (matches existing PR #72 behavior; ``test_weights``
+        feed the HPO eval objective).
+        """
+        feat_dict = self.freqai_info.get("feature_parameters", {})
+        dsp = dict(self.config["freqai"]["data_split_parameters"])
+        if "shuffle" not in dsp:
+            dsp["shuffle"] = False
+        sklearn_kwargs = {
+            k: v
+            for k, v in dsp.items()
+            if k in QuickAdapterRegressorV3._SKLEARN_TRAIN_TEST_SPLIT_KEYS
+        }
+        test_size = dsp.get("test_size", QuickAdapterRegressorV3._TEST_SIZE)
+
+        if test_size != 0:
+            (
+                train_features,
+                test_features,
+                train_labels,
+                test_labels,
+                train_weights,
+                test_weights,
+            ) = train_test_split(features, labels, weights, **sklearn_kwargs)
+        else:
+            train_features = features
+            train_labels = labels
+            train_weights = weights
+            test_features = pd.DataFrame()
+            test_labels = np.zeros(2)
+            test_weights = np.zeros(2)
+
+        if feat_dict.get("shuffle_after_split", False):
+            rint1 = random.randint(0, 100)
+            rint2 = random.randint(0, 100)
+            train_features = train_features.sample(
+                frac=1, random_state=rint1
+            ).reset_index(drop=True)
+            train_labels = train_labels.sample(
+                frac=1, random_state=rint1
+            ).reset_index(drop=True)
+            train_weights = (
+                pd.DataFrame(train_weights)
+                .sample(frac=1, random_state=rint1)
+                .reset_index(drop=True)
+                .to_numpy()[:, 0]
+            )
+            if test_size != 0:
+                test_features = test_features.sample(
+                    frac=1, random_state=rint2
+                ).reset_index(drop=True)
+                test_labels = test_labels.sample(
+                    frac=1, random_state=rint2
+                ).reset_index(drop=True)
+                test_weights = (
+                    pd.DataFrame(test_weights)
+                    .sample(frac=1, random_state=rint2)
+                    .reset_index(drop=True)
+                    .to_numpy()[:, 0]
+                )
+
+        if feat_dict.get("reverse_train_test_order", False):
+            return dk.build_data_dictionary(
+                test_features,
+                train_features,
+                test_labels,
+                train_labels,
+                test_weights,
+                train_weights,
+            )
+        return dk.build_data_dictionary(
+            train_features,
+            test_features,
+            train_labels,
+            test_labels,
+            train_weights,
+            test_weights,
+        )
 
     def _build_per_row_weights(
         self,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1383,18 +1383,16 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     def train(
         self, unfiltered_df: pd.DataFrame, pair: str, dk: FreqaiDataKitchen, **kwargs
     ) -> Any:
-        """
-        Filter the training data and train a model to it.
+        """Train a model with per-row sample weights.
 
-        Supports two data split methods:
-        - 'train_test_split' (default): Delegates to BaseRegressionModel.train()
-        - 'timeseries_split': Chronological split with configurable gap. Uses the final
-          fold from sklearn's TimeSeriesSplit.
-
-        :param unfiltered_df: Full dataframe for the current training period
-        :param pair: Trading pair being trained
-        :param dk: FreqaiDataKitchen object containing configuration
-        :return: Trained model
+        Dispatches on ``data_split_parameters.method``:
+        - ``train_test_split``: random sklearn split.
+        - ``timeseries_split``: chronological final-fold split.
+        Both paths compose per-row weights via ``_compose_per_row_weights``
+        before splitting and feed them to ``model.fit(sample_weight=...)``
+        through ``_train_common``. Train and test weights are renormalized
+        to mean=1 after ``feature_pipeline.fit_transform`` to preserve the
+        invariant despite pipeline-level row drops.
         """
         method = self.data_split_parameters.get(
             "method", QuickAdapterRegressorV3.DATA_SPLIT_METHOD_DEFAULT
@@ -1547,13 +1545,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     ) -> NDArray[np.floating]:
         """Build a per-row sample weight vector aligned to features_filtered.index.
 
-        Combines freqtrade's temporal recency weight with the geometric mean
-        of all per-target weight columns present on ``unfiltered_df``.
-        Alignment is done BEFORE any shuffle/split, on
-        ``features_filtered.index`` (a subset of ``unfiltered_df.index``),
-        avoiding any post-hoc reindex against shuffled data.
-
-        Generic over N targets: iterates ``dk.label_list`` and only includes
+        Composes freqtrade's temporal recency weight with the configured
+        per-label aggregation (default ``arithmetic_mean``) of every
+        per-target weight column present on ``unfiltered_df``. Alignment
+        runs before any shuffle/split on ``features_filtered.index``
+        (a subset of ``unfiltered_df.index``) to avoid post-hoc reindex
+        against shuffled data. Iterates ``dk.label_list`` and only includes
         labels whose ``label_weight_column(label)`` exists on
         ``unfiltered_df``.
         """

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1395,7 +1395,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         **kwargs,
     ) -> Any:
         def split_fn(features: pd.DataFrame, labels: pd.DataFrame) -> dict[str, Any]:
-            return self._make_timeseries_split_datasets(features, labels, dk)
+            feature_parameters = self.freqai_info.get("feature_parameters", {})
+            if feature_parameters.get("weight_factor", 0) > 0:
+                weights = np.asarray(
+                    dk.set_weights_higher_recent(len(features)), dtype=float
+                )
+            else:
+                weights = np.ones(len(features), dtype=float)
+            return self._make_timeseries_split_datasets(features, labels, weights, dk)
 
         return self._train_common(unfiltered_df, pair, dk, split_fn, **kwargs)
 
@@ -1729,6 +1736,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         self,
         filtered_dataframe: pd.DataFrame,
         labels: pd.DataFrame,
+        weights: NDArray[np.floating],
         dk: FreqaiDataKitchen,
     ) -> dict:
         """
@@ -1740,7 +1748,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         :param filtered_dataframe: Feature data to split
         :param labels: Label data to split
-        :param dk: FreqaiDataKitchen instance for weight calculation and data building
+        :param weights: Pre-computed per-row sample weights aligned to
+                        filtered_dataframe rows by position; sliced via
+                        ``weights[train_idx]`` / ``weights[test_idx]``.
+        :param dk: FreqaiDataKitchen instance for data building
         :return: data_dictionary with train/test features/labels/weights
         """
         n_splits = int(
@@ -1813,15 +1824,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         test_features = filtered_dataframe.iloc[test_idx]
         train_labels = labels.iloc[train_idx]
         test_labels = labels.iloc[test_idx]
-
-        feature_parameters = self.freqai_info.get("feature_parameters", {})
-        if feature_parameters.get("weight_factor", 0) > 0:
-            total_weights = dk.set_weights_higher_recent(len(train_idx) + len(test_idx))
-            train_weights = total_weights[: len(train_idx)]
-            test_weights = total_weights[len(train_idx) :]
-        else:
-            train_weights = np.ones(len(train_idx))
-            test_weights = np.ones(len(test_idx))
+        train_weights = weights[train_idx]
+        test_weights = weights[test_idx]
 
         return dk.build_data_dictionary(
             train_features,

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -87,6 +87,11 @@ DEFAULTS_LABEL_WEIGHTING: Final[dict[str, Any]] = {
     "softmax_temperature": 1.0,
 }
 
+DEFAULTS_SAMPLE_WEIGHTING: Final[dict[str, Any]] = {
+    "aggregation": COMBINED_AGGREGATIONS[0],  # "arithmetic_mean"
+    "softmax_temperature": 1.0,
+}
+
 DEFAULTS_LABEL_PIPELINE: Final[dict[str, Any]] = {
     "standardization": STANDARDIZATION_TYPES[0],  # "none"
     "robust_quantiles": (0.25, 0.75),

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -848,13 +848,10 @@ class QuickAdapterV3(IStrategy):
             )
 
             dataframe[label_col] = smooth(
-                dataframe[label_col],
-                col_smoothing_config["method"],
-                col_smoothing_config["window_candles"],
-                col_smoothing_config["beta"],
-                col_smoothing_config["polyorder"],
-                col_smoothing_config["mode"],
-                col_smoothing_config["sigma"],
+                dataframe[label_col], **col_smoothing_config
+            )
+            dataframe[f"{label_col}_weight"] = smooth(
+                dataframe[f"{label_col}_weight"], **col_smoothing_config
             )
 
             if label_col == EXTREMA_COLUMN:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -54,7 +54,7 @@ from Utils import (
     non_zero_diff,
     optuna_load_best_params,
     price_retracement_percent,
-    smooth_label,
+    smooth,
     top_log_return,
     validate_range,
     vwapb,
@@ -847,7 +847,7 @@ class QuickAdapterV3(IStrategy):
                 label_col, label_smoothing["default"], label_smoothing["columns"]
             )
 
-            dataframe[label_col] = smooth_label(
+            dataframe[label_col] = smooth(
                 dataframe[label_col],
                 col_smoothing_config["method"],
                 col_smoothing_config["window_candles"],

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -826,14 +826,15 @@ class QuickAdapterV3(IStrategy):
                 label_col, label_weighting["default"], label_weighting["columns"]
             )
 
-            weighted_label, _ = apply_label_weighting(
+            _, label_weights = apply_label_weighting(
                 label=label_data.series,
                 indices=label_data.indices,
                 metrics=label_data.metrics,
                 weighting_config=col_weighting_config,
             )
 
-            dataframe[label_col] = weighted_label
+            dataframe[label_col] = label_data.series
+            dataframe[f"{label_col}_weight"] = label_weights
 
             if label_col == EXTREMA_COLUMN:
                 extrema = dataframe[label_col]

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -34,7 +34,6 @@ from Utils import (
     EXTREMA_WEIGHT_COLUMN,
     EXTREMA_WEIGHT_SMOOTHED_COLUMN,
     LABEL_COLUMNS,
-    LABEL_WEIGHT_SUFFIX,
     TRADE_PRICE_TARGETS,
     alligator,
     bottom_log_return,
@@ -51,6 +50,7 @@ from Utils import (
     get_label_smoothing_config,
     get_label_weighting_config,
     get_zl_ma_fn,
+    label_weight_column,
     migrate_config,
     nan_average,
     non_zero_diff,
@@ -842,7 +842,7 @@ class QuickAdapterV3(IStrategy):
                 weighting_config=col_weighting_config,
             )
 
-            label_weight_col = f"{label_col}{LABEL_WEIGHT_SUFFIX}"
+            label_weight_col = label_weight_column(label_col)
 
             dataframe[label_col] = label_data.series
             dataframe[label_weight_col] = label_weights

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -856,8 +856,11 @@ class QuickAdapterV3(IStrategy):
             )
 
             dataframe[label_col] = smooth(dataframe[label_col], **col_smoothing_config)
-            dataframe[label_weight_col] = smooth(
+            smoothed_weights = smooth(
                 dataframe[label_weight_col], **col_smoothing_config
+            )
+            dataframe[label_weight_col] = smoothed_weights.where(
+                smoothed_weights.gt(0) & smoothed_weights.notna(), 0.0
             )
 
             if label_col == EXTREMA_COLUMN:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -50,7 +50,7 @@ from Utils import (
     get_label_smoothing_config,
     get_label_weighting_config,
     get_zl_ma_fn,
-    label_weight_column,
+    label_weight_column_name,
     migrate_config,
     nan_average,
     non_zero_diff,
@@ -842,7 +842,7 @@ class QuickAdapterV3(IStrategy):
                 weighting_config=col_weighting_config,
             )
 
-            label_weight_col = label_weight_column(label_col)
+            label_weight_col = label_weight_column_name(label_col)
 
             dataframe[label_col] = label_data.series
             dataframe[label_weight_col] = label_weights

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -30,10 +30,10 @@ from Utils import (
     DEFAULT_FIT_LIVE_PREDICTIONS_CANDLES,
     EXTREMA_COLUMN,
     EXTREMA_DIRECTION_COLUMN,
+    EXTREMA_DIRECTION_SMOOTHED_COLUMN,
     EXTREMA_WEIGHT_COLUMN,
+    EXTREMA_WEIGHT_SMOOTHED_COLUMN,
     LABEL_COLUMNS,
-    SMOOTHED_EXTREMA_COLUMN,
-    SMOOTHED_EXTREMA_WEIGHT_COLUMN,
     TRADE_PRICE_TARGETS,
     alligator,
     bottom_log_return,
@@ -206,11 +206,14 @@ class QuickAdapterV3(IStrategy):
                 },
                 "direction": {
                     EXTREMA_DIRECTION_COLUMN: {"color": "wheat", "type": "line"},
-                    SMOOTHED_EXTREMA_COLUMN: {"color": "orange", "type": "line"},
+                    EXTREMA_DIRECTION_SMOOTHED_COLUMN: {
+                        "color": "orange",
+                        "type": "line",
+                    },
                 },
                 "weight": {
                     EXTREMA_WEIGHT_COLUMN: {"color": "wheat", "type": "line"},
-                    SMOOTHED_EXTREMA_WEIGHT_COLUMN: {
+                    EXTREMA_WEIGHT_SMOOTHED_COLUMN: {
                         "color": "orange",
                         "type": "line",
                     },
@@ -857,8 +860,8 @@ class QuickAdapterV3(IStrategy):
             )
 
             if label_col == EXTREMA_COLUMN:
-                dataframe[SMOOTHED_EXTREMA_COLUMN] = dataframe[label_col]
-                dataframe[SMOOTHED_EXTREMA_WEIGHT_COLUMN] = dataframe[
+                dataframe[EXTREMA_DIRECTION_SMOOTHED_COLUMN] = dataframe[label_col]
+                dataframe[EXTREMA_WEIGHT_SMOOTHED_COLUMN] = dataframe[
                     f"{label_col}_weight"
                 ]
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -855,9 +855,7 @@ class QuickAdapterV3(IStrategy):
                 label_col, label_smoothing["default"], label_smoothing["columns"]
             )
 
-            dataframe[label_col] = smooth(
-                dataframe[label_col], **col_smoothing_config
-            )
+            dataframe[label_col] = smooth(dataframe[label_col], **col_smoothing_config)
             dataframe[label_weight_col] = smooth(
                 dataframe[label_weight_col], **col_smoothing_config
             )

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -29,10 +29,11 @@ from technical.pivots_points import pivots_points
 from Utils import (
     DEFAULT_FIT_LIVE_PREDICTIONS_CANDLES,
     EXTREMA_COLUMN,
+    EXTREMA_DIRECTION_COLUMN,
+    EXTREMA_WEIGHT_COLUMN,
     LABEL_COLUMNS,
-    MAXIMA_COLUMN,
-    MINIMA_COLUMN,
     SMOOTHED_EXTREMA_COLUMN,
+    SMOOTHED_EXTREMA_WEIGHT_COLUMN,
     TRADE_PRICE_TARGETS,
     alligator,
     bottom_log_return,
@@ -203,10 +204,16 @@ class QuickAdapterV3(IStrategy):
                     },
                     EXTREMA_COLUMN: {"color": "orange", "type": "line"},
                 },
-                "min_max": {
-                    SMOOTHED_EXTREMA_COLUMN: {"color": "wheat", "type": "line"},
-                    MAXIMA_COLUMN: {"color": "red", "type": "bar"},
-                    MINIMA_COLUMN: {"color": "green", "type": "bar"},
+                "direction": {
+                    EXTREMA_DIRECTION_COLUMN: {"color": "wheat", "type": "line"},
+                    SMOOTHED_EXTREMA_COLUMN: {"color": "orange", "type": "line"},
+                },
+                "weight": {
+                    EXTREMA_WEIGHT_COLUMN: {"color": "wheat", "type": "line"},
+                    SMOOTHED_EXTREMA_WEIGHT_COLUMN: {
+                        "color": "orange",
+                        "type": "line",
+                    },
                 },
             },
         }
@@ -835,13 +842,8 @@ class QuickAdapterV3(IStrategy):
             dataframe[f"{label_col}_weight"] = label_weights
 
             if label_col == EXTREMA_COLUMN:
-                extrema_direction = label_data.series
-                dataframe[MAXIMA_COLUMN] = extrema_direction.where(
-                    extrema_direction.gt(0), 0.0
-                )
-                dataframe[MINIMA_COLUMN] = extrema_direction.where(
-                    extrema_direction.lt(0), 0.0
-                )
+                dataframe[EXTREMA_DIRECTION_COLUMN] = dataframe[label_col]
+                dataframe[EXTREMA_WEIGHT_COLUMN] = dataframe[f"{label_col}_weight"]
 
             col_smoothing_config = get_label_column_config(
                 label_col, label_smoothing["default"], label_smoothing["columns"]
@@ -856,6 +858,9 @@ class QuickAdapterV3(IStrategy):
 
             if label_col == EXTREMA_COLUMN:
                 dataframe[SMOOTHED_EXTREMA_COLUMN] = dataframe[label_col]
+                dataframe[SMOOTHED_EXTREMA_WEIGHT_COLUMN] = dataframe[
+                    f"{label_col}_weight"
+                ]
 
         return dataframe
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -35,9 +35,9 @@ from Utils import (
     SMOOTHED_EXTREMA_COLUMN,
     TRADE_PRICE_TARGETS,
     alligator,
-    apply_label_weighting,
     bottom_log_return,
     calculate_quantile,
+    compute_label_weights,
     ensure_datetime_series,
     ewo,
     format_dict,
@@ -826,8 +826,8 @@ class QuickAdapterV3(IStrategy):
                 label_col, label_weighting["default"], label_weighting["columns"]
             )
 
-            _, label_weights = apply_label_weighting(
-                label=label_data.series,
+            label_weights = compute_label_weights(
+                n_values=len(label_data.series),
                 indices=label_data.indices,
                 metrics=label_data.metrics,
                 weighting_config=col_weighting_config,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -856,11 +856,11 @@ class QuickAdapterV3(IStrategy):
             )
 
             dataframe[label_col] = smooth(dataframe[label_col], **col_smoothing_config)
-            smoothed_weights = smooth(
+            smoothed_label_weights = smooth(
                 dataframe[label_weight_col], **col_smoothing_config
             )
-            dataframe[label_weight_col] = smoothed_weights.where(
-                smoothed_weights.gt(0) & smoothed_weights.notna(), 0.0
+            dataframe[label_weight_col] = smoothed_label_weights.where(
+                smoothed_label_weights.gt(0) & smoothed_label_weights.notna(), 0.0
             )
 
             if label_col == EXTREMA_COLUMN:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -106,8 +106,6 @@ class QuickAdapterV3(IStrategy):
 
     _ANNOTATION_LINE_OFFSET_CANDLES: Final[int] = 10
 
-    _PLOT_EXTREMA_MIN_EPS: Final[float] = 0.01
-
     def version(self) -> str:
         return "3.11.9"
 
@@ -837,29 +835,12 @@ class QuickAdapterV3(IStrategy):
             dataframe[f"{label_col}_weight"] = label_weights
 
             if label_col == EXTREMA_COLUMN:
-                extrema = dataframe[label_col]
                 extrema_direction = label_data.series
-                plot_eps = extrema.abs().where(extrema.ne(0.0)).min()
-                if not np.isfinite(plot_eps):
-                    plot_eps = 0.0
-                plot_eps = max(
-                    float(plot_eps) * 0.5, QuickAdapterV3._PLOT_EXTREMA_MIN_EPS
+                dataframe[MAXIMA_COLUMN] = extrema_direction.where(
+                    extrema_direction.gt(0), 0.0
                 )
-                dataframe[MAXIMA_COLUMN] = (
-                    extrema.where(extrema_direction.gt(0), 0.0)
-                    .clip(lower=0.0)
-                    .mask(
-                        extrema_direction.gt(0) & extrema.eq(0.0),
-                        plot_eps,
-                    )
-                )
-                dataframe[MINIMA_COLUMN] = (
-                    extrema.where(extrema_direction.lt(0), 0.0)
-                    .clip(upper=0.0)
-                    .mask(
-                        extrema_direction.lt(0) & extrema.eq(0.0),
-                        -plot_eps,
-                    )
+                dataframe[MINIMA_COLUMN] = extrema_direction.where(
+                    extrema_direction.lt(0), 0.0
                 )
 
             col_smoothing_config = get_label_column_config(

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -34,6 +34,7 @@ from Utils import (
     EXTREMA_WEIGHT_COLUMN,
     EXTREMA_WEIGHT_SMOOTHED_COLUMN,
     LABEL_COLUMNS,
+    LABEL_WEIGHT_SUFFIX,
     TRADE_PRICE_TARGETS,
     alligator,
     bottom_log_return,
@@ -841,12 +842,14 @@ class QuickAdapterV3(IStrategy):
                 weighting_config=col_weighting_config,
             )
 
+            label_weight_col = f"{label_col}{LABEL_WEIGHT_SUFFIX}"
+
             dataframe[label_col] = label_data.series
-            dataframe[f"{label_col}_weight"] = label_weights
+            dataframe[label_weight_col] = label_weights
 
             if label_col == EXTREMA_COLUMN:
                 dataframe[EXTREMA_DIRECTION_COLUMN] = dataframe[label_col]
-                dataframe[EXTREMA_WEIGHT_COLUMN] = dataframe[f"{label_col}_weight"]
+                dataframe[EXTREMA_WEIGHT_COLUMN] = dataframe[label_weight_col]
 
             col_smoothing_config = get_label_column_config(
                 label_col, label_smoothing["default"], label_smoothing["columns"]
@@ -855,15 +858,13 @@ class QuickAdapterV3(IStrategy):
             dataframe[label_col] = smooth(
                 dataframe[label_col], **col_smoothing_config
             )
-            dataframe[f"{label_col}_weight"] = smooth(
-                dataframe[f"{label_col}_weight"], **col_smoothing_config
+            dataframe[label_weight_col] = smooth(
+                dataframe[label_weight_col], **col_smoothing_config
             )
 
             if label_col == EXTREMA_COLUMN:
                 dataframe[EXTREMA_DIRECTION_SMOOTHED_COLUMN] = dataframe[label_col]
-                dataframe[EXTREMA_WEIGHT_SMOOTHED_COLUMN] = dataframe[
-                    f"{label_col}_weight"
-                ]
+                dataframe[EXTREMA_WEIGHT_SMOOTHED_COLUMN] = dataframe[label_weight_col]
 
         return dataframe
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -109,7 +109,7 @@ class QuickAdapterV3(IStrategy):
     _PLOT_EXTREMA_MIN_EPS: Final[float] = 0.01
 
     def version(self) -> str:
-        return "3.11.8"
+        return "3.11.9"
 
     timeframe = "5m"
     timeframe_minutes = timeframe_to_minutes(timeframe)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -680,6 +680,31 @@ def midpoint(value1: T, value2: T) -> T:
     return (value1 + value2) / 2
 
 
+def compose_sample_weights(
+    temporal: NDArray[np.floating],
+    label_weights_map: dict[str, NDArray[np.floating]],
+) -> NDArray[np.floating]:
+    if not label_weights_map:
+        return temporal
+    normalized_per_label: list[NDArray[np.floating]] = []
+    for w in label_weights_map.values():
+        arr = np.asarray(w, dtype=float)
+        arr = np.where(np.isfinite(arr) & (arr > 0), arr, 1.0)
+        total = arr.sum()
+        if total <= 0 or not np.isfinite(total):
+            arr = np.ones_like(arr)
+        else:
+            arr = arr * (len(arr) / total)
+        normalized_per_label.append(arr)
+    stacked = np.vstack(normalized_per_label)
+    agg = np.exp(np.log(stacked).mean(axis=0))
+    combined = np.asarray(temporal, dtype=float) * agg
+    combined_sum = combined.sum()
+    if combined_sum <= 0 or not np.isfinite(combined_sum):
+        return np.asarray(temporal, dtype=float)
+    return combined * (len(combined) / combined_sum)
+
+
 def nan_average(
     values: NDArray[np.floating],
     weights: NDArray[np.floating] | None = None,

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -739,7 +739,10 @@ def sanitize_and_renormalize(
     total = safe.sum()
     if total > 0 and np.isfinite(total):
         return safe * (len(safe) / total)
-    return np.ones_like(arr)
+    fallback = np.ones_like(arr)
+    if drop_mask is not None:
+        fallback[drop_mask] = 0.0
+    return fallback
 
 
 def compose_sample_weights(

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -731,13 +731,16 @@ def _sanitize_and_renormalize(
 def compose_sample_weights(
     temporal: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
+    aggregation: CombinedAggregation = COMBINED_AGGREGATIONS[0],
+    softmax_temperature: float = 1.0,
 ) -> NDArray[np.floating]:
     """Combine temporal recency weights with per-label importance weights.
 
     Returns w in R+^N with mean(w) == 1. Per-label arrays are sanitized
     (non-finite or <= 0 -> row dropped), individually mean-normalized,
-    aggregated row-wise via geometric mean, multiplied with temporal,
-    zeroed on dropped rows, and renormalized to mean=1.
+    aggregated row-wise via ``aggregation`` (default arithmetic_mean),
+    multiplied with temporal, zeroed on dropped rows, and renormalized
+    to mean=1.
 
     Raises ValueError on shape mismatch or when every row is dropped.
     Default-weight imputation in compute_label_weights uses full-series
@@ -768,7 +771,12 @@ def compose_sample_weights(
             f"(labels={list(label_weights_map)}); no surviving training samples"
         )
     stacked = np.vstack(normalized_per_label)
-    agg = np.exp(np.log(stacked).mean(axis=0))
+    agg = _aggregate_metrics(
+        stacked_metrics=stacked,
+        coefficients=np.ones(stacked.shape[0], dtype=float),
+        aggregation=aggregation,
+        softmax_temperature=softmax_temperature,
+    )
     combined = temporal * agg
     combined[drop_mask] = 0.0
     combined_sum = combined.sum()

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -251,6 +251,10 @@ _PREDICTION_SPECS: Final[dict[str, _ParamSpec]] = {
 
 EXTREMA_COLUMN: Final = "&s-extrema"
 LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
+EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
+EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
+EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
+EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
 
 
 @dataclass
@@ -323,11 +327,6 @@ def generate_label_data(
         )
     return generator(dataframe, params)
 
-
-EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
-EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
-EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
-EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
 
 SmoothingKernel = Literal["gaussian", "kaiser", "triang"]
 SMOOTHING_KERNELS: Final[tuple[SmoothingKernel, ...]] = (

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -325,9 +325,9 @@ def generate_label_data(
 
 
 EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
-SMOOTHED_EXTREMA_COLUMN: Final = "smoothed_extrema"
+EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
 EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
-SMOOTHED_EXTREMA_WEIGHT_COLUMN: Final = "smoothed_extrema_weight"
+EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
 
 SmoothingKernel = Literal["gaussian", "kaiser", "triang"]
 SMOOTHING_KERNELS: Final[tuple[SmoothingKernel, ...]] = (

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -260,6 +260,7 @@ EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
 EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
 
 
+@lru_cache(maxsize=16)
 def label_weight_column(label_col: str) -> str:
     """Return the weight column name for a label column.
 
@@ -750,8 +751,8 @@ def compose_sample_weights(
     if not label_weights_map:
         return _sanitize_and_renormalize(base_weights)
     n = len(base_weights)
-    for label, w in label_weights_map.items():
-        arr = np.asarray(w, dtype=float)
+    for label, label_values in label_weights_map.items():
+        arr = np.asarray(label_values, dtype=float)
         if arr.shape != (n,):
             raise ValueError(
                 f"compose_sample_weights: label {label!r} has shape {arr.shape}, "
@@ -759,8 +760,8 @@ def compose_sample_weights(
             )
     normalized_per_label: list[NDArray[np.floating]] = []
     drop_mask = np.zeros(n, dtype=bool)
-    for w in label_weights_map.values():
-        arr = np.asarray(w, dtype=float)
+    for label_values in label_weights_map.values():
+        arr = np.asarray(label_values, dtype=float)
         invalid = ~np.isfinite(arr) | (arr <= 0.0)
         drop_mask |= invalid
         arr = np.where(invalid, 1.0, np.maximum(arr, np.finfo(float).tiny))

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -251,6 +251,7 @@ _PREDICTION_SPECS: Final[dict[str, _ParamSpec]] = {
 
 EXTREMA_COLUMN: Final = "&s-extrema"
 LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
+LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
 EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
 EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
 EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2,6 +2,7 @@ import copy
 import functools
 import hashlib
 import json
+import logging
 import math
 import re
 from dataclasses import dataclass
@@ -56,6 +57,8 @@ else:
     XGBoostTrainingCallback = object
 
 T = TypeVar("T", pd.Series, float)
+
+_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -497,6 +500,14 @@ CONFIG_MIGRATIONS: Final[tuple[tuple[str, str], ...]] = (
     ("freqai.label_weighting.minmax_range", "freqai.label_pipeline.minmax_range"),
     ("freqai.label_weighting.sigmoid_scale", "freqai.label_pipeline.sigmoid_scale"),
     ("freqai.label_weighting.gamma", "freqai.label_pipeline.gamma"),
+    (
+        "freqai.feature_parameters.label_weights_aggregation",
+        "freqai.label_weighting.aggregation",
+    ),
+    (
+        "freqai.feature_parameters.label_weights_softmax_temperature",
+        "freqai.label_weighting.softmax_temperature",
+    ),
 )
 
 
@@ -786,6 +797,13 @@ def compose_sample_weights(
             scaled = combined * ratio
             if np.all(np.isfinite(scaled)):
                 return scaled
+    _logger.warning(
+        "compose_sample_weights: aggregated weights collapsed (labels=%s, "
+        "aggregation=%s, combined_sum=%r); falling back to base weights",
+        list(label_weights_map),
+        aggregation,
+        combined_sum,
+    )
     return sanitize_and_renormalize(base_weights, drop_mask=drop_mask)
 
 

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -324,9 +324,10 @@ def generate_label_data(
     return generator(dataframe, params)
 
 
-MAXIMA_COLUMN: Final = "maxima"
-MINIMA_COLUMN: Final = "minima"
+EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
 SMOOTHED_EXTREMA_COLUMN: Final = "smoothed_extrema"
+EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
+SMOOTHED_EXTREMA_WEIGHT_COLUMN: Final = "smoothed_extrema_weight"
 
 SmoothingKernel = Literal["gaussian", "kaiser", "triang"]
 SMOOTHING_KERNELS: Final[tuple[SmoothingKernel, ...]] = (

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -33,6 +33,7 @@ from LabelTransformer import (
     DEFAULTS_LABEL_PREDICTION,
     DEFAULTS_LABEL_SMOOTHING,
     DEFAULTS_LABEL_WEIGHTING,
+    DEFAULTS_SAMPLE_WEIGHTING,
     EXTREMA_SELECTION_METHODS,
     NORMALIZATION_TYPES,
     PREDICTION_METHODS,
@@ -230,6 +231,13 @@ _SMOOTHING_SPECS: Final[dict[str, _ParamSpec]] = {
     "mode": _ParamSpec(_EnumValidator(SMOOTHING_MODES)),
     "sigma": _ParamSpec(
         _NumericValidator(min_value=0, min_exclusive=True), output_type=float
+    ),
+}
+
+_SAMPLE_WEIGHTING_SPECS: Final[dict[str, _ParamSpec]] = {
+    "aggregation": _ParamSpec(_EnumValidator(COMBINED_AGGREGATIONS)),
+    "softmax_temperature": _ParamSpec(
+        _NumericValidator(min_value=0, min_exclusive=True)
     ),
 }
 
@@ -503,14 +511,6 @@ CONFIG_MIGRATIONS: Final[tuple[tuple[str, str], ...]] = (
     ("freqai.label_weighting.minmax_range", "freqai.label_pipeline.minmax_range"),
     ("freqai.label_weighting.sigmoid_scale", "freqai.label_pipeline.sigmoid_scale"),
     ("freqai.label_weighting.gamma", "freqai.label_pipeline.gamma"),
-    (
-        "freqai.feature_parameters.label_weights_aggregation",
-        "freqai.label_weighting.aggregation",
-    ),
-    (
-        "freqai.feature_parameters.label_weights_softmax_temperature",
-        "freqai.label_weighting.softmax_temperature",
-    ),
 )
 
 
@@ -664,6 +664,29 @@ def get_label_smoothing_config(
         "label_smoothing",
         _validate_smoothing_params,
         DEFAULTS_LABEL_SMOOTHING,
+    )
+
+
+def _validate_sample_weighting_params(
+    config: dict[str, Any],
+    logger: Logger,
+    config_name: str = "sample_weighting",
+) -> dict[str, Any]:
+    return _validate_params(
+        config, logger, config_name, _SAMPLE_WEIGHTING_SPECS, DEFAULTS_SAMPLE_WEIGHTING
+    )
+
+
+def get_sample_weighting_config(
+    config: dict[str, Any],
+    logger: Logger,
+) -> dict[str, Any]:
+    return _get_label_config(
+        config,
+        logger,
+        "sample_weighting",
+        _validate_sample_weighting_params,
+        DEFAULTS_SAMPLE_WEIGHTING,
     )
 
 

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -1077,46 +1077,6 @@ def compute_label_weights(
     )
 
 
-def _apply_label_weights(
-    values: NDArray[np.floating], weights: NDArray[np.floating]
-) -> NDArray[np.floating]:
-    if weights.size == 0:
-        return values
-
-    if not np.isfinite(weights).all():
-        return values
-
-    if np.allclose(weights, weights[0]):
-        return values
-
-    if np.allclose(weights, DEFAULT_LABEL_WEIGHT):
-        return values
-
-    return values * weights
-
-
-def apply_label_weighting(
-    label: pd.Series,
-    indices: list[int],
-    metrics: dict[str, list[float]],
-    weighting_config: dict[str, Any],
-) -> tuple[pd.Series, pd.Series]:
-    label_values = label.to_numpy(dtype=float)
-    label_index = label.index
-    n_values = label_values.size
-
-    weights = compute_label_weights(
-        n_values=n_values,
-        indices=indices,
-        metrics=metrics,
-        weighting_config=weighting_config,
-    )
-
-    return pd.Series(
-        _apply_label_weights(label_values, weights), index=label_index
-    ), pd.Series(weights, index=label_index)
-
-
 def get_callable_sha256(fn: Callable[..., Any]) -> str:
     if not callable(fn):
         raise ValueError(f"Invalid fn value {type(fn).__name__!r}: must be callable")

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -3,6 +3,7 @@ import functools
 import hashlib
 import json
 import math
+import re
 from dataclasses import dataclass
 from enum import IntEnum
 from functools import lru_cache, singledispatch
@@ -252,10 +253,38 @@ _PREDICTION_SPECS: Final[dict[str, _ParamSpec]] = {
 EXTREMA_COLUMN: Final = "&s-extrema"
 LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
 LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
+_LABEL_WEIGHT_PREFIX_PATTERN: Final = re.compile(r"^&-?")
 EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
 EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
 EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
 EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
+
+
+def label_weight_column(label_col: str) -> str:
+    """Return the weight column name for a label column.
+
+    Strips the freqtrade label sigil (``&`` and its optional immediate ``-``
+    separator) so the resulting column does NOT collide with
+    ``FreqaiDataKitchen.find_labels`` (which selects columns containing ``&``)
+    nor with ``find_features`` (which selects columns containing ``%``).
+    Preserves the project convention where a leading ``s`` denotes a smoothed
+    target series (e.g. ``&s-extrema``); no ``s`` denotes a raw target.
+    Raises ``ValueError`` if the result still contains ``&`` or ``%``.
+
+    Examples:
+        ``"&s-extrema"``      -> ``"s-extrema_weight"`` (smoothed marker preserved)
+        ``"&-amplitude"``     -> ``"amplitude_weight"`` (raw target)
+        ``"&-time_to_pivot"`` -> ``"time_to_pivot_weight"`` (raw target)
+        ``"&-natr"``          -> ``"natr_weight"`` (raw target)
+    """
+    stripped = _LABEL_WEIGHT_PREFIX_PATTERN.sub("", label_col, count=1)
+    result = f"{stripped}{LABEL_WEIGHT_SUFFIX}"
+    if "&" in result or "%" in result:
+        raise ValueError(
+            f"label_weight_column produced collision-prone name {result!r} "
+            f"from {label_col!r}; weight columns must not contain '&' or '%'"
+        )
+    return result
 
 
 @dataclass

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -688,8 +688,10 @@ def compose_sample_weights(
     if not label_weights_map:
         return temporal
     normalized_per_label: list[NDArray[np.floating]] = []
+    drop_mask = np.zeros(len(temporal), dtype=bool)
     for w in label_weights_map.values():
         arr = np.asarray(w, dtype=float)
+        drop_mask |= arr == 0.0
         arr = np.where(np.isfinite(arr) & (arr > 0), arr, 1.0)
         total = arr.sum()
         if total <= 0 or not np.isfinite(total):
@@ -700,6 +702,7 @@ def compose_sample_weights(
     stacked = np.vstack(normalized_per_label)
     agg = np.exp(np.log(stacked).mean(axis=0))
     combined = np.asarray(temporal, dtype=float) * agg
+    combined[drop_mask] = 0.0
     combined_sum = combined.sum()
     if combined_sum <= 0 or not np.isfinite(combined_sum):
         return np.asarray(temporal, dtype=float)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -710,42 +710,64 @@ def midpoint(value1: T, value2: T) -> T:
     return (value1 + value2) / 2
 
 
+def _sanitize_and_renormalize(
+    arr: NDArray[np.floating],
+    drop_mask: NDArray[np.bool_] | None = None,
+) -> NDArray[np.floating]:
+    safe = np.where(np.isfinite(arr) & (arr > 0), arr, 0.0)
+    if drop_mask is not None:
+        safe = safe.copy()
+        safe[drop_mask] = 0.0
+    total = safe.sum()
+    if total > 0 and np.isfinite(total):
+        ratio = len(safe) / total
+        if np.isfinite(ratio):
+            scaled = safe * ratio
+            if np.all(np.isfinite(scaled)):
+                return scaled
+    return np.ones_like(arr)
+
+
 def compose_sample_weights(
     temporal: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
 ) -> NDArray[np.floating]:
     temporal = np.asarray(temporal, dtype=float)
     if not label_weights_map:
-        return temporal
+        return _sanitize_and_renormalize(temporal)
+    n = len(temporal)
+    for label, w in label_weights_map.items():
+        arr = np.asarray(w, dtype=float)
+        if arr.shape != (n,):
+            raise ValueError(
+                f"compose_sample_weights: label {label!r} has shape {arr.shape}, "
+                f"expected ({n},)"
+            )
     normalized_per_label: list[NDArray[np.floating]] = []
-    drop_mask = np.zeros(len(temporal), dtype=bool)
+    drop_mask = np.zeros(n, dtype=bool)
     for w in label_weights_map.values():
         arr = np.asarray(w, dtype=float)
-        drop_mask |= arr == 0.0
-        arr = np.where(np.isfinite(arr) & (arr > 0), arr, 1.0)
-        total = arr.sum()
-        if total <= 0 or not np.isfinite(total):
-            arr = np.ones_like(arr)
-        else:
-            arr = arr * (len(arr) / total)
-        normalized_per_label.append(arr)
+        invalid = ~np.isfinite(arr) | (arr <= 0.0)
+        drop_mask |= invalid
+        arr = np.where(invalid, 1.0, np.maximum(arr, np.finfo(float).tiny))
+        normalized_per_label.append(_sanitize_and_renormalize(arr))
+    if drop_mask.all():
+        raise ValueError(
+            f"compose_sample_weights: all rows dropped by per-label zero weights "
+            f"(labels={list(label_weights_map)}); no surviving training samples"
+        )
     stacked = np.vstack(normalized_per_label)
     agg = np.exp(np.log(stacked).mean(axis=0))
     combined = temporal * agg
     combined[drop_mask] = 0.0
     combined_sum = combined.sum()
     if combined_sum > 0 and np.isfinite(combined_sum):
-        return combined * (len(combined) / combined_sum)
-    # Degenerate path: sanitize temporal, honour drop_mask, never return NaN/Inf.
-    fallback = np.where(np.isfinite(temporal) & (temporal >= 0), temporal, 0.0)
-    fallback[drop_mask] = 0.0
-    fb_sum = fallback.sum()
-    if fb_sum > 0 and np.isfinite(fb_sum):
-        return fallback * (len(fallback) / fb_sum)
-    # Last resort: uniform on survivors (rows not in drop_mask).
-    fallback = np.ones_like(temporal)
-    fallback[drop_mask] = 0.0
-    return fallback
+        ratio = n / combined_sum
+        if np.isfinite(ratio):
+            scaled = combined * ratio
+            if np.all(np.isfinite(scaled)):
+                return scaled
+    return _sanitize_and_renormalize(temporal, drop_mask=drop_mask)
 
 
 def nan_average(

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -711,21 +711,20 @@ def midpoint(value1: T, value2: T) -> T:
     return (value1 + value2) / 2
 
 
-def _sanitize_and_renormalize(
+def sanitize_and_renormalize(
     arr: NDArray[np.floating],
     drop_mask: NDArray[np.bool_] | None = None,
 ) -> NDArray[np.floating]:
+    arr = np.asarray(arr, dtype=float)
+    if arr.size == 0:
+        return arr
     safe = np.where(np.isfinite(arr) & (arr > 0), arr, 0.0)
     if drop_mask is not None:
         safe = safe.copy()
         safe[drop_mask] = 0.0
     total = safe.sum()
     if total > 0 and np.isfinite(total):
-        ratio = len(safe) / total
-        if np.isfinite(ratio):
-            scaled = safe * ratio
-            if np.all(np.isfinite(scaled)):
-                return scaled
+        return safe * (len(safe) / total)
     return np.ones_like(arr)
 
 
@@ -749,7 +748,7 @@ def compose_sample_weights(
     """
     base_weights = np.asarray(base_weights, dtype=float)
     if not label_weights_map:
-        return _sanitize_and_renormalize(base_weights)
+        return sanitize_and_renormalize(base_weights)
     n = len(base_weights)
     for label, label_values in label_weights_map.items():
         arr = np.asarray(label_values, dtype=float)
@@ -765,7 +764,7 @@ def compose_sample_weights(
         invalid = ~np.isfinite(arr) | (arr <= 0.0)
         drop_mask |= invalid
         arr = np.where(invalid, 1.0, np.maximum(arr, np.finfo(float).tiny))
-        normalized_per_label.append(_sanitize_and_renormalize(arr))
+        normalized_per_label.append(sanitize_and_renormalize(arr))
     if drop_mask.all():
         raise ValueError(
             f"compose_sample_weights: all rows dropped by per-label zero weights "
@@ -787,7 +786,7 @@ def compose_sample_weights(
             scaled = combined * ratio
             if np.all(np.isfinite(scaled)):
                 return scaled
-    return _sanitize_and_renormalize(base_weights, drop_mask=drop_mask)
+    return sanitize_and_renormalize(base_weights, drop_mask=drop_mask)
 
 
 def nan_average(

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -253,7 +253,7 @@ _PREDICTION_SPECS: Final[dict[str, _ParamSpec]] = {
 EXTREMA_COLUMN: Final = "&s-extrema"
 LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
 LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
-_LABEL_WEIGHT_PREFIX_PATTERN: Final = re.compile(r"^&-?")
+_FREQAI_LABEL_SIGIL_PATTERN: Final = re.compile(r"^&-?")
 EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
 EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
 EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
@@ -277,7 +277,7 @@ def label_weight_column(label_col: str) -> str:
         ``"&-time_to_pivot"`` -> ``"time_to_pivot_weight"`` (raw target)
         ``"&-natr"``          -> ``"natr_weight"`` (raw target)
     """
-    stripped = _LABEL_WEIGHT_PREFIX_PATTERN.sub("", label_col, count=1)
+    stripped = _FREQAI_LABEL_SIGIL_PATTERN.sub("", label_col, count=1)
     result = f"{stripped}{LABEL_WEIGHT_SUFFIX}"
     if "&" in result or "%" in result:
         raise ValueError(
@@ -729,27 +729,27 @@ def _sanitize_and_renormalize(
 
 
 def compose_sample_weights(
-    temporal: NDArray[np.floating],
+    base_weights: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
     aggregation: CombinedAggregation = COMBINED_AGGREGATIONS[0],
     softmax_temperature: float = 1.0,
 ) -> NDArray[np.floating]:
-    """Combine temporal recency weights with per-label importance weights.
+    """Combine base sample weights with per-label importance weights.
 
     Returns w in R+^N with mean(w) == 1. Per-label arrays are sanitized
     (non-finite or <= 0 -> row dropped), individually mean-normalized,
     aggregated row-wise via ``aggregation`` (default arithmetic_mean),
-    multiplied with temporal, zeroed on dropped rows, and renormalized
+    multiplied with base_weights, zeroed on dropped rows, and renormalized
     to mean=1.
 
     Raises ValueError on shape mismatch or when every row is dropped.
     Default-weight imputation in compute_label_weights uses full-series
     median (bounded leakage; see AFML section 7.4).
     """
-    temporal = np.asarray(temporal, dtype=float)
+    base_weights = np.asarray(base_weights, dtype=float)
     if not label_weights_map:
-        return _sanitize_and_renormalize(temporal)
-    n = len(temporal)
+        return _sanitize_and_renormalize(base_weights)
+    n = len(base_weights)
     for label, w in label_weights_map.items():
         arr = np.asarray(w, dtype=float)
         if arr.shape != (n,):
@@ -777,7 +777,7 @@ def compose_sample_weights(
         aggregation=aggregation,
         softmax_temperature=softmax_temperature,
     )
-    combined = temporal * agg
+    combined = base_weights * agg
     combined[drop_mask] = 0.0
     combined_sum = combined.sum()
     if combined_sum > 0 and np.isfinite(combined_sum):
@@ -786,7 +786,7 @@ def compose_sample_weights(
             scaled = combined * ratio
             if np.all(np.isfinite(scaled)):
                 return scaled
-    return _sanitize_and_renormalize(temporal, drop_mask=drop_mask)
+    return _sanitize_and_renormalize(base_weights, drop_mask=drop_mask)
 
 
 def nan_average(
@@ -993,7 +993,7 @@ def _impute_weights(
     return weights
 
 
-def _build_weights_array(
+def _scatter_weights(
     n_values: int,
     indices: list[int],
     weights: NDArray[np.floating],
@@ -1153,7 +1153,7 @@ def compute_label_weights(
         weights=weights,
     )
 
-    return _build_weights_array(
+    return _scatter_weights(
         n_values=n_values,
         indices=indices,
         weights=weights,
@@ -2603,7 +2603,7 @@ def fit_regressor(
     return model
 
 
-def eval_set_and_weights(
+def make_test_set_and_weights(
     X_test: pd.DataFrame,
     y_test: pd.DataFrame,
     test_weights: NDArray[np.floating],

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -732,6 +732,17 @@ def compose_sample_weights(
     temporal: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
 ) -> NDArray[np.floating]:
+    """Combine temporal recency weights with per-label importance weights.
+
+    Returns w in R+^N with mean(w) == 1. Per-label arrays are sanitized
+    (non-finite or <= 0 -> row dropped), individually mean-normalized,
+    aggregated row-wise via geometric mean, multiplied with temporal,
+    zeroed on dropped rows, and renormalized to mean=1.
+
+    Raises ValueError on shape mismatch or when every row is dropped.
+    Default-weight imputation in compute_label_weights uses full-series
+    median (bounded leakage; see AFML section 7.4).
+    """
     temporal = np.asarray(temporal, dtype=float)
     if not label_weights_map:
         return _sanitize_and_renormalize(temporal)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2,7 +2,6 @@ import copy
 import functools
 import hashlib
 import json
-import logging
 import math
 import re
 from dataclasses import dataclass
@@ -58,8 +57,6 @@ else:
     XGBoostTrainingCallback = object
 
 T = TypeVar("T", pd.Series, float)
-
-_logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -771,6 +768,8 @@ def sanitize_and_renormalize(
 def compose_sample_weights(
     base_weights: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
+    *,
+    logger: Logger,
     aggregation: CombinedAggregation = COMBINED_AGGREGATIONS[0],
     softmax_temperature: float = 1.0,
 ) -> NDArray[np.floating]:
@@ -826,7 +825,7 @@ def compose_sample_weights(
             scaled = combined * ratio
             if np.all(np.isfinite(scaled)):
                 return scaled
-    _logger.warning(
+    logger.warning(
         "compose_sample_weights: aggregated weights collapsed (labels=%s, "
         "aggregation=%s, combined_sum=%r); falling back to base weights",
         list(label_weights_map),

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -796,7 +796,7 @@ def zero_phase_filter(
     return pd.Series(filtered_values, index=series.index)
 
 
-def smooth_label(
+def smooth(
     series: pd.Series,
     method: SmoothingMethod = DEFAULTS_LABEL_SMOOTHING["method"],
     window_candles: int = DEFAULTS_LABEL_SMOOTHING["window_candles"],

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -264,7 +264,7 @@ EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
 
 
 @lru_cache(maxsize=16)
-def label_weight_column(label_col: str) -> str:
+def label_weight_column_name(label_col: str) -> str:
     """Return the weight column name for a label column.
 
     Strips the freqtrade label sigil (``&`` and its optional immediate ``-``
@@ -285,7 +285,7 @@ def label_weight_column(label_col: str) -> str:
     result = f"{stripped}{LABEL_WEIGHT_SUFFIX}"
     if "&" in result or "%" in result:
         raise ValueError(
-            f"label_weight_column produced collision-prone name {result!r} "
+            f"label_weight_column_name produced collision-prone name {result!r} "
             f"from {label_col!r}; weight columns must not contain '&' or '%'"
         )
     return result

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -714,6 +714,7 @@ def compose_sample_weights(
     temporal: NDArray[np.floating],
     label_weights_map: dict[str, NDArray[np.floating]],
 ) -> NDArray[np.floating]:
+    temporal = np.asarray(temporal, dtype=float)
     if not label_weights_map:
         return temporal
     normalized_per_label: list[NDArray[np.floating]] = []
@@ -730,12 +731,21 @@ def compose_sample_weights(
         normalized_per_label.append(arr)
     stacked = np.vstack(normalized_per_label)
     agg = np.exp(np.log(stacked).mean(axis=0))
-    combined = np.asarray(temporal, dtype=float) * agg
+    combined = temporal * agg
     combined[drop_mask] = 0.0
     combined_sum = combined.sum()
-    if combined_sum <= 0 or not np.isfinite(combined_sum):
-        return np.asarray(temporal, dtype=float)
-    return combined * (len(combined) / combined_sum)
+    if combined_sum > 0 and np.isfinite(combined_sum):
+        return combined * (len(combined) / combined_sum)
+    # Degenerate path: sanitize temporal, honour drop_mask, never return NaN/Inf.
+    fallback = np.where(np.isfinite(temporal) & (temporal >= 0), temporal, 0.0)
+    fallback[drop_mask] = 0.0
+    fb_sum = fallback.sum()
+    if fb_sum > 0 and np.isfinite(fb_sum):
+        return fallback * (len(fallback) / fb_sum)
+    # Last resort: uniform on survivors (rows not in drop_mask).
+    fallback = np.ones_like(temporal)
+    fallback[drop_mask] = 0.0
+    return fallback
 
 
 def nan_average(

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -745,7 +745,7 @@ def compose_sample_weights(
 
     Raises ValueError on shape mismatch or when every row is dropped.
     Default-weight imputation in compute_label_weights uses full-series
-    median (bounded leakage; see AFML section 7.4).
+    median (bounded leakage; see AFML chapter 4).
     """
     base_weights = np.asarray(base_weights, dtype=float)
     if not label_weights_map:
@@ -1071,6 +1071,8 @@ def _aggregate_metrics(
             ]
         )
     elif aggregation == COMBINED_AGGREGATIONS[5]:  # "softmax"
+        # Per-column softmax-weighted convex combination of stacked rows.
+        # T -> 0 collapses to argmax row; T -> +inf collapses to coefficient-weighted mean.
         scaled_metrics = stacked_metrics / softmax_temperature
         softmax_weights = sp.special.softmax(scaled_metrics, axis=0)
         combined_weights = softmax_weights * coefficients[:, np.newaxis]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -254,13 +254,16 @@ _PREDICTION_SPECS: Final[dict[str, _ParamSpec]] = {
 
 
 EXTREMA_COLUMN: Final = "&s-extrema"
-LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
-LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
-_FREQAI_LABEL_SIGIL_PATTERN: Final = re.compile(r"^&-?")
 EXTREMA_DIRECTION_COLUMN: Final = "extrema_direction"
 EXTREMA_DIRECTION_SMOOTHED_COLUMN: Final = "extrema_direction_smoothed"
 EXTREMA_WEIGHT_COLUMN: Final = "extrema_weight"
 EXTREMA_WEIGHT_SMOOTHED_COLUMN: Final = "extrema_weight_smoothed"
+
+LABEL_WEIGHT_SUFFIX: Final[str] = "_weight"
+
+LABEL_COLUMNS: Final[tuple[str, ...]] = (EXTREMA_COLUMN,)
+
+_FREQAI_LABEL_SIGIL_PATTERN: Final = re.compile(r"^&-?")
 
 
 @lru_cache(maxsize=16)


### PR DESCRIPTION
## Problem

`QuickAdapterV3.set_freqai_targets` discarded the per-row weights returned by `apply_label_weighting` and folded them into the label value (`label = direction × weight`). This conflates `sample_weight` semantics (sample importance) with target-value scaling (regression objective), baking pivot magnitudes into labels in a way downstream normalisation cannot undo.

## Fix

Per-label weights flow as `<label>_weight` columns on `unfiltered_df`, are composed into a single per-row sample weight vector before splitting, and propagate through `model.fit(sample_weight=...)` for both data-split methods.

### `Utils.py`

- `label_weight_column_name(label_col)` — canonical `<label>_weight` column name, sigil-stripped via `^&-?` (preserves `s-` smoothed marker).
- `compose_sample_weights(base_weights, label_weights_map, *, logger, aggregation, softmax_temperature)` — pure NumPy. Per-label arrays sanitized (non-finite or `<= 0` → row dropped), individually mean-normalised, aggregated row-wise via `aggregation` (default `arithmetic_mean`; also `geometric_mean`, `harmonic_mean`, `quadratic_mean`, `weighted_median`, `softmax`), multiplied with `base_weights`, zeroed on dropped rows, renormalised to `mean=1`. Raises `ValueError` on shape mismatch or all-rows-dropped; warns and falls back to base weights on collapsed aggregation.
- `sanitize_and_renormalize(arr, drop_mask=None)` — single source of truth for the `mean=1` invariant.
- `get_label_weighting_config` validates per-label weighting (`strategy`, `metric_coefficients`, `aggregation`, `softmax_temperature`) used by `compute_label_weights` for cross-metric aggregation.
- `get_sample_weighting_config` validates the new `freqai.sample_weighting` block (`aggregation`, `softmax_temperature`) used by `compose_sample_weights` for cross-label aggregation. Returns `{default, columns}` like the other `get_label_*_config` helpers.

### `QuickAdapterV3.py`

- `dataframe[label_col] = label_data.series` — raw direction `{-1, 0, +1}`.
- `dataframe[label_weight_column_name(label_col)] = label_weights` — per-row weight, opt-in.
- The smoothed weight column is clipped to non-negative finite (`Series.where(gt(0) & notna(), 0.0)`) before assignment so filters that ring negative (savgol/filtfilt) cannot silently drop rows downstream.

### `QuickAdapterRegressorV3.py`

- `train()` dispatches on `data_split_parameters.method` via `match`/`case`:
  - `train_test_split` → `_make_train_test_split_datasets` (mirrors freqtrade's `make_train_test_datasets` accepting external weights; honours `shuffle_after_split` with deterministic seeding from `data_split_parameters.random_state`, and `reverse_train_test_order`).
  - `timeseries_split` → `_make_timeseries_split_datasets` (chronological final-fold split via `TimeSeriesSplit`; honours `reverse_train_test_order`; raises on `shuffle_after_split=True` since chronological + shuffle would leak future data).
- `_compose_per_row_weights` reads every present `<label>_weight` column on `unfiltered_df`, calls `compose_sample_weights` with the validated `sample_weighting` config, and returns a `mean=1` weight vector aligned to `features_filtered.index` before any shuffle/split. Logs which per-label weight columns are active or missing.
- `_train_common` filters features, composes weights, splits, fits `feature_pipeline`/`label_pipeline`, then `model.fit(..., sample_weight=train_weights)`. Train and test weights are renormalised to `mean=1` after `feature_pipeline.fit_transform` to absorb pipeline-level row drops.

### Configuration

Two distinct top-level blocks for two distinct aggregations:

- `freqai.label_weighting.{aggregation, softmax_temperature}` — cross-metric aggregation per pivot in `compute_label_weights` (active when `strategy: "combined"`).
- `freqai.sample_weighting.{aggregation, softmax_temperature}` — cross-label aggregation per row in `compose_sample_weights`.

The `<label>_weight` column convention is opt-in: when absent, `_compose_per_row_weights` returns the existing `weight_factor` temporal decay unchanged.
