### PR TITLE
fix(quickadapter): route reversed train weights through support_policy

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1886,10 +1886,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         if test_size == 0 and feat_dict.get("reverse_train_test_order", False):
             raise ValueError(
                 "data_split_parameters.test_size=0 is incompatible with "
-                "feature_parameters.reverse_train_test_order=True: the swap "
-                "would route an empty slice through "
-                "_compose_train_weights_with_support and trip support_policy "
-                "on zero rows"
+                "feature_parameters.reverse_train_test_order=True: the empty "
+                "test slice cannot be promoted to the training slot"
             )
 
         if test_size != 0:

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1883,6 +1883,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 f"Invalid data_split_parameters.test_size value {test_size!r}: "
                 f"must be int or float"
             )
+        if test_size == 0 and feat_dict.get("reverse_train_test_order", False):
+            raise ValueError(
+                "data_split_parameters.test_size=0 is incompatible with "
+                "feature_parameters.reverse_train_test_order=True: the swap "
+                "would route an empty slice through "
+                "_compose_train_weights_with_support and trip support_policy "
+                "on zero rows"
+            )
 
         if test_size != 0:
             if weights.label is None:
@@ -1983,6 +1991,19 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     )
                 )
 
+        if feat_dict.get("reverse_train_test_order", False):
+            (
+                train_features, test_features,
+                train_labels, test_labels,
+                train_base_weights, test_base_weights,
+                train_label_weights, test_label_weights,
+            ) = (
+                test_features, train_features,
+                test_labels, train_labels,
+                test_base_weights, train_base_weights,
+                test_label_weights, train_label_weights,
+            )
+
         train_weights = QuickAdapterRegressorV3._compose_train_weights_with_support(
             train_base_weights,
             train_label_weights,
@@ -1998,15 +2019,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         else:
             test_weights = test_base_weights
 
-        if feat_dict.get("reverse_train_test_order", False):
-            return dk.build_data_dictionary(
-                test_features,
-                train_features,
-                test_labels,
-                train_labels,
-                test_weights,
-                train_weights,
-            )
         return dk.build_data_dictionary(
             train_features,
             test_features,
@@ -2336,11 +2348,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             None if weights.label is None else weights.label[train_idx]
         )
         test_label_weights = None if weights.label is None else weights.label[test_idx]
-        test_weights = QuickAdapterRegressorV3._compose_eval_weights(
-            test_base_weights,
-            test_label_weights,
-            context=f"[{dk.pair}] timeseries_split:test",
-        )
 
         if causal_mode:
             row_positions = QuickAdapterRegressorV3._row_positions(
@@ -2373,22 +2380,31 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             else:
                 _log_known_at_none_once(dk.pair, "timeseries_split causal guard")
 
+        if feat_dict.get("reverse_train_test_order", False):
+            (
+                train_features, test_features,
+                train_labels, test_labels,
+                train_base_weights, test_base_weights,
+                train_label_weights, test_label_weights,
+            ) = (
+                test_features, train_features,
+                test_labels, train_labels,
+                test_base_weights, train_base_weights,
+                test_label_weights, train_label_weights,
+            )
+
         train_weights = QuickAdapterRegressorV3._compose_train_weights_with_support(
             train_base_weights,
             train_label_weights,
             weights.label_weighting_config,
             context=f"[{dk.pair}] timeseries_split:train",
         )
+        test_weights = QuickAdapterRegressorV3._compose_eval_weights(
+            test_base_weights,
+            test_label_weights,
+            context=f"[{dk.pair}] timeseries_split:test",
+        )
 
-        if feat_dict.get("reverse_train_test_order", False):
-            return dk.build_data_dictionary(
-                test_features,
-                train_features,
-                test_labels,
-                train_labels,
-                test_weights,
-                train_weights,
-            )
         return dk.build_data_dictionary(
             train_features,
             test_features,


### PR DESCRIPTION
## Summary

Routes the actual-train weights through `_compose_train_weights_with_support`
(policy-gated) and the actual-test weights through `_compose_eval_weights`
(policy-bypassing) when `data_split_parameters.reverse_train_test_order=True`.

The fix swaps the train/test slices BEFORE weight composition rather than
swapping the composed results at `build_data_dictionary`. Both call sites
(`_make_train_test_split_datasets`, `_make_timeseries_split_datasets`)
converge to a single `dk.build_data_dictionary` return.

Adds an upfront `ValueError` in `_make_train_test_split_datasets` for
`test_size=0 AND reverse_train_test_order=True` (mirrors the existing
`causal_mode=True AND reverse=True` rejection pattern). The `timeseries_split`
path already rejects `test_size < 1` upstream of the swap.

Reachable only under `causal_mode=False` (deprecated); `causal_mode=True`
rejects `reverse_train_test_order=True` upfront at both call sites.

## Behavior change

In the deprecated path (`causal_mode=False` + `reverse_train_test_order=True`):
- `support_policy='raise'` now correctly raises on actual-train insufficient
  support (previously: silent bypass).
- `support_policy='fallback'` now correctly logs a `WARNING` on actual-train
  insufficient support (previously: silent bypass).
- `support_policy` context strings in log/raise messages now reflect the
  true train/test role.
- `test_size=0 + reverse_train_test_order=True` now raises upfront
  (previously: silent garbage `dd["train_weights"]` = empty array).

## Design

Pre-implementation design was reviewed by three parallel Oracle passes
(math + algorithmics + scope/reachability; Python state-of-the-art +
harmonization + implementation elegance; documentation + terminology +
completeness). Each Oracle quoted upstream evidence from
`~/SAPDevelop/freqtrade-git/freqtrade/freqai/` (`data_kitchen.py:297-316`
for `build_data_dictionary` positional contract; `:191-209` for the
upstream `reverse_train_test_order` swap pattern; `BaseRegressionModel.py:53,59-79`
for downstream consumer symmetry). Consensus resolved 7 blockers
(PR provenance #85, `Closes #N.` convention, ≤72 char title, `test_size==0`
upfront reject, paired bug/fix reproducer scaffold, pre-written PR
description, jargon tightening in commit body).

The chosen approach (swap-before-compose) was validated against four
alternatives (swap-after-compose / `actual_*` rename / `SplitSlices`
dataclass / pairwise helper loop) and selected on grounds of (a) atomic
exception safety via single tuple-assignment, (b) zero new type machinery,
(c) preservation of the `train_<noun>` convention established by PR #95.

## Tests

Reproducer pair under `/tmp/quickadapter-tests/` (jetable, hors-repo per
project convention):
- `test_reverse_train_test_order_support_policy_bug.py` — locks pre-fix
  behavior (4 tests); documents pre-fix semantics via inline mocks of the buggy logic.
- `test_reverse_train_test_order_support_policy_fix.py` — locks post-fix
  behavior (9 tests); documents post-fix semantics via inline mocks of the fixed logic.

Both cover both `data_split_parameters.method` values (`train_test_split`, `timeseries_split`) and the 5 design scenarios:
1. `support_policy='raise'` + insufficient support → raises (negative lock).
2. `support_policy='fallback'` + insufficient support → warns (negative lock).
3. `support_policy='raise'` + sufficient support → no raise (positive lock).
4. `test_size=0 + reverse=True` → upfront `ValueError` (edge case lock).
5. `reverse=False` → no behavior change (regression check).

Plus a context-string sanity check confirming `:train` / `:test` reflect
the actual role after swap.

## Diff scope

1 file, +39/-23. Touches only `quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py`:
- `_make_train_test_split_datasets`: upfront reject + swap-before-compose +
  unified return (eliminates the dual `if reverse: return X; return Y` pattern).
- `_make_timeseries_split_datasets`: removes the early test_weights
  composition (was line 2339), inserts the swap after the causal-guard
  block, composes both weights at the end, unified return.

No README change: the `support_policy` row (`README.md:90`) already
documents the universal contract; this PR realigns the implementation
with the contract.

No docstring change: the `train()` method docstring (lines 1796-1807)
already describes the wrapper routing generically; the fix makes the
existing wording accurate for all paths.

Closes #92.
