### PR TITLE
refactor(quickadapter): consolidate Optuna sampler tuples to NamedTuple

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -187,30 +187,6 @@ class _OptunaLabelSamplers(NamedTuple):
     nsgaiii: Literal["nsgaiii"] = "nsgaiii"
 
 
-# Cross-link invariants pin the [0]=default and prefix/permutation
-# relationships between the three sampler registries at module load,
-# replacing the prior ``_OPTUNA_SAMPLERS[:2]`` slice derivation and the
-# 4-entry custom reorder of ``_OPTUNA_LABEL_SAMPLERS``.
-assert _OptunaHpoSamplers()[0] == "tpe", (
-    "_OPTUNA_HPO_SAMPLERS[0] is the documented HPO default "
-    "(README 'freqai.optuna_hyperopt.sampler' enum head)"
-)
-assert _OptunaLabelSamplers()[0] == "auto", (
-    "_OPTUNA_LABEL_SAMPLERS[0] is the documented label-namespace HPO "
-    "default (README 'freqai.optuna_hyperopt.label_sampler' enum head)"
-)
-assert tuple(_OptunaHpoSamplers()) == tuple(_OptunaSamplers())[:2], (
-    f"_OptunaHpoSamplers fields must remain the order-preserving prefix "
-    f"of _OptunaSamplers; got {tuple(_OptunaHpoSamplers())} vs "
-    f"{tuple(_OptunaSamplers())[:2]}"
-)
-assert frozenset(_OptunaLabelSamplers()) == frozenset(_OptunaSamplers()), (
-    f"_OptunaLabelSamplers fields must remain a permutation of "
-    f"_OptunaSamplers; got {frozenset(_OptunaLabelSamplers())} vs "
-    f"{frozenset(_OptunaSamplers())}"
-)
-
-
 class QuickAdapterRegressorV3(BaseRegressionModel):
     """
     The following freqaimodel is released to sponsors of the non-profit FreqAI open-source project.

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -14,6 +14,7 @@ from typing import (
     ClassVar,
     Final,
     Literal,
+    NamedTuple,
     Optional,
     Union,
     assert_never,
@@ -167,6 +168,49 @@ class SampleWeightInputs:
             )
 
 
+class _OptunaSamplers(NamedTuple):
+    tpe: Literal["tpe"] = "tpe"
+    auto: Literal["auto"] = "auto"
+    nsgaii: Literal["nsgaii"] = "nsgaii"
+    nsgaiii: Literal["nsgaiii"] = "nsgaiii"
+
+
+class _OptunaHpoSamplers(NamedTuple):
+    tpe: Literal["tpe"] = "tpe"
+    auto: Literal["auto"] = "auto"
+
+
+class _OptunaLabelSamplers(NamedTuple):
+    auto: Literal["auto"] = "auto"
+    tpe: Literal["tpe"] = "tpe"
+    nsgaii: Literal["nsgaii"] = "nsgaii"
+    nsgaiii: Literal["nsgaiii"] = "nsgaiii"
+
+
+# Cross-link invariants pin the [0]=default and prefix/permutation
+# relationships between the three sampler registries at module load,
+# replacing the prior ``_OPTUNA_SAMPLERS[:2]`` slice derivation and the
+# 4-entry custom reorder of ``_OPTUNA_LABEL_SAMPLERS``.
+assert _OptunaHpoSamplers()[0] == "tpe", (
+    "_OPTUNA_HPO_SAMPLERS[0] is the documented HPO default "
+    "(README 'freqai.optuna_hyperopt.sampler' enum head)"
+)
+assert _OptunaLabelSamplers()[0] == "auto", (
+    "_OPTUNA_LABEL_SAMPLERS[0] is the documented label-namespace HPO "
+    "default (README 'freqai.optuna_hyperopt.label_sampler' enum head)"
+)
+assert tuple(_OptunaHpoSamplers()) == tuple(_OptunaSamplers())[:2], (
+    f"_OptunaHpoSamplers fields must remain the order-preserving prefix "
+    f"of _OptunaSamplers; got {tuple(_OptunaHpoSamplers())} vs "
+    f"{tuple(_OptunaSamplers())[:2]}"
+)
+assert frozenset(_OptunaLabelSamplers()) == frozenset(_OptunaSamplers()), (
+    f"_OptunaLabelSamplers fields must remain a permutation of "
+    f"_OptunaSamplers; got {frozenset(_OptunaLabelSamplers())} vs "
+    f"{frozenset(_OptunaSamplers())}"
+)
+
+
 class QuickAdapterRegressorV3(BaseRegressionModel):
     """
     The following freqaimodel is released to sponsors of the non-profit FreqAI open-source project.
@@ -202,22 +246,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         optuna.study.StudyDirection.MAXIMIZE,
     ) * _OPTUNA_LABEL_N_OBJECTIVES
     _OPTUNA_STORAGE_BACKENDS: Final[tuple[str, ...]] = ("file", "sqlite")
-    _OPTUNA_SAMPLERS: Final[tuple[OptunaSampler, ...]] = (
-        "tpe",
-        "auto",
-        "nsgaii",
-        "nsgaiii",
-    )
-    _OPTUNA_HPO_SAMPLERS: Final[tuple[OptunaSampler, ...]] = _OPTUNA_SAMPLERS[:2]
+    _OPTUNA_SAMPLERS: Final[_OptunaSamplers] = _OptunaSamplers()
+    _OPTUNA_HPO_SAMPLERS: Final[_OptunaHpoSamplers] = _OptunaHpoSamplers()
     _OPTUNA_HPO_SAMPLERS_SET: Final[frozenset[OptunaSampler]] = frozenset(
         _OPTUNA_HPO_SAMPLERS
     )
-    _OPTUNA_LABEL_SAMPLERS: Final[tuple[OptunaSampler, ...]] = (
-        _OPTUNA_SAMPLERS[1],  # "auto"
-        _OPTUNA_SAMPLERS[0],  # "tpe"
-        _OPTUNA_SAMPLERS[2],  # "nsgaii"
-        _OPTUNA_SAMPLERS[3],  # "nsgaiii"
-    )
+    _OPTUNA_LABEL_SAMPLERS: Final[_OptunaLabelSamplers] = _OptunaLabelSamplers()
     _OPTUNA_LABEL_SAMPLERS_SET: Final[frozenset[OptunaSampler]] = frozenset(
         _OPTUNA_LABEL_SAMPLERS
     )
@@ -1239,16 +1273,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 .get("n_jobs", QuickAdapterRegressorV3.OPTUNA_N_JOBS_DEFAULT),
                 max(int(self.max_system_threads / 4), 1),
             ),
-            "sampler": QuickAdapterRegressorV3._OPTUNA_HPO_SAMPLERS[0],  # "tpe"
+            "sampler": QuickAdapterRegressorV3._OPTUNA_HPO_SAMPLERS.tpe,
             "storage": QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS[0],  # "file"
             "continuous": True,
             "warm_start": True,
             "n_startup_trials": QuickAdapterRegressorV3.OPTUNA_N_STARTUP_TRIALS_DEFAULT,
             "n_trials": QuickAdapterRegressorV3.OPTUNA_N_TRIALS_DEFAULT,
             "timeout": QuickAdapterRegressorV3.OPTUNA_TIMEOUT_DEFAULT,
-            "label_sampler": QuickAdapterRegressorV3._OPTUNA_LABEL_SAMPLERS[
-                0
-            ],  # "auto"
+            "label_sampler": QuickAdapterRegressorV3._OPTUNA_LABEL_SAMPLERS.auto,
             "label_candles_step": QuickAdapterRegressorV3.OPTUNA_LABEL_CANDLES_STEP_DEFAULT,
             "space_reduction": QuickAdapterRegressorV3.OPTUNA_SPACE_REDUCTION_DEFAULT,
             "space_fraction": QuickAdapterRegressorV3.OPTUNA_SPACE_FRACTION_DEFAULT,
@@ -4235,7 +4267,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             sampler = self._optuna_config.get(
                 "sampler",
             )
-        if sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS[0]:  # "tpe"
+        if sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.tpe:
             return optuna.samplers.TPESampler(
                 n_startup_trials=self._optuna_config.get(
                     "n_startup_trials",
@@ -4251,19 +4283,19 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                     "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
                 ),
             )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS[1]:  # "auto"
+        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.auto:
             return optunahub.load_module("samplers/auto_sampler").AutoSampler(
                 seed=self._optuna_config.get(
                     "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
                 )
             )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS[2]:  # "nsgaii"
+        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaii:
             return optuna.samplers.NSGAIISampler(
                 seed=self._optuna_config.get(
                     "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
                 ),
             )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS[3]:  # "nsgaiii"
+        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaiii:
             return optuna.samplers.NSGAIIISampler(
                 seed=self._optuna_config.get(
                     "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
@@ -4283,14 +4315,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return (
                 QuickAdapterRegressorV3._OPTUNA_HPO_SAMPLERS_SET,
                 self._optuna_config.get(
-                    "sampler", QuickAdapterRegressorV3._OPTUNA_HPO_SAMPLERS[0]
+                    "sampler", QuickAdapterRegressorV3._OPTUNA_HPO_SAMPLERS.tpe
                 ),
             )
         elif namespace == _OPTUNA_NAMESPACES.label:
             return (
                 QuickAdapterRegressorV3._OPTUNA_LABEL_SAMPLERS_SET,
                 self._optuna_config.get(
-                    "label_sampler", QuickAdapterRegressorV3._OPTUNA_LABEL_SAMPLERS[0]
+                    "label_sampler", QuickAdapterRegressorV3._OPTUNA_LABEL_SAMPLERS.auto
                 ),
             )
         else:


### PR DESCRIPTION
## Summary

Propagate the `_OptunaNamespaces` NamedTuple pattern from PR #81 (`Utils.py`) to the three sibling sampler tuples in `QuickAdapterRegressorV3.py`:

- `_OPTUNA_SAMPLERS` (tpe, auto, nsgaii, nsgaiii)
- `_OPTUNA_HPO_SAMPLERS` (tpe, auto)
- `_OPTUNA_LABEL_SAMPLERS` (auto, tpe, nsgaii, nsgaiii)

Replaces `[N]  # "name"` positional indexing with `.<name>` attribute access at 8 call sites; drops the 6 surviving inline annotations + the 4 analogous annotations inside the deleted 6-line `_OPTUNA_LABEL_SAMPLERS` custom-ordering block. Per-field types are singleton `Literal["..."]` (not the `OptunaSampler` union) to unlock pyright/mypy narrowing — preparing the ground for a future `assert_never` migration of the `optuna_create_sampler` dispatch chain.

## Design

Pre-implementation, the design went through two parallel review passes:

**Pass 1 — 3-oracle review on design v1** (math/algo/scope; Python state-of-the-art + harmonization; documentation + terminology + completeness). 9 convergent blockers were synthesized into design v2.

**Pass 2 — Metis + Momus + meta-Oracle review on design v2** (hidden intentions / AI failure modes; clarity / verifiability / completeness; closure audit + new blind spots). 11 additional clarifications were synthesized into design v3. Momus approved the on-disk plan as executable.

Each reviewer pass quoted upstream evidence from `~/SAPDevelop/freqtrade-git/` confirming no upstream consumer of the 3 sampler constants (refactor is API-boundary safe).

The chosen approach (NamedTuple at module level, instance constants at class level, with module-load cross-link assertions) was validated against four alternatives (`StrEnum`, `dataclass(frozen=True, slots=True)`, status quo + inline `# "name"` comments, `TypedDict`) and selected for (a) tuple-subclass invariance preserving `[0]` indexing + `len(...)` + `frozenset(...)` + `', '.join(...)`, (b) per-field singleton `Literal[...]` type narrowing, (c) verbatim match to the established `_OptunaNamespaces` template.

## Trade-off acknowledgment

Each `_Optuna*Samplers` redeclares its field defaults (per-class `Literal["tpe"] = "tpe"` etc.), replacing the prior tuple-slice derivation `_OPTUNA_HPO_SAMPLERS = _OPTUNA_SAMPLERS[:2]` and the 4-entry custom reordering. Minor string-literal duplication across 3 classes is accepted for harmonization with the `_OptunaNamespaces` template — the single source of truth for the 4 valid tokens remains the `OptunaSampler = Literal[...]` alias at module level, unchanged. Four module-load assertions pin the `[0]`-default invariants (HPO → `"tpe"`, label → `"auto"`) and the prefix/permutation invariants (`_OptunaHpoSamplers` is the order-preserving prefix of `_OptunaSamplers`; `_OptunaLabelSamplers` is a permutation of it), recovering the safety the slice derivation provided.

Assertions become no-ops under `python -O` — accepted scope limitation since project entrypoints do not pass `-O`.

## Deferred (out of scope)

Per-field singleton `Literal[...]` types unlock `assert_never` exhaustiveness on the `optuna_create_sampler` if/elif dispatch chain. The migration (`else: raise ValueError(...)` becoming `assert_never(sampler)`) changes the user-facing error contract on the unreachable branch and is **deferred to a follow-up PR**. This is a planner-side scope decision beyond what issue #88 lists explicitly under "Out of scope". `assert_never` is already imported in anticipation.

## Non-migration sites confirmed unchanged

- `frozenset(_OPTUNA_HPO_SAMPLERS)` / `frozenset(_OPTUNA_LABEL_SAMPLERS)` companion construction.
- `', '.join(QuickAdapterRegressorV3._OPTUNA_SAMPLERS)` error-message iteration — output `"tpe, auto, nsgaii, nsgaiii"` is byte-identical (NamedTuple iteration yields field values in declaration order).
- `_OPTUNA_HPO_SAMPLERS_SET` / `_OPTUNA_LABEL_SAMPLERS_SET` membership references at `optuna_samplers_by_namespace` (O(1) membership testing preserved).

## Tests

Reproducer under `/tmp/quickadapter-tests/test_optuna_samplers_consolidation.py` (jetable, hors-repo per project convention) — 8 invariant tests covering `[0]` indexing, attribute access, prefix relation, permutation relation, join output, and set memberships. All pass on this branch.

## Diff scope

1 file (`QuickAdapterRegressorV3.py`), +55 / −23.

Closes #88.