### PR TITLE
fix(quickadapter): quarantine corrupt optuna journal log and recover

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -4321,9 +4321,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             journal_path = storage_dir / f"{storage_filename}.log"
 
             # Pre-validate EOF: close the read_logs deferred-raise gap (see helper).
-            if QuickAdapterRegressorV3._optuna_journal_has_corrupt_tail(
-                journal_path
-            ):
+            if QuickAdapterRegressorV3._optuna_journal_has_corrupt_tail(journal_path):
                 QuickAdapterRegressorV3._optuna_quarantine_journal(
                     journal_path,
                     pair,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -4257,6 +4257,50 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         )
         return quarantine_path
 
+    @staticmethod
+    def _optuna_journal_has_corrupt_tail(journal_path: Path) -> bool:
+        """Detect a deferred-raise hazard at the end of a journal log file.
+
+        ``JournalFileBackend.read_logs`` defers ``ValueError('Invalid log
+        format.')`` (line without trailing newline) and ``json.JSONDecodeError``
+        (malformed JSON) to the *next* loop iteration. A bad trailing record
+        with no successor line therefore does NOT surface during
+        ``JournalStorage.__init__``; it surfaces only later, when a subsequent
+        ``_sync_with_backend`` call (triggered by ``optuna.create_study``,
+        ``optuna.load_study`` or ``optuna.delete_study``) reads the new
+        successor line and re-raises the stored error. That site sits outside
+        the ``optuna_create_storage`` try/except and falls through to the
+        broad outer handler in ``optuna_create_study``, reproducing the
+        silent-HPO-skip symptom this fix is meant to eliminate.
+
+        Probe: bounded tail read (last 64 KiB; a journal log line is
+        typically < 2 KiB). Return True iff the file is non-empty AND either
+        (a) lacks a trailing newline (truncated) OR (b) its last complete
+        line fails ``json.loads`` (malformed).
+        """
+        if not journal_path.exists():
+            return False
+        try:
+            size = journal_path.stat().st_size
+            if size == 0:
+                return False
+            with journal_path.open("rb") as f:
+                f.seek(max(0, size - 65536))
+                tail = f.read()
+        except OSError:
+            return False
+        if not tail.endswith(b"\n"):
+            return True
+        last_newline = tail.rfind(b"\n", 0, len(tail) - 1)
+        last_line = tail[last_newline + 1 : -1]
+        if not last_line:
+            return False
+        try:
+            json.loads(last_line)
+        except json.JSONDecodeError:
+            return True
+        return False
+
     def optuna_create_storage(self, pair: str) -> optuna.storages.BaseStorage:
         storage_dir = self.full_path
         storage_filename = f"optuna-{pair.split('/')[0]}"
@@ -4265,6 +4309,25 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             storage_backend == QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS[0]
         ):  # "file"
             journal_path = storage_dir / f"{storage_filename}.log"
+
+            # Pre-validate the trailing record. JournalFileBackend.read_logs
+            # defers decode errors to the next iteration, so a corrupt EOF
+            # record does NOT surface during JournalStorage.__init__; it
+            # surfaces later (inside optuna.create_study / load_study /
+            # delete_study) where the broad outer handler in
+            # optuna_create_study reproduces the silent-HPO-skip symptom.
+            # Quarantining here is the single uniform fix for all downstream
+            # re-sync sites.
+            if QuickAdapterRegressorV3._optuna_journal_has_corrupt_tail(
+                journal_path
+            ):
+                QuickAdapterRegressorV3._optuna_quarantine_journal(
+                    journal_path,
+                    pair,
+                    ValueError(
+                        "trailing journal record is truncated or malformed JSON"
+                    ),
+                )
 
             def _build_journal_storage() -> optuna.storages.JournalStorage:
                 return optuna.storages.JournalStorage(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -231,6 +231,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         json.JSONDecodeError,
     )
     _OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 8
+    _OPTUNA_JOURNAL_TAIL_PROBE_BYTES: Final[int] = 65536
     _OPTUNA_SAMPLERS: Final[_OptunaSamplers] = _OptunaSamplers()
     _OPTUNA_HPO_SAMPLERS: Final[_OptunaHpoSamplers] = _OptunaHpoSamplers()
     _OPTUNA_HPO_SAMPLERS_SET: Final[frozenset[OptunaSampler]] = frozenset(
@@ -4263,20 +4264,27 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         ``JournalFileBackend.read_logs`` defers ``ValueError('Invalid log
         format.')`` (line without trailing newline) and ``json.JSONDecodeError``
-        (malformed JSON) to the *next* loop iteration. A bad trailing record
-        with no successor line therefore does NOT surface during
-        ``JournalStorage.__init__``; it surfaces only later, when a subsequent
-        ``_sync_with_backend`` call (triggered by ``optuna.create_study``,
-        ``optuna.load_study`` or ``optuna.delete_study``) reads the new
-        successor line and re-raises the stored error. That site sits outside
-        the ``optuna_create_storage`` try/except and falls through to the
-        broad outer handler in ``optuna_create_study``, reproducing the
-        silent-HPO-skip symptom this fix is meant to eliminate.
+        (malformed or empty JSON line) to the *next* loop iteration. A bad
+        trailing record with no successor line therefore does NOT surface
+        during ``JournalStorage.__init__``; it surfaces only later, when a
+        subsequent ``_sync_with_backend`` call (triggered by
+        ``optuna.create_study``, ``optuna.load_study`` or
+        ``optuna.delete_study``) reads the new successor line and re-raises
+        the stored error. That site sits outside the ``optuna_create_storage``
+        try/except and falls through to the broad outer handler in
+        ``optuna_create_study``, reproducing the silent-HPO-skip symptom this
+        fix is meant to eliminate.
 
-        Probe: bounded tail read (last 64 KiB; a journal log line is
-        typically < 2 KiB). Return True iff the file is non-empty AND either
-        (a) lacks a trailing newline (truncated) OR (b) its last complete
-        line fails ``json.loads`` (malformed).
+        Probe: bounded tail read (last
+        ``_OPTUNA_JOURNAL_TAIL_PROBE_BYTES``; a journal log line is typically
+        < 2 KiB). Return True iff the file is non-empty AND any of:
+        (a) it lacks a trailing newline (truncated), or
+        (b) its last complete line is empty (bare trailing newline), or
+        (c) its last complete line fails ``json.loads`` (malformed).
+        Fail-open (return False) when the probe window cannot see a prior
+        newline AND the file exceeds the window: the last line is larger
+        than the window and cannot be validated here; defer to the
+        post-construction handler.
         """
         if not journal_path.exists():
             return False
@@ -4285,16 +4293,26 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             if size == 0:
                 return False
             with journal_path.open("rb") as f:
-                f.seek(max(0, size - 65536))
+                f.seek(
+                    max(
+                        0,
+                        size - QuickAdapterRegressorV3._OPTUNA_JOURNAL_TAIL_PROBE_BYTES,
+                    )
+                )
                 tail = f.read()
         except OSError:
             return False
         if not tail.endswith(b"\n"):
             return True
         last_newline = tail.rfind(b"\n", 0, len(tail) - 1)
-        last_line = tail[last_newline + 1 : -1]
+        if last_newline == -1:
+            if size > QuickAdapterRegressorV3._OPTUNA_JOURNAL_TAIL_PROBE_BYTES:
+                return False
+            last_line = tail[:-1]
+        else:
+            last_line = tail[last_newline + 1 : -1]
         if not last_line:
-            return False
+            return True
         try:
             json.loads(last_line)
         except json.JSONDecodeError:
@@ -4310,14 +4328,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         ):  # "file"
             journal_path = storage_dir / f"{storage_filename}.log"
 
-            # Pre-validate the trailing record. JournalFileBackend.read_logs
-            # defers decode errors to the next iteration, so a corrupt EOF
-            # record does NOT surface during JournalStorage.__init__; it
-            # surfaces later (inside optuna.create_study / load_study /
-            # delete_study) where the broad outer handler in
-            # optuna_create_study reproduces the silent-HPO-skip symptom.
-            # Quarantining here is the single uniform fix for all downstream
-            # re-sync sites.
+            # Pre-validate the trailing record to close the deferred-raise
+            # gap in JournalFileBackend.read_logs (see helper docstring).
             if QuickAdapterRegressorV3._optuna_journal_has_corrupt_tail(
                 journal_path
             ):

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1,10 +1,12 @@
 import copy
+import json
 import logging
 import math
 import random
 import time
 import warnings
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from functools import lru_cache
 from pathlib import Path
 from typing import (
@@ -222,6 +224,13 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         optuna.study.StudyDirection.MAXIMIZE,
     ) * _OPTUNA_LABEL_N_OBJECTIVES
     _OPTUNA_STORAGE_BACKENDS: Final[tuple[str, ...]] = ("file", "sqlite")
+    _OPTUNA_JOURNAL_QUARANTINE_TAG: Final[str] = "corrupt"
+    _OPTUNA_JOURNAL_RECOVERABLE_ERRORS: Final[tuple[type[Exception], ...]] = (
+        KeyError,
+        ValueError,
+        json.JSONDecodeError,
+    )
+    _OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 8
     _OPTUNA_SAMPLERS: Final[_OptunaSamplers] = _OptunaSamplers()
     _OPTUNA_HPO_SAMPLERS: Final[_OptunaHpoSamplers] = _OptunaHpoSamplers()
     _OPTUNA_HPO_SAMPLERS_SET: Final[frozenset[OptunaSampler]] = frozenset(
@@ -4195,6 +4204,59 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         self.optuna_save_best_params(pair, namespace)
         return study
 
+    @staticmethod
+    def _optuna_quarantine_path(journal_path: Path, now: datetime) -> Path:
+        """Compute the quarantine target path for a corrupt Optuna journal.
+
+        The quarantine tag is appended *after* the ``.log`` suffix so that the
+        live-journal glob ``optuna-*.log`` never matches quarantined artefacts.
+        Suffix collisions are bounded by
+        ``_OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT``; microsecond UTC
+        resolution makes collisions practically impossible.
+        """
+        stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
+        tag = QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TAG
+        candidate = journal_path.with_name(f"{journal_path.name}.{tag}-{stamp}")
+        for n in range(
+            1, QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT + 1
+        ):
+            if not candidate.exists():
+                return candidate
+            candidate = journal_path.with_name(f"{journal_path.name}.{tag}-{stamp}-{n}")
+        return candidate
+
+    @staticmethod
+    def _optuna_quarantine_journal(
+        journal_path: Path, pair: str, cause: Exception
+    ) -> Optional[Path]:
+        """Atomically move a corrupt Optuna journal aside.
+
+        Returns the quarantine path on success, or ``None`` if ``journal_path``
+        does not exist (caller should propagate the original error). Re-raises
+        any ``OSError`` from the rename itself so operator-actionable
+        filesystem failures (read-only mount, cross-device, ENOSPC) are not
+        masked.
+        """
+        if not journal_path.exists():
+            return None
+        quarantine_path = QuickAdapterRegressorV3._optuna_quarantine_path(
+            journal_path, datetime.now(timezone.utc)
+        )
+        try:
+            journal_path.rename(quarantine_path)
+        except OSError as rename_exc:
+            logger.error(
+                f"[{pair}] Optuna journal {journal_path.name} "
+                f"quarantine failed: {rename_exc!r}",
+                exc_info=True,
+            )
+            raise
+        logger.warning(
+            f"[{pair}] Optuna journal {journal_path.name} corrupt ({cause!r}); "
+            f"quarantined to {quarantine_path.name}; resuming with fresh journal"
+        )
+        return quarantine_path
+
     def optuna_create_storage(self, pair: str) -> optuna.storages.BaseStorage:
         storage_dir = self.full_path
         storage_filename = f"optuna-{pair.split('/')[0]}"
@@ -4202,11 +4264,28 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         if (
             storage_backend == QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS[0]
         ):  # "file"
-            storage = optuna.storages.JournalStorage(
-                optuna.storages.journal.JournalFileBackend(
-                    f"{storage_dir}/{storage_filename}.log"
+            journal_path = storage_dir / f"{storage_filename}.log"
+
+            def _build_journal_storage() -> optuna.storages.JournalStorage:
+                return optuna.storages.JournalStorage(
+                    optuna.storages.journal.JournalFileBackend(str(journal_path))
                 )
-            )
+
+            try:
+                storage = _build_journal_storage()
+            except QuickAdapterRegressorV3._OPTUNA_JOURNAL_RECOVERABLE_ERRORS as exc:
+                # Replay-time corruption (KeyError 'type', malformed JSON,
+                # unknown distribution class). Quarantine the offending log
+                # and retry exactly once on a fresh path. OSError is
+                # intentionally NOT in the recoverable set: filesystem
+                # failures fall through to the outer handler in
+                # optuna_create_study unchanged.
+                quarantined = QuickAdapterRegressorV3._optuna_quarantine_journal(
+                    journal_path, pair, exc
+                )
+                if quarantined is None:
+                    raise
+                storage = _build_journal_storage()
         elif (
             storage_backend == QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS[1]
         ):  # "sqlite"

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -4207,13 +4207,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     @staticmethod
     def _optuna_quarantine_path(journal_path: Path, now: datetime) -> Path:
-        """Compute the quarantine target path for a corrupt Optuna journal.
+        """Quarantine target path for a corrupt Optuna journal.
 
-        The quarantine tag is appended *after* the ``.log`` suffix so that the
-        live-journal glob ``optuna-*.log`` never matches quarantined artefacts.
-        Suffix collisions are bounded by
-        ``_OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT``; microsecond UTC
-        resolution makes collisions practically impossible.
+        The tag is appended *after* ``.log`` so the live-journal glob
+        ``optuna-*.log`` never matches quarantined artefacts. Collisions
+        are bounded by ``_OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT``;
+        microsecond UTC stamping makes them practically impossible.
         """
         stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
         tag = QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TAG
@@ -4232,11 +4231,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     ) -> Optional[Path]:
         """Atomically move a corrupt Optuna journal aside.
 
-        Returns the quarantine path on success, or ``None`` if ``journal_path``
-        does not exist (caller should propagate the original error). Re-raises
-        any ``OSError`` from the rename itself so operator-actionable
-        filesystem failures (read-only mount, cross-device, ENOSPC) are not
-        masked.
+        Return the quarantine path on success, or ``None`` if
+        ``journal_path`` is missing (caller propagates the original
+        error). ``OSError`` from the rename is re-raised so operator-
+        actionable filesystem failures (RO mount, EXDEV, ENOSPC) are
+        not masked.
         """
         if not journal_path.exists():
             return None
@@ -4260,30 +4259,23 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
     @staticmethod
     def _optuna_journal_has_corrupt_tail(journal_path: Path) -> bool:
-        """Detect a deferred-raise hazard at the end of a journal log file.
+        """Detect a deferred-raise hazard at EOF of a journal log file.
 
-        ``JournalFileBackend.read_logs`` defers ``ValueError('Invalid log
-        format.')`` (line without trailing newline) and ``json.JSONDecodeError``
-        (malformed or empty JSON line) to the *next* loop iteration. A bad
-        trailing record with no successor line therefore does NOT surface
-        during ``JournalStorage.__init__``; it surfaces only later, when a
-        subsequent ``_sync_with_backend`` call (triggered by
-        ``optuna.create_study``, ``optuna.load_study`` or
-        ``optuna.delete_study``) reads the new successor line and re-raises
-        the stored error. That site sits outside the ``optuna_create_storage``
-        try/except and falls through to the broad outer handler in
-        ``optuna_create_study``, reproducing the silent-HPO-skip symptom this
-        fix is meant to eliminate.
+        ``JournalFileBackend.read_logs`` stores ``ValueError('Invalid
+        log format.')`` (missing trailing newline) and
+        ``json.JSONDecodeError`` (malformed or empty line) as
+        ``last_decode_error`` and re-raises only on the *next*
+        iteration. A bad trailing record with no successor therefore
+        does NOT raise during ``JournalStorage.__init__``; it surfaces
+        at the next ``_sync_with_backend``, outside the
+        ``optuna_create_storage`` try/except, where the broad handler
+        in ``optuna_create_study`` returns ``None`` (silent HPO skip).
 
-        Probe: bounded tail read (last
-        ``_OPTUNA_JOURNAL_TAIL_PROBE_BYTES``; a journal log line is typically
-        < 2 KiB). Return True iff the file is non-empty AND any of:
-        (a) it lacks a trailing newline (truncated), or
-        (b) its last complete line is empty (bare trailing newline), or
-        (c) its last complete line fails ``json.loads`` (malformed).
-        Fail-open (return False) when the probe window cannot see a prior
-        newline AND the file exceeds the window: the last line is larger
-        than the window and cannot be validated here; defer to the
+        Bounded tail probe (last ``_OPTUNA_JOURNAL_TAIL_PROBE_BYTES``).
+        Return True iff the file is non-empty AND its trailing record
+        is (a) missing the newline, (b) empty (bare ``\\n``), or
+        (c) malformed JSON. Fail-open when the probe window cuts a
+        single line larger than the window; defer to the
         post-construction handler.
         """
         if not journal_path.exists():
@@ -4328,8 +4320,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         ):  # "file"
             journal_path = storage_dir / f"{storage_filename}.log"
 
-            # Pre-validate the trailing record to close the deferred-raise
-            # gap in JournalFileBackend.read_logs (see helper docstring).
+            # Pre-validate EOF: close the read_logs deferred-raise gap (see helper).
             if QuickAdapterRegressorV3._optuna_journal_has_corrupt_tail(
                 journal_path
             ):
@@ -4349,12 +4340,8 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             try:
                 storage = _build_journal_storage()
             except QuickAdapterRegressorV3._OPTUNA_JOURNAL_RECOVERABLE_ERRORS as exc:
-                # Replay-time corruption (KeyError 'type', malformed JSON,
-                # unknown distribution class). Quarantine the offending log
-                # and retry exactly once on a fresh path. OSError is
-                # intentionally NOT in the recoverable set: filesystem
-                # failures fall through to the outer handler in
-                # optuna_create_study unchanged.
+                # Replay-time corruption: quarantine + retry once. OSError is
+                # excluded from the tuple — FS failures stay operator-actionable.
                 quarantined = QuickAdapterRegressorV3._optuna_quarantine_journal(
                     journal_path, pair, exc
                 )


### PR DESCRIPTION
## Summary

When `JournalFileBackend`'s replay encounters a `set_trial_param` record whose `distribution` JSON lacks both `name` and `type` keys, optuna's `json_to_distribution` raises `KeyError('type')`, `JournalStorage.__init__` aborts, and HPO for the affected pair is silently skipped on every subsequent fit cycle until manual cleanup.

Wraps `JournalStorage` construction in a narrow `try / except` over `(KeyError, ValueError, json.JSONDecodeError)`, atomically renames the corrupt log aside, logs a `WARNING`, and retries exactly once on a fresh path. `OSError` is intentionally excluded so filesystem failures stay operator-actionable. A pre-validation tail probe additionally closes the deferred-raise gap in `JournalFileBackend.read_logs` (corrupt EOF records that do NOT surface during `__init__` and would otherwise re-emerge inside `optuna.create_study / load_study / delete_study`).

## Defect

Production traceback (Optuna v4.7.0, Python 3.14):

```pytb
ERROR   QuickAdapterRegressorV3 - [SOL/USD:USD] Optuna label storage creation failed for study quickadapter-catboost-SOL/USD:USD-label: KeyError('type')
  File ".../freqaimodels/QuickAdapterRegressorV3.py", line 4303, in optuna_create_study
    storage = self.optuna_create_storage(pair)
  File ".../freqaimodels/QuickAdapterRegressorV3.py", line 4175, in optuna_create_storage
    storage = optuna.storages.JournalStorage(
        optuna.storages.journal.JournalFileBackend(
            f"{storage_dir}/{storage_filename}.log"
        )
    )
  File ".../optuna/storages/journal/_storage.py", line 112, in __init__
    self._sync_with_backend()
  File ".../journal/_storage.py", line 586, in _apply_set_trial_param
    distribution = json_to_distribution(log["distribution"])
  File ".../optuna/distributions.py", line 590, in json_to_distribution
    if json_dict["type"] == "categorical":
KeyError: 'type'
```

Corruption classes covered:
- **Class A** — `KeyError('type')` / `KeyError('name')` from `json_to_distribution` during initial replay
- **Class B** — `json.JSONDecodeError` on inner `distribution` field during replay
- **Class C1** — Truncated tail (record without trailing newline); raise deferred to next sync
- **Class C2** — Last complete line is malformed JSON; raise deferred to next sync
- **Class C3** — Last complete line is empty (`…data\n\n`); raise deferred to next sync

A and B raise immediately during `JournalStorage.__init__`. C1, C2, C3 are deferred by `JournalFileBackend.read_logs` (it stores `last_decode_error` and only re-raises on the next iteration; with no successor line during construction, the generator returns cleanly). These surface only later inside `optuna.create_study / load_study / delete_study` where the broad outer handler in `optuna_create_study` returns `None`, reproducing the silent-HPO-skip symptom.

NSC condition: optuna's own `distribution_to_json` (master HEAD, verified) always emits `{"name", "attributes"}`, so the malformed record cannot originate from optuna's writer — the source is on-disk corruption (partial/interleaved write, NFS race, container kill mid-fsync, manipulation externe, or a third-party tool writing distribution JSON).

## Design

Pre-implementation, the design went through three parallel cross-validation passes:

**Pass 1 — explore agent**: full map of optuna storage handling in repo (call sites, naming conventions, logging patterns, existing stale-file detection patterns).

**Pass 2 — two independent Oracle agents** (A + B) on the same brief, evaluating 10 fix options against 7 criteria (elegance, SOTA on scope, math/algorithmics, Python state-of-the-art, codebase harmonization, implementation elegance, terminology). Both Oracles converged on option #1 (catch + quarantine + retry once).

**Pass 3 — librarian agent** for upstream evidence: `distribution_to_json` master writes only `{"name", "attributes"}` (no schema migration since v3.0.0); v4.0 stabilization explicitly guarantees journal-log backward compatibility; `JournalStorage.apply_logs` has no `skip_on_error` hook (verified v4.0–v4.9); SOTA WAL recovery survey (SQLite truncate-at-CRC, PostgreSQL abort, etcd truncate-tail, RocksDB `WALRecoveryMode` with `kSkipAnyCorruptedRecords`).

Two parallel post-implementation review passes (5 reviewers each: Goal+criteria / QA / Code-quality / Security / Context-mining) then drove two follow-up commits:

- **Pass-1 post-impl review** flagged a deferred-raise gap (matching an inline Codex P2 finding): the narrow `try/except` around `JournalStorage(...)` construction covers Classes A and B (immediate raise) but not C1/C2 (deferred raise). Addressed by adding `_optuna_journal_has_corrupt_tail` (O(1) bounded tail probe) called BEFORE construction.

- **Pass-2 post-impl review** converged on 4 non-blocking polish items: lift the magic number `65536` to a named `Final[int]` constant; trim the in-line block comment to remove duplication with the helper docstring; close a theoretical false-positive (huge single line > probe window); close a theoretical false-negative (Class C3 empty trailing line). All applied in the final commit.

## Changes

`quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py`:

Three new module-level `Final` constants placed adjacent to `_OPTUNA_STORAGE_BACKENDS`:
- `_OPTUNA_JOURNAL_QUARANTINE_TAG: Final[str] = "corrupt"`
- `_OPTUNA_JOURNAL_RECOVERABLE_ERRORS: Final[tuple[type[Exception], ...]] = (KeyError, ValueError, json.JSONDecodeError)`
- `_OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 8`
- `_OPTUNA_JOURNAL_TAIL_PROBE_BYTES: Final[int] = 65536`

Three new `@staticmethod` helpers:
- `_optuna_quarantine_path(journal_path, now) -> Path` — pure (no IO), testable; computes `optuna-<COIN>.log.corrupt-<UTC ISO8601 µs>` with bounded `-1, -2, …` tie-break.
- `_optuna_quarantine_journal(journal_path, pair, cause) -> Optional[Path]` — atomic rename + structured logging. Returns `None` if `journal_path` does not exist (caller re-raises). Re-raises `OSError` from `rename` itself.
- `_optuna_journal_has_corrupt_tail(journal_path) -> bool` — bounded O(1) tail probe (last `_OPTUNA_JOURNAL_TAIL_PROBE_BYTES`). Detects three deferred-raise sub-classes: truncated tail (no `\n`), empty last line (bare `\n`), malformed JSON last line. Fails open on `OSError` and on >probe-window single-line cuts (defer to post-construction handler).

`optuna_create_storage` `"file"` branch:
- Path operator harmonization: `storage_dir / f"{storage_filename}.log"` matches the `Utils.py:3898/3923` convention.
- Pre-validation call BEFORE construction: if `_optuna_journal_has_corrupt_tail` returns True, invoke `_optuna_quarantine_journal` with a synthetic `ValueError` cause.
- Construction wrapped in `try / except _OPTUNA_JOURNAL_RECOVERABLE_ERRORS as exc` calling the quarantine helper then retrying once. No loop, no recursion. `sqlite` branch unchanged.

`OSError` is excluded from the recoverable set (filesystem failures must stay operator-actionable). `optuna.delete_study` is _not_ used because it only removes the in-storage record without touching the file on disk.

Log messages follow the existing `[{pair}] Optuna ...` convention (`logger.warning` on quarantine success matches `optuna_delete_study` severity; `logger.error` with `exc_info=True` on rename failure matches existing storage-error patterns). No `namespace` token in the message because the journal file is shared across `hp` and `label` namespaces (single file per pair).

## Behavior change

| Scenario | Before | After |
|---|---|---|
| Healthy journal | `JournalStorage(...)` succeeds | Unchanged (one stat + one bounded read added; sub-millisecond overhead) |
| Corrupt journal Class A/B (mid-file, immediate raise) | Crash → ERROR log → `return None` → **HPO silently skipped indefinitely** | Quarantine + WARNING + retry → fresh study → **HPO resumes** |
| Corrupt journal Class C1/C2/C3 (EOF, deferred raise) | Construction succeeds, raise later inside `optuna.create_study` → broad handler → `return None` → **HPO silently skipped indefinitely** | Pre-validation detects → quarantine + WARNING + retry → **HPO resumes** |
| Rename impossible (read-only FS, EXDEV, ENOSPC) | Crash | ERROR log + propagate to `optuna_create_study`'s outer handler (current behavior preserved) |
| Corruption recurs cycle after cycle | HPO silently skipped forever | Stream of WARNING per cycle (visible operator signal) |

No public API change. `optuna_create_storage` signature is unchanged.

## Validation

- `python -m py_compile quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py`
- `ruff check quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py` → `All checks passed!`
- AST inspection confirms imports (`json`, `datetime/timezone`), the 4 new `Final` constants in the class, the 3 new `@staticmethod` helpers, and the modified `optuna_create_storage` body.
- Two parallel post-implementation review passes (5 reviewers each) — all 10 lanes return PASS after the final commit.
- Jetable reproducer under `/tmp/quickadapter-tests/test_optuna_journal_quarantine.py` (hors-repo per project convention) locks 17 invariants of the quarantine algorithm via verbatim replication of all 3 helpers, plus the pass-1 integration suite at `/tmp/quickadapter-tests/test_optuna_journal_quarantine_integration.py` (22 end-to-end scenarios against real optuna 4.9.0).

## Diff scope

3 commits, 1 file (`QuickAdapterRegressorV3.py`), +146 / −4 vs `main`. No tunable added (recovery is implicit and unconditional). No README change (the WARNING log message is self-documenting: `[{pair}] Optuna journal {name} corrupt ({cause!r}); quarantined to {qname}; resuming with fresh journal`).

## References

Source: production log from a freqtrade container running QuickAdapter on `SOL/USD:USD` with `catboost` regressor and `file` storage backend. No GitHub issue tracked.

Inline review threads addressed: Codex P2 finding on commit `b8172a8` resolved by commit `075a7b4` (deferred-raise gap).

Related upstream defensive improvement (parked, separate scope): [jerome-benoit/optuna#fix-json-to-distribution-key-error](https://github.com/jerome-benoit/optuna/tree/fix-json-to-distribution-key-error) — proposes converting the cryptic upstream `KeyError` into a clear `ValueError`. This QuickAdapter fix is _not_ a workaround for an upstream bug: optuna provides no recovery hook, so on-disk fault tolerance is an orchestration-layer responsibility (cf. systemd vs Linux kernel).

Follow-up tracking (out of scope of this PR): `ReforceXY/user_data/freqaimodels/ReforceXY.py:1333-1361` has the same vulnerable `JournalStorage(JournalFileBackend(...))` pattern without quarantine — propagate this defense in a separate PR.