### PR TITLE
refactor(quickadapter): dispatch optuna_create_sampler via match + assert_never

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -4243,45 +4243,48 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             sampler = self._optuna_config.get(
                 "sampler",
             )
-        if sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.tpe:
-            return optuna.samplers.TPESampler(
-                n_startup_trials=self._optuna_config.get(
-                    "n_startup_trials",
-                    QuickAdapterRegressorV3.OPTUNA_N_STARTUP_TRIALS_DEFAULT,
-                ),
-                multivariate=True,
-                group=True,
-                constant_liar=self._optuna_config.get(
-                    "n_jobs", QuickAdapterRegressorV3.OPTUNA_N_JOBS_DEFAULT
+        match sampler:
+            case None:
+                raise ValueError(
+                    f"Invalid optuna sampler value {sampler!r}: "
+                    f"supported values are {', '.join(QuickAdapterRegressorV3._OPTUNA_SAMPLERS)}"
                 )
-                > 1,
-                seed=self._optuna_config.get(
-                    "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
-                ),
-            )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.auto:
-            return optunahub.load_module("samplers/auto_sampler").AutoSampler(
-                seed=self._optuna_config.get(
-                    "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
+            case QuickAdapterRegressorV3._OPTUNA_SAMPLERS.tpe:
+                return optuna.samplers.TPESampler(
+                    n_startup_trials=self._optuna_config.get(
+                        "n_startup_trials",
+                        QuickAdapterRegressorV3.OPTUNA_N_STARTUP_TRIALS_DEFAULT,
+                    ),
+                    multivariate=True,
+                    group=True,
+                    constant_liar=self._optuna_config.get(
+                        "n_jobs", QuickAdapterRegressorV3.OPTUNA_N_JOBS_DEFAULT
+                    )
+                    > 1,
+                    seed=self._optuna_config.get(
+                        "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
+                    ),
                 )
-            )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaii:
-            return optuna.samplers.NSGAIISampler(
-                seed=self._optuna_config.get(
-                    "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
-                ),
-            )
-        elif sampler == QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaiii:
-            return optuna.samplers.NSGAIIISampler(
-                seed=self._optuna_config.get(
-                    "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
-                ),
-            )
-        else:
-            raise ValueError(
-                f"Invalid optuna sampler value {sampler!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._OPTUNA_SAMPLERS)}"
-            )
+            case QuickAdapterRegressorV3._OPTUNA_SAMPLERS.auto:
+                return optunahub.load_module("samplers/auto_sampler").AutoSampler(
+                    seed=self._optuna_config.get(
+                        "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
+                    )
+                )
+            case QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaii:
+                return optuna.samplers.NSGAIISampler(
+                    seed=self._optuna_config.get(
+                        "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
+                    ),
+                )
+            case QuickAdapterRegressorV3._OPTUNA_SAMPLERS.nsgaiii:
+                return optuna.samplers.NSGAIIISampler(
+                    seed=self._optuna_config.get(
+                        "seed", QuickAdapterRegressorV3.OPTUNA_SEED_DEFAULT
+                    ),
+                )
+            case _:
+                assert_never(sampler)
 
     @lru_cache(maxsize=8)
     def optuna_samplers_by_namespace(


### PR DESCRIPTION
## Summary

Follow-up to #101. Converts the `optuna_create_sampler` if/elif/else dispatch chain to a `match`/`case` statement using value patterns (`QuickAdapterRegressorV3._OPTUNA_SAMPLERS.<name>`) — the per-field singleton `Literal[...]` typing introduced by #101 unlocks pyright/mypy exhaustiveness narrowing, so the final `case _: assert_never(sampler)` type-checks as `Never` and catches any future extension of `OptunaSampler` that forgets to add a corresponding match branch.

## Why this was deferred from #101

The migration changes the user-facing error contract on the unreachable branch (`ValueError` → `AssertionError` with a different message format). Issue #88 did not list `assert_never` migration explicitly, so #101 deferred it as a planner-side scope decision. The per-field singleton `Literal["..."]` typing introduced in #101 is the load-bearing prerequisite that makes this migration possible.

## Behavior delta

| Input | Pre-fix exception | Post-fix exception |
|---|---|---|
| `None` (no sampler in kwargs nor in `_optuna_config`) | `ValueError("Invalid optuna sampler value None: supported values are tpe, auto, nsgaii, nsgaiii")` | **unchanged** — `case None:` preserves the original `ValueError` verbatim |
| `"tpe"` / `"auto"` / `"nsgaii"` / `"nsgaiii"` | dispatch to corresponding sampler factory | **unchanged** — dispatch via value patterns is observationally identical |
| Non-`Literal` string (e.g. `"garbage"` via dynamic injection) | `ValueError("Invalid optuna sampler value 'garbage': supported values are ...")` | `AssertionError("Expected code to be unreachable, but got: 'garbage'")` from `typing.assert_never` |

The third row is the only behavior change. Under correctly-typed call paths this branch is **unreachable by construction** (`OptunaSampler = Literal["tpe","auto","nsgaii","nsgaiii"]`); only ad-hoc runtime injection of invalid strings observes the new exception type.

In practice, the AssertionError path is **unreachable from every current in-repo call site**: the sole caller `optuna_create_study` (around line 4392) already validates `sampler not in samplers` and raises `ValueError` with the supported-values list (around lines 4383-4387) **before** dispatching to `optuna_create_sampler`. A misconfigured `_optuna_config["sampler"] = "tpr"` therefore surfaces the old `ValueError` shape from the upstream gate; the new `AssertionError` would only manifest via a hypothetical future caller that bypasses `optuna_create_study`, which does not exist today.

## Static benefit (load-bearing rationale)

After the 5 `case` patterns cover the full `OptunaSampler | None` domain, pyright/mypy narrow `sampler` to `Never` at the `case _:` branch. `typing.assert_never(sampler)` is then statically verified to be unreachable. **If a future contributor adds a 5th sampler to `OptunaSampler` without adding a corresponding `case` branch, the type-checker flags the `assert_never` call as a type error** — exhaustiveness becomes a compile-time gate.

This is the entire payoff of the NamedTuple consolidation from #101.

## Tests

Runtime sanity validated via inline harness:
- 5-branch dispatch reachable: `None`, `"tpe"`, `"auto"`, `"nsgaii"`, `"nsgaiii"` each route to the correct branch.
- `assert_never(v)` raises `AssertionError("Expected code to be unreachable, but got: 'garbage'")` on invalid value (confirmed under Python 3.13).

## Diff scope

1 file (`QuickAdapterRegressorV3.py`), +40 / -37 (net +3). Pure dispatch shape change in one method (`optuna_create_sampler`).

## Convention

Value patterns use the canonical project attribute-access syntax (`QuickAdapterRegressorV3._OPTUNA_SAMPLERS.tpe` etc.) — no string literals — matching the convention established at the 8 call sites migrated in #101.

Closes the deferred follow-up from PR #101 (issue #88).
