### PR TITLE
fix(quickadapter): harden take-profit execution accounting

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,33 +154,50 @@ from terminal Freqtrade orders that can be linked to a specific take-profit
 attempt. The persisted plan includes every partial fraction and NATR trigger, so
 an open trade cannot silently switch execution plans after a deployment. Targets
 remain immutable: terminal partial fills credit only their observed net base
-amount, while a base amount that deterministically rounds to zero is carried FIFO
-to a later threshold. Exchange minimum hints never mutate the ledger; Freqtrade's
-final exit validation remains authoritative.
+amount. Quantity rounding and exchange minimum checks happen before submission;
+non-executable partial stages are carried FIFO to a later threshold and ultimately
+to the final exit. Live and dry-run checks conservatively account for the exit
+price, leverage, amount reserve, and stoploss reserve used by Freqtrade.
 Legacy emergency orders and recovered untagged orders are accepted only when
 their relationship to an attempt is unique.
+Schema v4 states migrate automatically to v5. Because the former callbacks could
+fail open, every surviving v4 `proposed` attempt becomes `ambiguous` and requires
+an exact tagged order or the operator recovery procedure below.
 
 `unfilledtimeout.exit_timeout_count` must be `0`; QuickAdapter is the sole owner of
-partial-exit retries, and `order_types.exit` must be `limit` because Freqtrade has
-no equivalent pre-submission callback for partial market exits. A strict zero-fill
-outcome is retried automatically only when its persisted status is `rejected` or
-`expired`, its remaining amount equals the order amount, it has no base fee, and
-it has no fill timestamp. `canceled` and `cancelled` always require operator
-verification:
+partial-exit retries. Partial attempts are persisted as `submitting` before the
+position-adjustment callback can reach the exchange. Final attempts remain local
+proposals until `confirm_trade_exit`; their confirmation returns `false` on every
+state persistence failure. Take-profit limit and market exits therefore use the
+same durable submission protocol. A strict zero-fill outcome is retried
+automatically only when its persisted status is `rejected` or `expired`, its
+remaining amount equals
+the order amount, it has no base fee, and it has no fill timestamp. `canceled` and
+`cancelled` always require operator verification:
 Freqtrade can synthesize a canceled response when cancellation and order retrieval
 both fail. A lost CEX response, foreign filled exit, or filled stoploss also fails
-closed instead of risking a duplicate reduction. Open stoploss orders without
-partial-fill evidence remain protective and do not affect the take-profit ledger. If
-`stoploss_on_exchange` is enabled, an uncertain canceled stoploss requires the same
-operator verification before take-profit resumes.
+closed instead of risking a duplicate reduction.
+
+`order_types.stoploss_on_exchange` must be `false`. Freqtrade 2026.6 and 2026.7-dev do
+not persist enough cancellation provenance for the strategy to distinguish a
+confirmed stoploss cancellation from a synthetic canceled response. Before
+deploying this version to an existing bot, stop the bot, cancel or reconcile every
+remaining CEX stoploss order, verify the position on the exchange, set the option
+to `false`, and only then restart.
 
 The ledger derives initial exposure from terminal entry fills, applies Freqtrade's
-amount precision, and requires current trade exposure to equal entries minus
-credited take-profit fills. The logical take-profit stage also drives stoploss
-tightening, so multiple fills or retries within one stage cannot tighten it more
-than once. Discretionary exits are denied while reconciliation is pending or a
-non-stoploss order remains open; stoploss, trailing stoploss, emergency exit, and
-force exit remain available.
+amount precision, and separates two concerns. Every validated terminal strategy
+exit reduces exposure, but only causally attributed take-profit fills advance the
+take-profit stages. A discretionary exit that is partially filled therefore leaves
+the stage unchanged and can be reevaluated normally instead of permanently
+blocking the trade. Freqtrade's full-exit wallet fallback is recorded as a bounded,
+audited exposure adjustment; a later canonical fill retires that adjustment when
+Freqtrade recalculates the amount from orders. The logical take-profit stage also
+drives stoploss tightening, so multiple fills or retries within one stage cannot
+tighten it more than once. Discretionary exits are denied while reconciliation is
+pending or an order remains open; stoploss, trailing stoploss, emergency exit, and
+force exit remain available. Their full-exit wallet fallback is audited when
+possible, but an audit failure never denies these safety exits.
 
 An ambiguous submission can be cleared only after checking the CEX order history
 for the complete attempt window. Stop the bot, inspect the state, then use the
@@ -201,11 +218,14 @@ docker compose -f quickadapter/docker-compose.yml start freqtrade
 ```
 
 The clear command is unavailable until the persisted recovery deadline. `inspect`
-reports current and expected exposure, their delta, immutable stage targets,
-credits, deferred stages, attributed orders, and operator proofs. For an
-`unknown_terminal_fill` block with a verified positive fill, first correct both
-the canonical Freqtrade order and trade accounting from exchange data. Then
-revalidate that exact order:
+does not modify take-profit data. It initializes Freqtrade persistence like other
+database clients and may create or migrate supported database schema objects.
+It reports current and expected exposure, their delta, take-profit and
+non-take-profit credits, active or retired wallet adjustments, immutable stage
+targets, deferred stages, attributed orders, and operator proofs. For an
+`unknown_terminal_fill` or `unattributed_exit_fill` block with a verified positive
+fill, first correct the canonical Freqtrade order, its exit tag, and trade
+accounting from exchange data. Then revalidate that exact order:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \

--- a/README.md
+++ b/README.md
@@ -158,11 +158,10 @@ amount. Quantity rounding and exchange minimum checks happen before submission;
 non-executable partial stages are carried FIFO to a later threshold and ultimately
 to the final exit. Live and dry-run checks conservatively account for the exit
 price, leverage, amount reserve, and stoploss reserve used by Freqtrade.
-Legacy emergency orders and recovered untagged orders are accepted only when
-their relationship to an attempt is unique.
-Schema v4 states migrate automatically to v5. Because the former callbacks could
-fail open, every surviving v4 `proposed` attempt becomes `ambiguous` and requires
-an exact tagged order or the operator recovery procedure below.
+Public order tags are stable per direction and stage; attempt UUIDs remain internal.
+After an uncertain submission, reconciliation accepts either the exact tagged order
+or one unique untagged order matching the attempt side, amount, and submission time
+window. Any other candidate set remains blocked for operator review.
 
 `unfilledtimeout.exit_timeout_count` must be `0`; QuickAdapter is the sole owner of
 partial-exit retries. Partial attempts are persisted as `submitting` before the
@@ -175,29 +174,40 @@ remaining amount equals
 the order amount, it has no base fee, and it has no fill timestamp. `canceled` and
 `cancelled` always require operator verification:
 Freqtrade can synthesize a canceled response when cancellation and order retrieval
-both fail. A lost CEX response, foreign filled exit, or filled stoploss also fails
-closed instead of risking a duplicate reduction.
+both fail. A canceled positive fill requires a separate immutable snapshot of its
+creation time, tag, side, status, amount, fill, remainder, base fee, and fill
+timestamp. A lost CEX response or any terminal external order with uncertain or
+positive execution remains fail-closed and requires manual position reconciliation.
 
 `order_types.stoploss_on_exchange` must be `false`. Freqtrade 2026.6 and 2026.7-dev do
 not persist enough cancellation provenance for the strategy to distinguish a
 confirmed stoploss cancellation from a synthetic canceled response. Before
-deploying this version to an existing bot, stop the bot, cancel or reconcile every
-remaining CEX stoploss order, verify the position on the exchange, set the option
-to `false`, and only then restart.
+deploying this version, stop the bot and ensure that no open trade retains an
+exchange-stoploss order record. Reconcile or close those trades, verify each CEX
+position, set the option to `false`, and only then restart.
 
 The ledger derives initial exposure from terminal entry fills, applies Freqtrade's
 amount precision, and separates two concerns. Every validated terminal strategy
-exit reduces exposure, but only causally attributed take-profit fills advance the
-take-profit stages. A discretionary exit that is partially filled therefore leaves
-the stage unchanged and can be reevaluated normally instead of permanently
-blocking the trade. Freqtrade's full-exit wallet fallback is recorded as a bounded,
-audited exposure adjustment; a later canonical fill retires that adjustment when
-Freqtrade recalculates the amount from orders. The logical take-profit stage also
-drives stoploss tightening, so multiple fills or retries within one stage cannot
-tighten it more than once. Discretionary exits are denied while reconciliation is
-pending or an order remains open; stoploss, trailing stoploss, emergency exit, and
-force exit remain available. Their full-exit wallet fallback is audited when
-possible, but an audit failure never denies these safety exits.
+exit reduces exposure, but only an order whose immutable attribution still matches
+its canonical ID, tag, side, amount, stage, and provenance advances the take-profit
+stages. A discretionary exit that is partially filled therefore leaves the stage
+unchanged and can be reevaluated normally instead of permanently blocking the
+trade. Freqtrade's full-exit wallet fallback is recorded as a bounded, audited
+exposure adjustment; a later canonical fill retires that adjustment when Freqtrade
+recalculates the amount from orders. Retired adjustment details are compacted only
+when the bounded ledger needs room; active adjustments are never discarded, and
+the compacted count and amount remain visible. For live and dry-run partial exits,
+QuickAdapter refreshes the spot-like wallet and applies Freqtrade's 2% fallback
+bound before persisting the attempt. If Freqtrade still mutates the trade amount,
+the state records that partial-wallet mutation and its exact canonical order, when
+one exists. The active attempt pauses automatic execution until canonical trade
+accounting is restored. Futures are unchanged. Deferred stages affect scheduling
+only: stoploss tightening follows the separately computed credited stage, so an
+unexecuted or retried stage cannot tighten the stoploss. Discretionary exits are
+denied while reconciliation is pending or an order remains open; stoploss,
+trailing stoploss, emergency exit, and force exit remain available. Their distinct
+full-exit wallet fallback is audited when possible, but an audit failure never
+denies these safety exits.
 
 An ambiguous submission can be cleared only after checking the CEX order history
 for the complete attempt window. Stop the bot, inspect the state, then use the
@@ -221,22 +231,55 @@ The clear command is unavailable until the persisted recovery deadline. `inspect
 does not modify take-profit data. It initializes Freqtrade persistence like other
 database clients and may create or migrate supported database schema objects.
 It reports current and expected exposure, their delta, take-profit and
-non-take-profit credits, active or retired wallet adjustments, immutable stage
-targets, deferred stages, attributed orders, and operator proofs. For an
-`unknown_terminal_fill` or `unattributed_exit_fill` block with a verified positive
-fill, first correct the canonical Freqtrade order, its exit tag, and trade
-accounting from exchange data. Then revalidate that exact order:
+non-take-profit credits, active or retired wallet adjustments and compacted totals,
+immutable stage targets, deferred stages, attribution evidence, partial wallet
+mutations, the single supported recovery path, and operator proofs. For an unbound
+partial-wallet mutation, `clear-ambiguous` recalculates the trade from canonical
+orders and requires the exact pre-submission exposure. It commits that canonical
+trade first and clears the blocked attempt second, so a crash between the writes
+remains fail-closed.
+
+When a bound order has a native terminal outcome such as `expired`, `rejected`, or
+`closed`, restore the amount with the exact evidence-bound token printed by
+`inspect`:
+
+```shell
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT restore-partial-wallet-mutation \
+  --order-id 987654 --apply \
+  --confirmation 'RESTORE-PARTIAL-WALLET:42:abc123:987654:expired:v1:<sha256-from-inspect>'
+```
+
+For a revalidatable terminal or attribution block, first repair the canonical
+Freqtrade order, its exit tag, and trade accounting from exchange data. An existing
+take-profit attribution cannot increase beyond its submitted maximum or change to
+a non-take-profit tag. Then revalidate that exact order:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
   --trade-id 42 --expected-pair ETH/USDT revalidate-terminal \
-  --order-id 987654 --apply --confirmation 'RECONCILE:42:987654'
+  --order-id 987654 --apply \
+  --confirmation 'RECONCILE:42:987654:v1:<sha256-from-inspect>'
 ```
 
-For a verified `canceled` or `cancelled` zero-fill strategy order or stoploss, use
-the status-bound confirmation token printed by `inspect`:
+For a verified `canceled` or `cancelled` positive fill, use the dedicated
+evidence-bound confirmation token printed by `inspect`:
+
+```shell
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-canceled \
+  --order-id 987654 --terminal-status canceled --apply \
+  --confirmation 'CANCELED-FILL:42:987654:canceled:v1:<sha256-from-inspect>'
+```
+
+For a verified `canceled` or `cancelled` zero-fill strategy order, use the
+evidence-bound confirmation token printed by `inspect`:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
@@ -244,15 +287,30 @@ docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoin
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
   --trade-id 42 --expected-pair ETH/USDT confirm-terminal-zero \
   --order-id 987654 --terminal-status canceled --apply \
-  --confirmation 'NO-FILL:42:987654:canceled'
+  --confirmation 'NO-FILL:42:987654:canceled:v1:<sha256-from-inspect>'
 ```
 
-Recovery commands recompute the ledger from canonical orders and record a bounded
-audit entry; they never edit orders or trade exposure. A confirmed zero-fill also
-persists an immutable order snapshot outside that bounded audit. Any later change
-to its side, status, amount, remainder, fee, fill, or fill timestamp blocks the
-ledger again. If canonical data still cannot prove the outcome, reconcile the
-position manually or close the trade.
+Recovery commands never edit orders. The clear, restore, and bound confirmation
+paths use Freqtrade's native order recalculation and commit canonical trade
+accounting before take-profit state, making an interrupted run safely replayable.
+This automatic recalculation is limited to spot trades. Freqtrade bypasses the
+wallet fallback for futures, while margin interest depends on mutable exposure and
+wall-clock time, so replaying its native recalculation is not deterministic. For a
+margin partial-wallet mutation, `inspect` withholds the apply token and reports
+`margin_recalculation_not_replay_safe`. Automatic state recovery is unavailable;
+reconcile and close the position manually.
+Other paths require trade accounting to be repaired first. Every command recomputes
+the ledger and records a bounded audit entry. Confirmed zero and canceled positive
+fills persist immutable order snapshots outside that bounded audit. Any later
+change to a proved creation time, tag, side, status, amount, remainder, fee, fill,
+or fill timestamp blocks the ledger again. Every order-based confirmation token
+also contains a versioned digest of the recovery instruction, take-profit state,
+stable trade inputs, and the ordered canonical entry and exit orders. Any
+intervening evidence change invalidates the token and requires a new `inspect`.
+Derived trade accounting fields are excluded so the same token remains replayable
+after an interruption between the canonical accounting commit and the state commit.
+If canonical data still cannot prove the outcome, reconcile the position manually
+or close the trade.
 
 ## ReforceXY
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 - [QuickAdapter](#quickadapter)
   - [Quick start](#quick-start)
   - [Configuration tunables](#configuration-tunables)
+  - [Partial exit execution](#partial-exit-execution)
 - [ReforceXY](#reforcexy)
   - [Quick start](#quick-start-1)
   - [Supported models](#supported-models)
@@ -148,11 +149,90 @@ docker compose up -d --build
 
 ### Partial exit execution
 
-QuickAdapter advances a take-profit stage only after the tagged exit quantity is
-fully filled. Open, rejected, expired, or unfilled cancelled orders do not commit
-the stage. When an order is partially filled and then cancelled, the next position
-adjustment retries only the unfilled quantity. Progress is reconstructed from the
-orders persisted by Freqtrade, including after a bot restart.
+QuickAdapter persists a versioned execution state and advances take-profit stages
+from terminal Freqtrade orders that can be linked to a specific take-profit
+attempt. The persisted plan includes every partial fraction and NATR trigger, so
+an open trade cannot silently switch execution plans after a deployment. Targets
+remain immutable: terminal partial fills credit only their observed net base
+amount, while a base amount that deterministically rounds to zero is carried FIFO
+to a later threshold. Exchange minimum hints never mutate the ledger; Freqtrade's
+final exit validation remains authoritative.
+Legacy emergency orders and recovered untagged orders are accepted only when
+their relationship to an attempt is unique.
+
+`unfilledtimeout.exit_timeout_count` must be `0`; QuickAdapter is the sole owner of
+partial-exit retries, and `order_types.exit` must be `limit` because Freqtrade has
+no equivalent pre-submission callback for partial market exits. A strict zero-fill
+outcome is retried automatically only when its persisted status is `rejected` or
+`expired`, its remaining amount equals the order amount, it has no base fee, and
+it has no fill timestamp. `canceled` and `cancelled` always require operator
+verification:
+Freqtrade can synthesize a canceled response when cancellation and order retrieval
+both fail. A lost CEX response, foreign filled exit, or filled stoploss also fails
+closed instead of risking a duplicate reduction. Open stoploss orders without
+partial-fill evidence remain protective and do not affect the take-profit ledger. If
+`stoploss_on_exchange` is enabled, an uncertain canceled stoploss requires the same
+operator verification before take-profit resumes.
+
+The ledger derives initial exposure from terminal entry fills, applies Freqtrade's
+amount precision, and requires current trade exposure to equal entries minus
+credited take-profit fills. The logical take-profit stage also drives stoploss
+tightening, so multiple fills or retries within one stage cannot tighten it more
+than once. Discretionary exits are denied while reconciliation is pending or a
+non-stoploss order remains open; stoploss, trailing stoploss, emergency exit, and
+force exit remain available.
+
+An ambiguous submission can be cleared only after checking the CEX order history
+for the complete attempt window. Stop the bot, inspect the state, then use the
+exact confirmation token printed by this procedure:
+
+```shell
+docker compose -f quickadapter/docker-compose.yml stop freqtrade
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT inspect
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT clear-ambiguous \
+  --attempt-id abc123 --apply --confirmation 'NO-ORDER:42:abc123'
+docker compose -f quickadapter/docker-compose.yml start freqtrade
+```
+
+The clear command is unavailable until the persisted recovery deadline. `inspect`
+reports current and expected exposure, their delta, immutable stage targets,
+credits, deferred stages, attributed orders, and operator proofs. For an
+`unknown_terminal_fill` block with a verified positive fill, first correct both
+the canonical Freqtrade order and trade accounting from exchange data. Then
+revalidate that exact order:
+
+```shell
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT revalidate-terminal \
+  --order-id 987654 --apply --confirmation 'RECONCILE:42:987654'
+```
+
+For a verified `canceled` or `cancelled` zero-fill strategy order or stoploss, use
+the status-bound confirmation token printed by `inspect`:
+
+```shell
+docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
+  /freqtrade/user_data/scripts/take_profit_maintenance.py \
+  --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
+  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-zero \
+  --order-id 987654 --terminal-status canceled --apply \
+  --confirmation 'NO-FILL:42:987654:canceled'
+```
+
+Recovery commands recompute the ledger from canonical orders and record a bounded
+audit entry; they never edit orders or trade exposure. A confirmed zero-fill also
+persists an immutable order snapshot outside that bounded audit. Any later change
+to its side, status, amount, remainder, fee, fill, or fill timestamp blocks the
+ledger again. If canonical data still cannot prove the outcome, reconcile the
+position manually or close the trade.
 
 ## ReforceXY
 

--- a/README.md
+++ b/README.md
@@ -208,9 +208,15 @@ exchange-stoploss order record. Reconcile or close those trades, verify each CEX
 position, set the option to `false`, and only then restart.
 
 The ledger derives initial exposure from terminal entry fills and applies the live
-Freqtrade amount precision. Every validated terminal strategy exit reduces exposure,
-but only an order whose audited attribution still matches its ID, tag, side,
-amount, stage, and provenance advances take-profit progress. A discretionary
+Freqtrade amount precision. For spot-like trades, initialization waits until
+Freqtrade has finalized the entry fee, so a late base-currency fee cannot invalidate
+the initial exposure. Futures trades do not wait because their fees do not reduce
+the position amount. If the fee remains unavailable, automatic take-profit stays
+inactive, but a non-take-profit strategy exit remains available while no take-profit
+ledger or open order exists. Any pre-callback wallet fallback applied by Freqtrade
+remains the canonical exposure. Every validated terminal strategy exit reduces
+exposure, but only an order whose audited attribution still matches its ID, tag,
+side, amount, stage, and provenance advances take-profit progress. A discretionary
 partial fill therefore leaves the stage unchanged. Retired wallet-adjustment detail
 is compacted only when the bounded audit needs room; active evidence is never
 discarded.
@@ -232,14 +238,17 @@ without advancing a stage and preserves it even when order creation fails. A lat
 positive fill retires the adjustment only when native order accounting proves the
 order-backed exposure.
 
+Freqtrade passes a defensive trade copy to the strategy exit-confirmation callback.
 If a non-safety exit is denied because that adjustment cannot be persisted,
-QuickAdapter restores the previous amount only after confirming that the previous
-state is still stored. If the adjusted state was written before the error, the
-wallet-corrected amount remains authoritative.
+QuickAdapter restores the previous amount on the canonical ORM trade only after
+confirming that the previous state is still stored. If the adjusted state was
+written before the error, the wallet-corrected amount remains authoritative.
 
 Before a live spot-like partial exit, the total wallet balance must cover the entire
 canonical trade exposure, not only the requested partial amount. Otherwise no attempt
-is submitted and the same stage remains pending. An amount mutation that is not
+is submitted and the same stage remains pending. Live exit minimums use Freqtrade's
+exchange calculation for the exit rate, stoploss reserve, leverage, and contract
+limits; backtests keep the callback-provided minimum. An amount mutation that is not
 explained by a persisted exposure adjustment is separate, fail-closed evidence of an
 interrupted wallet transition. An unbound mutation retains the ambiguous attempt so
 a late unique order can still be discovered; attribution can bind the evidence to

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 - [QuickAdapter](#quickadapter)
   - [Quick start](#quick-start)
   - [Configuration tunables](#configuration-tunables)
-  - [Partial exit execution](#partial-exit-execution)
+  - [Take-profit execution](#take-profit-execution)
 - [ReforceXY](#reforcexy)
   - [Quick start](#quick-start-1)
   - [Supported models](#supported-models)
@@ -147,37 +147,58 @@ docker compose up -d --build
 | freqai.optuna_hyperopt.min_resource                            | 3                             | int >= 1                                                                                                                                                                                                     | Minimum resource per [HyperbandPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.HyperbandPruner.html) rung.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | freqai.optuna_hyperopt.seed                                    | 1                             | int >= 0                                                                                                                                                                                                     | HPO RNG seed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
-### Partial exit execution
+### Take-profit execution
 
-QuickAdapter persists a versioned execution state and advances take-profit stages
-from terminal Freqtrade orders that can be linked to a specific take-profit
-attempt. The persisted plan includes every partial fraction and NATR trigger, so
-an open trade cannot silently switch execution plans after a deployment. Targets
-remain immutable: terminal partial fills credit only their observed net base
-amount. Quantity rounding and exchange minimum checks happen before submission;
-non-executable partial stages are carried FIFO to a later threshold and ultimately
-to the final exit. Live and dry-run checks conservatively account for the exit
-price, leverage, amount reserve, and stoploss reserve used by Freqtrade.
-Public order tags are stable per direction and stage; attempt UUIDs remain internal.
-After an uncertain submission, reconciliation accepts either the exact tagged order
-or one unique untagged order matching the attempt side, amount, and submission time
-window. Any other candidate set remains blocked for operator review.
+QuickAdapter persists a versioned execution state and advances a stage only from a
+terminal Freqtrade order with validated causal attribution. The persisted plan
+contains every partial fraction and NATR trigger, so an open trade cannot silently
+switch plans after deployment. Stage targets remain immutable; partial fills credit
+only their observed net base amount. Non-executable amounts are deferred FIFO to a
+later trigger and ultimately to the final exit. Public order tags are stable per
+direction and stage, while attempt IDs remain internal.
+
+Partial attempts are persisted as `submitting` before the position-adjustment
+callback can reach the exchange. Final attempts remain local proposals until
+`confirm_trade_exit`; any persistence failure makes that callback return `false`.
+The final proposal keeps the raw trade amount that Freqtrade passes back to the
+confirmation callback; exchange precision is applied after that confirmation.
+An attempt must target the current execution stage and cannot exceed either that
+stage's remaining debt or order-backed exposure; a final proposal may only shrink at
+confirmation.
+After submission, reconciliation accepts either the exact tagged order or one unique
+untagged order matching the attempt side, amount, and submission window. Attribution
+is persisted before the terminal outcome is classified, including when the first
+observed order snapshot is already terminal. Multiple candidates remain fail-closed.
+
+Terminal outcomes use the following policy:
+
+| Canonical Freqtrade status | Fill evidence | Result |
+| --- | --- | --- |
+| open | any consistent snapshot | Attribute the order, credit nothing, and wait. |
+| `expired` or `rejected` | strict zero fill | Credit zero and schedule a bounded retry. |
+| `closed`, `expired`, or `rejected` | strict positive fill | Credit the net base fill; a coherent remainder, fee, and canonical fill timestamp are required. |
+| `closed` | zero fill | Block as an unknown terminal outcome. |
+| `canceled` or `cancelled` | strict zero fill | Require an exact operator-confirmed zero-fill snapshot. |
+| `canceled` or `cancelled` | strict positive fill | Require an exact operator-confirmed canceled-fill snapshot. |
+| any terminal status | missing or inconsistent evidence | Block without advancing the stage. |
+
+A strict automatic zero fill has `filled == 0`, `remaining == amount`, no base fee,
+no funding fee, and no fill timestamp. A positive fill must not exceed the order
+amount; its remainder must be coherent; its base fee must be smaller than the fill;
+and its execution price, funding fee, and canonical fill timestamp must be valid.
+The timestamp is Freqtrade evidence, not proof that the CEX supplied it directly.
+Operators must still verify canceled outcomes against the CEX because Freqtrade can
+synthesize a canceled response when cancellation and order retrieval both fail.
 
 `unfilledtimeout.exit_timeout_count` must be `0`; QuickAdapter is the sole owner of
-partial-exit retries. Partial attempts are persisted as `submitting` before the
-position-adjustment callback can reach the exchange. Final attempts remain local
-proposals until `confirm_trade_exit`; their confirmation returns `false` on every
-state persistence failure. Take-profit limit and market exits therefore use the
-same durable submission protocol. A strict zero-fill outcome is retried
-automatically only when its persisted status is `rejected` or `expired`, its
-remaining amount equals
-the order amount, it has no base fee, and it has no fill timestamp. `canceled` and
-`cancelled` always require operator verification:
-Freqtrade can synthesize a canceled response when cancellation and order retrieval
-both fail. A canceled positive fill requires a separate immutable snapshot of its
-creation time, tag, side, status, amount, fill, remainder, base fee, and fill
-timestamp. A lost CEX response or any terminal external order with uncertain or
-positive execution remains fail-closed and requires manual position reconciliation.
+take-profit retries. Each causally attributed terminal zero fill persists its stage,
+consecutive count, last order ID, and next eligible retry time. The original attempt
+recovery window, derived from `unfilledtimeout.exit`, is applied with delays of 1x,
+2x, 4x, then 8x. The fifth consecutive zero-fill outcome blocks automatic
+take-profit with `zero_fill_retry_limit_reached`; there is no operator reset for this
+safety budget. A positive take-profit fill clears the retry sequence. The deadline,
+count, and limit survive process restarts, and both partial and final callbacks check
+the gate before proposing another order.
 
 `order_types.stoploss_on_exchange` must be `false`. Freqtrade 2026.6 and 2026.7-dev do
 not persist enough cancellation provenance for the strategy to distinguish a
@@ -186,32 +207,57 @@ deploying this version, stop the bot and ensure that no open trade retains an
 exchange-stoploss order record. Reconcile or close those trades, verify each CEX
 position, set the option to `false`, and only then restart.
 
-The ledger derives initial exposure from terminal entry fills, applies Freqtrade's
-amount precision, and separates two concerns. Every validated terminal strategy
-exit reduces exposure, but only an order whose immutable attribution still matches
-its canonical ID, tag, side, amount, stage, and provenance advances the take-profit
-stages. A discretionary exit that is partially filled therefore leaves the stage
-unchanged and can be reevaluated normally instead of permanently blocking the
-trade. Freqtrade's full-exit wallet fallback is recorded as a bounded, audited
-exposure adjustment; a later canonical fill retires that adjustment when Freqtrade
-recalculates the amount from orders. Retired adjustment details are compacted only
-when the bounded ledger needs room; active adjustments are never discarded, and
-the compacted count and amount remain visible. For live and dry-run partial exits,
-QuickAdapter refreshes the spot-like wallet and applies Freqtrade's 2% fallback
-bound before persisting the attempt. If Freqtrade still mutates the trade amount,
-the state records that partial-wallet mutation and its exact canonical order, when
-one exists. The active attempt pauses automatic execution until canonical trade
-accounting is restored. Futures are unchanged. Deferred stages affect scheduling
-only: stoploss tightening follows the separately computed credited stage, so an
-unexecuted or retried stage cannot tighten the stoploss. Discretionary exits are
-denied while reconciliation is pending or an order remains open; stoploss,
-trailing stoploss, emergency exit, and force exit remain available. Their distinct
-full-exit wallet fallback is audited when possible, but an audit failure never
-denies these safety exits.
+The ledger derives initial exposure from terminal entry fills and applies the live
+Freqtrade amount precision. Every validated terminal strategy exit reduces exposure,
+but only an order whose audited attribution still matches its ID, tag, side,
+amount, stage, and provenance advances take-profit progress. A discretionary
+partial fill therefore leaves the stage unchanged. Retired wallet-adjustment detail
+is compacted only when the bounded audit needs room; active evidence is never
+discarded.
 
-An ambiguous submission can be cleared only after checking the CEX order history
-for the complete attempt window. Stop the bot, inspect the state, then use the
-exact confirmation token printed by this procedure:
+When an exchange response initially omits the order amount, an automatic attribution
+may normalize once from Freqtrade's provisional raw amount to its exact
+exchange-quantized amount. Automatic reconciliation accepts no later amount change;
+further changes remain blocked until evidence-bound terminal recovery.
+
+Order creation timestamps are not normalized automatically because Freqtrade does
+not expose whether its initial value came from the exchange. A changed timestamp
+therefore remains fail-closed while the order is open and requires evidence-bound
+terminal recovery.
+
+Freqtrade can reduce `trade.amount` while applying its full-exit wallet fallback,
+before order creation succeeds. This is a durable correction to the available wallet
+exposure, not fill evidence. QuickAdapter records it as an active exposure adjustment
+without advancing a stage and preserves it even when order creation fails. A later
+positive fill retires the adjustment only when native order accounting proves the
+order-backed exposure.
+
+If a non-safety exit is denied because that adjustment cannot be persisted,
+QuickAdapter restores the previous amount only after confirming that the previous
+state is still stored. If the adjusted state was written before the error, the
+wallet-corrected amount remains authoritative.
+
+Before a live spot-like partial exit, the total wallet balance must cover the entire
+canonical trade exposure, not only the requested partial amount. Otherwise no attempt
+is submitted and the same stage remains pending. An amount mutation that is not
+explained by a persisted exposure adjustment is separate, fail-closed evidence of an
+interrupted wallet transition. An unbound mutation retains the ambiguous attempt so
+a late unique order can still be discovered; attribution can bind the evidence to
+that order but cannot prove the remaining wallet exposure. Orders alone may never be
+used to increase the observed amount. Perform a fresh wallet and CEX reconciliation
+before taking manual action. Automatic take-profit remains blocked; manage or close
+the position through the native Freqtrade lifecycle.
+
+Deferred or retried stages do not tighten the stoploss: stoploss progression follows
+the separately computed credited stage. Discretionary exits are denied while
+reconciliation is pending or an order remains open. Stoploss, trailing stoploss,
+emergency exit, and force exit remain available; an audit failure never denies these
+safety exits.
+
+Run take-profit maintenance only while the bot is stopped. An ambiguous submission
+can be cleared only after checking the CEX order history for the complete attempt
+window. Inspect the current evidence, then use the exact confirmation token that
+`inspect` prints:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml stop freqtrade
@@ -223,47 +269,50 @@ docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoin
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
   --trade-id 42 --expected-pair ETH/USDT clear-ambiguous \
-  --attempt-id abc123 --apply --confirmation 'NO-ORDER:42:abc123'
+  --attempt-id abc123 --apply \
+  --confirmation 'NO-ORDER:42:abc123:v1:<sha256-from-inspect>'
 docker compose -f quickadapter/docker-compose.yml start freqtrade
 ```
 
-The clear command is unavailable until the persisted recovery deadline. `inspect`
+The clear command is unavailable until the persisted recovery deadline. A normal
+no-order clear removes only the ambiguous attempt; it preserves any audited wallet
+exposure adjustment and its corrected trade amount. `inspect`
 does not modify take-profit data. It initializes Freqtrade persistence like other
-database clients and may create or migrate supported database schema objects.
-It reports current and expected exposure, their delta, take-profit and
-non-take-profit credits, active or retired wallet adjustments and compacted totals,
-immutable stage targets, deferred stages, attribution evidence, partial wallet
-mutations, the single supported recovery path, and operator proofs. For an unbound
-partial-wallet mutation, `clear-ambiguous` recalculates the trade from canonical
-orders and requires the exact pre-submission exposure. It commits that canonical
-trade first and clears the blocked attempt second, so a crash between the writes
-remains fail-closed.
+database clients and may create or migrate supported database schema objects. It
+reports exposure, both exit ledgers, retry state, stage targets, deferred stages,
+attributions, wallet mutations, at most one recovery disposition, any reason
+that automatic recovery is withheld, and the exact confirmation token. A partial
+wallet mutation never receives an order-only recovery token, whether it is unbound
+or bound to a terminal order. `inspect` reports
+`fresh_wallet_and_cex_audit_required`, and the observed amount remains unchanged.
 
-When a bound order has a native terminal outcome such as `expired`, `rejected`, or
-`closed`, restore the amount with the exact evidence-bound token printed by
-`inspect`:
+For a revalidatable terminal-order block, first repair the canonical Freqtrade order
+and exit tag from verified exchange data. An existing attribution cannot increase
+beyond its submitted maximum or change its persisted tag. The tool can rebuild
+accounting for a partial terminal fill only when the trade is spot and remains open:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
-  --trade-id 42 --expected-pair ETH/USDT restore-partial-wallet-mutation \
+  --trade-id 42 --expected-pair ETH/USDT revalidate-terminal-order \
   --order-id 987654 --apply \
-  --confirmation 'RESTORE-PARTIAL-WALLET:42:abc123:987654:expired:v1:<sha256-from-inspect>'
+  --confirmation 'REVALIDATE-ORDER:42:987654:v1:<sha256-from-inspect>'
 ```
 
-For a revalidatable terminal or attribution block, first repair the canonical
-Freqtrade order, its exit tag, and trade accounting from exchange data. An existing
-take-profit attribution cannot increase beyond its submitted maximum or change to
-a non-take-profit tag. Then revalidate that exact order:
+If an eligible latch remains after its underlying data has been restored exactly,
+`inspect` emits a state-revalidation token only when clearing the latch and running a
+complete reconciliation already succeeds. An unknown open take-profit order can be
+reclassified only while the same canonical order remains open on the exit side and
+has an explicit, non-empty, non-take-profit exit tag. This action does not rewrite
+evidence:
 
 ```shell
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
-  --trade-id 42 --expected-pair ETH/USDT revalidate-terminal \
-  --order-id 987654 --apply \
-  --confirmation 'RECONCILE:42:987654:v1:<sha256-from-inspect>'
+  --trade-id 42 --expected-pair ETH/USDT revalidate-state --apply \
+  --confirmation 'REVALIDATE-STATE:42:v1:<sha256-from-inspect>'
 ```
 
 For a verified `canceled` or `cancelled` positive fill, use the dedicated
@@ -273,7 +322,7 @@ evidence-bound confirmation token printed by `inspect`:
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
-  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-canceled \
+  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-canceled-fill \
   --order-id 987654 --terminal-status canceled --apply \
   --confirmation 'CANCELED-FILL:42:987654:canceled:v1:<sha256-from-inspect>'
 ```
@@ -285,32 +334,59 @@ evidence-bound confirmation token printed by `inspect`:
 docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoint python freqtrade \
   /freqtrade/user_data/scripts/take_profit_maintenance.py \
   --db-url sqlite:////freqtrade/user_data/freqtrade-quickadapter-tradesv3.sqlite \
-  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-zero \
+  --trade-id 42 --expected-pair ETH/USDT confirm-terminal-zero-fill \
   --order-id 987654 --terminal-status canceled --apply \
-  --confirmation 'NO-FILL:42:987654:canceled:v1:<sha256-from-inspect>'
+  --confirmation 'ZERO-FILL:42:987654:canceled:v1:<sha256-from-inspect>'
 ```
 
-Recovery commands never edit orders. The clear, restore, and bound confirmation
-paths use Freqtrade's native order recalculation and commit canonical trade
-accounting before take-profit state, making an interrupted run safely replayable.
-This automatic recalculation is limited to spot trades. Freqtrade bypasses the
-wallet fallback for futures, while margin interest depends on mutable exposure and
-wall-clock time, so replaying its native recalculation is not deterministic. For a
-margin partial-wallet mutation, `inspect` withholds the apply token and reports
-`margin_recalculation_not_replay_safe`. Automatic state recovery is unavailable;
-reconcile and close the position manually.
-Other paths require trade accounting to be repaired first. Every command recomputes
-the ledger and records a bounded audit entry. Confirmed zero and canceled positive
-fills persist immutable order snapshots outside that bounded audit. Any later
-change to a proved creation time, tag, side, status, amount, remainder, fee, fill,
-or fill timestamp blocks the ledger again. Every order-based confirmation token
-also contains a versioned digest of the recovery instruction, take-profit state,
-stable trade inputs, and the ordered canonical entry and exit orders. Any
-intervening evidence change invalidates the token and requires a new `inspect`.
-Derived trade accounting fields are excluded so the same token remains replayable
-after an interruption between the canonical accounting commit and the state commit.
-If canonical data still cannot prove the outcome, reconcile the position manually
-or close the trade.
+Recovery commands never rewrite canonical Freqtrade order evidence. For an
+attributed terminal order, the applicable token may rebind the attribution amount up
+to its submitted maximum. It may also rebind the canonical creation timestamp when
+the attribution retains its original submission window and the timestamp remains
+inside it. A terminal order without an attribution can receive an operator
+attribution only from a valid take-profit tag for the trade direction and configured
+stage; any active attempt must also match its side, amount, tag, and submission
+window. When every relevant accounting field is already correct, recovery persists
+only the audited state transition. Otherwise it may use
+`Trade.recalc_trade_from_orders()` to rebuild an open spot trade from all canonical
+orders, then reapply the exposure amount derived from the take-profit ledger. The
+tool never calls the native terminal-fill lifecycle and never changes an open trade
+into a closed trade. A positive fill that consumes the remaining exposure must be
+processed by the running Freqtrade lifecycle. The prospective ledger exposure,
+rather than the fill-to-residual ratio, determines that boundary. `inspect` reports
+the `native_freqtrade_lifecycle` disposition without an apply token. Every positive
+terminal-fill recovery in futures or margin mode is also withheld, even when ORM
+accounting appears aligned, because persisted fields cannot prove native fill side
+effects such as liquidation, wallet, callback, and stoploss updates. Closed trades
+are strictly inspect-only.
+
+Before emitting a token, the tool checks every accounting field rebuilt or updated by
+`Trade.recalc_trade_from_orders()` against an isolated native rebuild. Every filled
+source order must have a finite, positive price. Open and zero-fill orders must have
+zero funding fees. For an open trade, its persisted funding total must equal the sum
+stored on terminal positive-fill orders plus the current running accrual. An
+accounting rebuild is available only for spot trades. `inspect` reports one of
+`closed_trade_is_inspect_only`,
+`fresh_wallet_and_cex_audit_required`,
+`positive_fill_requires_native_freqtrade_lifecycle`,
+`non_spot_trade_accounting_not_replay_safe`, or
+`automatic_trade_accounting_precondition_failed` when recovery is recognized but
+cannot be applied safely.
+
+When an offline accounting rebuild is required, trade accounting is committed first
+and take-profit state second. A crash between those commits remains fail-closed.
+Because confirmation tokens bind the inspected trade fields, reconciled state,
+effective instruction, and every ordered entry and exit record, the first commit
+invalidates the previous token. Rerun `inspect` and use its new token to complete the
+remaining state transition. Tokens are never normalized across commit phases.
+
+Every successfully applied recovery command appends a bounded audit entry. Confirmed
+zero and canceled positive fills also persist immutable snapshots of every order
+field used for classification and native accounting, including funding and positive
+fill execution price. Any later change to proved order evidence blocks the ledger
+again. Any trade, state, instruction, or order change invalidates the v1 token and
+requires a new `inspect`. If canonical data cannot prove a safe outcome, reconcile
+the position through Freqtrade or close the trade.
 
 ## ReforceXY
 

--- a/README.md
+++ b/README.md
@@ -284,16 +284,17 @@ docker compose -f quickadapter/docker-compose.yml run --rm --no-deps --entrypoin
 docker compose -f quickadapter/docker-compose.yml start freqtrade
 ```
 
-The clear command is unavailable until the persisted recovery deadline. A normal
-no-order clear removes only the ambiguous attempt; it preserves any audited wallet
-exposure adjustment and its corrected trade amount. `inspect`
-does not modify take-profit data. It initializes Freqtrade persistence like other
-database clients and may create or migrate supported database schema objects. It
-reports exposure, both exit ledgers, retry state, stage targets, deferred stages,
-attributions, wallet mutations, at most one recovery disposition, any reason
-that automatic recovery is withheld, and the exact confirmation token. A partial
-wallet mutation never receives an order-only recovery token, whether it is unbound
-or bound to a terminal order. `inspect` reports
+The clear command and its confirmation token are unavailable until the persisted
+recovery deadline. Run a fresh `inspect` after that deadline and verify the complete
+CEX attempt window before using the emitted token. A normal no-order clear removes
+only the ambiguous attempt; it preserves any audited wallet exposure adjustment and
+its corrected trade amount. `inspect` does not modify take-profit data. It initializes
+Freqtrade persistence like other database clients and may create or migrate supported
+database schema objects. It reports exposure, both exit ledgers, retry state, stage
+targets, deferred stages, attributions, wallet mutations, at most one recovery
+disposition, any reason that automatic recovery is withheld, and the exact
+confirmation token. A partial wallet mutation never receives an order-only recovery
+token, whether it is unbound or bound to a terminal order. `inspect` reports
 `fresh_wallet_and_cex_audit_required`, and the observed amount remains unchanged.
 
 For a revalidatable terminal-order block, first repair the canonical Freqtrade order

--- a/README.md
+++ b/README.md
@@ -146,6 +146,14 @@ docker compose up -d --build
 | freqai.optuna_hyperopt.min_resource                            | 3                             | int >= 1                                                                                                                                                                                                     | Minimum resource per [HyperbandPruner](https://optuna.readthedocs.io/en/stable/reference/generated/optuna.pruners.HyperbandPruner.html) rung.                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 | freqai.optuna_hyperopt.seed                                    | 1                             | int >= 0                                                                                                                                                                                                     | HPO RNG seed.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
 
+### Partial exit execution
+
+QuickAdapter advances a take-profit stage only after the tagged exit quantity is
+fully filled. Open, rejected, expired, or unfilled cancelled orders do not commit
+the stage. When an order is partially filled and then cancelled, the next position
+adjustment retries only the unfilled quantity. Progress is reconstructed from the
+orders persisted by Freqtrade, including after a bot restart.
+
 ## ReforceXY
 
 ### Quick start

--- a/README.md
+++ b/README.md
@@ -244,18 +244,19 @@ QuickAdapter restores the previous amount on the canonical ORM trade only after
 confirming that the previous state is still stored. If the adjusted state was
 written before the error, the wallet-corrected amount remains authoritative.
 
-Before a live spot-like partial exit, the total wallet balance must cover the entire
-canonical trade exposure, not only the requested partial amount. Otherwise no attempt
-is submitted and the same stage remains pending. Live exit minimums use Freqtrade's
-exchange calculation for the exit rate, stoploss reserve, leverage, and contract
-limits; backtests keep the callback-provided minimum. An amount mutation that is not
-explained by a persisted exposure adjustment is separate, fail-closed evidence of an
-interrupted wallet transition. An unbound mutation retains the ambiguous attempt so
-a late unique order can still be discovered; attribution can bind the evidence to
-that order but cannot prove the remaining wallet exposure. Orders alone may never be
-used to increase the observed amount. Perform a fresh wallet and CEX reconciliation
-before taking manual action. Automatic take-profit remains blocked; manage or close
-the position through the native Freqtrade lifecycle.
+Before a live spot-like partial exit, the total base-asset wallet balance must cover
+the entire canonical trade exposure, not only the requested partial amount. For a
+sell-side exit, the free base-asset balance must also cover the requested amount.
+Otherwise no attempt is submitted and the same stage remains pending. Live exit
+minimums use Freqtrade's exchange calculation for the exit rate, stoploss reserve,
+leverage, and contract limits; backtests keep the callback-provided minimum. An
+amount mutation that is not explained by a persisted exposure adjustment is separate,
+fail-closed evidence of an interrupted wallet transition. An unbound mutation retains
+the ambiguous attempt so a late unique order can still be discovered; attribution can
+bind the evidence to that order but cannot prove the remaining wallet exposure. Orders
+alone may never be used to increase the observed amount. Perform a fresh wallet and
+CEX reconciliation before taking manual action. Automatic take-profit remains
+blocked; manage or close the position through the native Freqtrade lifecycle.
 
 Deferred or retried stages do not tighten the stoploss: stoploss progression follows
 the separately computed credited stage. Discretionary exits are denied while

--- a/quickadapter/user_data/scripts/take_profit_maintenance.py
+++ b/quickadapter/user_data/scripts/take_profit_maintenance.py
@@ -365,6 +365,13 @@ def _ambiguous_confirmation_token(
     )
 
 
+def _recovery_deadline_is_reached(
+    recovery_deadline: str,
+    current_time: datetime.datetime,
+) -> bool:
+    return current_time >= datetime.datetime.fromisoformat(recovery_deadline)
+
+
 def _require_recovery_instruction(
     trade: Trade,
     state: TakeProfitStageState,
@@ -865,6 +872,14 @@ def _summary(
                 if not trade.is_open
                 else "automatic_trade_accounting_precondition_failed"
             )
+    clear_confirmation_is_available = (
+        clearable_attempt is not None
+        and clear_blocked_reason is None
+        and _recovery_deadline_is_reached(
+            clearable_attempt.recovery_deadline,
+            datetime.datetime.now(datetime.timezone.utc),
+        )
+    )
     recovery_is_available = recovery is not None and recovery_blocked_reason is None
     return {
         "command": command,
@@ -894,7 +909,7 @@ def _summary(
                     state,
                     clearable_attempt.attempt_id,
                 )
-                if clearable_attempt is not None and clear_blocked_reason is None
+                if clear_confirmation_is_available and clearable_attempt is not None
                 else None
             ),
             "recovery_action": recovery.action if recovery is not None else None,
@@ -1054,8 +1069,10 @@ def _validate_ambiguous_attempt(
             "or investigate the reported block before clearing anything"
         )
 
-    recovery_deadline = datetime.datetime.fromisoformat(attempt.recovery_deadline)
-    if datetime.datetime.now(datetime.timezone.utc) < recovery_deadline:
+    if not _recovery_deadline_is_reached(
+        attempt.recovery_deadline,
+        datetime.datetime.now(datetime.timezone.utc),
+    ):
         _fail(f"ambiguous attempt cannot be cleared before {attempt.recovery_deadline}")
 
 

--- a/quickadapter/user_data/scripts/take_profit_maintenance.py
+++ b/quickadapter/user_data/scripts/take_profit_maintenance.py
@@ -15,6 +15,8 @@ from typing import NoReturn
 
 from freqtrade.exchange import amount_to_contract_precision
 from freqtrade.persistence import Trade, init_db
+from sqlalchemy.engine import make_url
+from sqlalchemy.exc import ArgumentError
 
 
 STRATEGIES_DIR = Path(__file__).resolve().parents[1] / "strategies"
@@ -37,7 +39,10 @@ def _parser() -> argparse.ArgumentParser:
     parser.add_argument("--expected-pair", required=True)
     parser.add_argument("--json", action="store_true", dest="as_json")
     commands = parser.add_subparsers(dest="command", required=True)
-    commands.add_parser("inspect", help="Show the persisted state without writing")
+    commands.add_parser(
+        "inspect",
+        help="Show take-profit data without modifying it",
+    )
     clear_parser = commands.add_parser(
         "clear-ambiguous",
         help="Clear an ambiguous attempt after proving no remote order exists",
@@ -76,6 +81,16 @@ def _load_trade(args: argparse.Namespace) -> Trade:
         _fail("trade-id must be positive")
     if args.db_url in {"sqlite://", "sqlite:///", "sqlite:///:memory:"}:
         _fail("db-url must identify a persistent database")
+    try:
+        database_url = make_url(args.db_url)
+    except ArgumentError as error:
+        raise MaintenanceError("db-url is invalid") from error
+    if database_url.drivername.startswith("sqlite"):
+        database_path = Path(database_url.database or "")
+        if not database_path.is_absolute():
+            database_path = Path.cwd() / database_path
+        if not database_path.is_file():
+            _fail("SQLite database does not exist")
 
     init_db(args.db_url)
     trades = Trade.get_trades(Trade.id == args.trade_id).all()
@@ -96,7 +111,16 @@ def _load_state(trade: Trade) -> TakeProfitStageState:
     if not isinstance(raw_state, dict):
         _fail("trade has no valid take-profit state mapping")
     try:
-        return TakeProfitStageState.from_mapping(raw_state)
+        source_version = raw_state.get("version")
+        if isinstance(source_version, bool) or not isinstance(source_version, int):
+            raise ValueError("Take-profit state version must be an integer")
+        state = TakeProfitStageState.from_mapping(raw_state)
+        return TakeProfitStageManager.reconcile_migrated_state(
+            trade,
+            state,
+            source_version,
+            amount_quantizer=partial(_quantize_trade_amount, trade),
+        )
     except ValueError as error:
         raise MaintenanceError(f"invalid take-profit state: {error}") from error
 
@@ -184,7 +208,8 @@ def _summary(
             ),
             "required_revalidation_confirmation": (
                 f"RECONCILE:{trade.id}:{state.blocked_order_id}"
-                if state.blocked_reason == "unknown_terminal_fill"
+                if state.blocked_reason
+                in {"unknown_terminal_fill", "unattributed_exit_fill"}
                 and state.blocked_order_id is not None
                 else None
             ),
@@ -200,8 +225,16 @@ def _summary(
                 "initial_amount": state.initial_amount,
                 "expected_trade_amount": expected_trade_amount,
                 "trade_amount_delta": trade_amount_delta,
-                "total_credited_amount": sum(
+                "total_take_profit_credited_amount": sum(
                     amount for _, amount in state.credited_order_amounts
+                ),
+                "total_non_take_profit_exit_amount": sum(
+                    amount for _, amount in state.non_take_profit_exit_order_amounts
+                ),
+                "active_exposure_adjustment_amount": sum(
+                    adjustment.amount
+                    for adjustment in state.exposure_adjustments
+                    if adjustment.is_active
                 ),
                 "stage_targets": [
                     {"stage": stage, "amount": amount}
@@ -212,6 +245,13 @@ def _summary(
                 "credited_order_amounts": [
                     {"order_id": order_id, "amount": amount}
                     for order_id, amount in state.credited_order_amounts
+                ],
+                "non_take_profit_exit_order_amounts": [
+                    {"order_id": order_id, "amount": amount}
+                    for order_id, amount in state.non_take_profit_exit_order_amounts
+                ],
+                "exposure_adjustments": [
+                    adjustment.to_mapping() for adjustment in state.exposure_adjustments
                 ],
                 "entry_order_amounts": [
                     {"order_id": order_id, "amount": amount}

--- a/quickadapter/user_data/scripts/take_profit_maintenance.py
+++ b/quickadapter/user_data/scripts/take_profit_maintenance.py
@@ -1,0 +1,423 @@
+"""Inspect or recover a fail-closed QuickAdapter take-profit state.
+
+Run this tool only while the bot is stopped and only after checking the CEX order
+history. Repair canonical Freqtrade order data before revalidating a terminal fill.
+"""
+
+import argparse
+import datetime
+import json
+import sys
+from collections.abc import Sequence
+from functools import partial
+from pathlib import Path
+from typing import NoReturn
+
+from freqtrade.exchange import amount_to_contract_precision
+from freqtrade.persistence import Trade, init_db
+
+
+STRATEGIES_DIR = Path(__file__).resolve().parents[1] / "strategies"
+sys.path.insert(0, str(STRATEGIES_DIR))
+
+from TakeProfitStageManager import (  # noqa: E402
+    TakeProfitStageManager,
+    TakeProfitStageState,
+)
+
+
+class MaintenanceError(RuntimeError):
+    """Refuse an unsafe or inconsistent maintenance request."""
+
+
+def _parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--db-url", required=True)
+    parser.add_argument("--trade-id", required=True, type=int)
+    parser.add_argument("--expected-pair", required=True)
+    parser.add_argument("--json", action="store_true", dest="as_json")
+    commands = parser.add_subparsers(dest="command", required=True)
+    commands.add_parser("inspect", help="Show the persisted state without writing")
+    clear_parser = commands.add_parser(
+        "clear-ambiguous",
+        help="Clear an ambiguous attempt after proving no remote order exists",
+    )
+    clear_parser.add_argument("--attempt-id", required=True)
+    clear_parser.add_argument("--apply", action="store_true")
+    clear_parser.add_argument("--confirmation")
+    revalidate_parser = commands.add_parser(
+        "revalidate-terminal",
+        help="Reconcile a repaired canonical terminal order",
+    )
+    revalidate_parser.add_argument("--order-id", required=True)
+    revalidate_parser.add_argument("--apply", action="store_true")
+    revalidate_parser.add_argument("--confirmation")
+    zero_fill_parser = commands.add_parser(
+        "confirm-terminal-zero",
+        help="Confirm an exact canceled zero-fill order after CEX verification",
+    )
+    zero_fill_parser.add_argument("--order-id", required=True)
+    zero_fill_parser.add_argument(
+        "--terminal-status",
+        required=True,
+        choices=("canceled", "cancelled"),
+    )
+    zero_fill_parser.add_argument("--apply", action="store_true")
+    zero_fill_parser.add_argument("--confirmation")
+    return parser
+
+
+def _fail(message: str) -> NoReturn:
+    raise MaintenanceError(message)
+
+
+def _load_trade(args: argparse.Namespace) -> Trade:
+    if args.trade_id <= 0:
+        _fail("trade-id must be positive")
+    if args.db_url in {"sqlite://", "sqlite:///", "sqlite:///:memory:"}:
+        _fail("db-url must identify a persistent database")
+
+    init_db(args.db_url)
+    trades = Trade.get_trades(Trade.id == args.trade_id).all()
+    if len(trades) != 1:
+        _fail(f"expected exactly one trade, found {len(trades)}")
+    trade = trades[0]
+    if trade.pair != args.expected_pair:
+        _fail("trade pair does not match expected-pair")
+    if trade.strategy != "QuickAdapterV3":
+        _fail("trade does not belong to QuickAdapterV3")
+    if not trade.is_open:
+        _fail("trade is not open")
+    return trade
+
+
+def _load_state(trade: Trade) -> TakeProfitStageState:
+    raw_state = trade.get_custom_data(TakeProfitStageManager.STATE_KEY)
+    if not isinstance(raw_state, dict):
+        _fail("trade has no valid take-profit state mapping")
+    try:
+        return TakeProfitStageState.from_mapping(raw_state)
+    except ValueError as error:
+        raise MaintenanceError(f"invalid take-profit state: {error}") from error
+
+
+def _order_summary(order) -> dict[str, object]:
+    return {
+        "order_id": order.order_id,
+        "tag": order.ft_order_tag,
+        "side": order.ft_order_side,
+        "status": order.status,
+        "is_open": order.ft_is_open,
+        "amount": order.amount,
+        "filled": order.filled,
+        "remaining": order.remaining,
+        "fee_base": order.ft_fee_base,
+        "order_date": order.order_date_utc.isoformat(),
+        "filled_date": (
+            order.order_filled_utc.isoformat()
+            if order.order_filled_utc is not None
+            else None
+        ),
+    }
+
+
+def _quantize_trade_amount(trade: Trade, amount: float) -> float:
+    return amount_to_contract_precision(
+        amount,
+        trade.amount_precision,
+        trade.precision_mode,
+        trade.contract_size,
+    )
+
+
+def _summary(
+    trade: Trade,
+    state: TakeProfitStageState,
+    *,
+    command: str,
+    would_apply: bool = False,
+) -> dict[str, object]:
+    attempt = state.active_attempt
+    amount_quantizer = partial(_quantize_trade_amount, trade)
+    expected_trade_amount = TakeProfitStageManager.get_expected_trade_amount(
+        state,
+        amount_quantizer=amount_quantizer,
+    )
+    trade_amount_delta = TakeProfitStageManager.get_trade_amount_delta(
+        trade,
+        state,
+        amount_quantizer=amount_quantizer,
+    )
+    blocked_order = next(
+        (order for order in trade.orders if order.order_id == state.blocked_order_id),
+        None,
+    )
+    zero_fill_status = (
+        (blocked_order.status or "").lower() if blocked_order is not None else None
+    )
+    return {
+        "command": command,
+        "would_apply": would_apply,
+        "trade": {
+            "id": trade.id,
+            "pair": trade.pair,
+            "direction": trade.trade_direction,
+            "is_open": trade.is_open,
+            "strategy": trade.strategy,
+            "amount": trade.amount,
+            "stake_amount": trade.stake_amount,
+        },
+        "state": {
+            "version": state.version,
+            "blocked_reason": state.blocked_reason,
+            "blocked_order_id": state.blocked_order_id,
+            "active_attempt": attempt.to_mapping() if attempt is not None else None,
+            "clear_eligible_at": (
+                attempt.recovery_deadline
+                if attempt is not None and attempt.status == "ambiguous"
+                else None
+            ),
+            "required_clear_confirmation": (
+                f"NO-ORDER:{trade.id}:{attempt.attempt_id}"
+                if attempt is not None and attempt.status == "ambiguous"
+                else None
+            ),
+            "required_revalidation_confirmation": (
+                f"RECONCILE:{trade.id}:{state.blocked_order_id}"
+                if state.blocked_reason == "unknown_terminal_fill"
+                and state.blocked_order_id is not None
+                else None
+            ),
+            "required_zero_fill_confirmation": (
+                f"NO-FILL:{trade.id}:{state.blocked_order_id}:{zero_fill_status}"
+                if state.blocked_reason
+                in {"unknown_terminal_fill", "unknown_external_exit_fill"}
+                and state.blocked_order_id is not None
+                and zero_fill_status in {"canceled", "cancelled"}
+                else None
+            ),
+            "ledger": {
+                "initial_amount": state.initial_amount,
+                "expected_trade_amount": expected_trade_amount,
+                "trade_amount_delta": trade_amount_delta,
+                "total_credited_amount": sum(
+                    amount for _, amount in state.credited_order_amounts
+                ),
+                "stage_targets": [
+                    {"stage": stage, "amount": amount}
+                    for stage, amount in state.stage_targets
+                ],
+                "deferred_stages": list(state.deferred_stages),
+                "attributed_order_ids": list(state.attributed_order_ids),
+                "credited_order_amounts": [
+                    {"order_id": order_id, "amount": amount}
+                    for order_id, amount in state.credited_order_amounts
+                ],
+                "entry_order_amounts": [
+                    {"order_id": order_id, "amount": amount}
+                    for order_id, amount in state.entry_order_amounts
+                ],
+                "confirmed_zero_fill_orders": [
+                    proof.to_mapping() for proof in state.confirmed_zero_fill_orders
+                ],
+            },
+            "operator_resolutions": [
+                resolution.to_mapping() for resolution in state.operator_resolutions
+            ],
+        },
+        "orders": [
+            _order_summary(order)
+            for order in trade.orders
+            if order.ft_order_side != trade.entry_side
+        ],
+    }
+
+
+def _print_result(result: dict[str, object], *, as_json: bool) -> None:
+    if as_json:
+        print(json.dumps(result, indent=2, sort_keys=True))
+        return
+    print(f"command: {result['command']}")
+    print(f"would_apply: {result['would_apply']}")
+    print(json.dumps(result["trade"], sort_keys=True))
+    print(json.dumps(result["state"], sort_keys=True))
+    for order in result["orders"]:
+        print(json.dumps(order, sort_keys=True))
+
+
+def _validate_ambiguous_attempt(
+    trade: Trade,
+    state: TakeProfitStageState,
+    attempt_id: str,
+) -> None:
+    if not attempt_id or "_" in attempt_id:
+        _fail("attempt-id must be non-empty and contain no underscore")
+    if state.blocked_reason is not None:
+        _fail(f"take-profit state is blocked: {state.blocked_reason}")
+    attempt = state.active_attempt
+    if (
+        attempt is None
+        or attempt.attempt_id != attempt_id
+        or attempt.status != "ambiguous"
+    ):
+        _fail("no matching ambiguous attempt")
+    parsed_tag = TakeProfitStageManager.parse_order_tag(attempt.tag)
+    if parsed_tag != (trade.trade_direction, attempt.stage, attempt.attempt_id):
+        _fail("active attempt tag does not match the trade")
+
+    reconciled_state = TakeProfitStageManager.reconcile(
+        trade,
+        state,
+        amount_quantizer=lambda amount: _quantize_trade_amount(trade, amount),
+    )
+    if reconciled_state != state:
+        _fail(
+            "database orders change the persisted state; restart normal reconciliation "
+            "or investigate the reported block before clearing anything"
+        )
+
+    recovery_deadline = datetime.datetime.fromisoformat(attempt.recovery_deadline)
+    if datetime.datetime.now(datetime.timezone.utc) < recovery_deadline:
+        _fail(f"ambiguous attempt cannot be cleared before {attempt.recovery_deadline}")
+
+
+def _clear_ambiguous(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    _validate_ambiguous_attempt(trade, state, args.attempt_id)
+    expected_confirmation = f"NO-ORDER:{trade.id}:{args.attempt_id}"
+    if not args.apply:
+        return _summary(
+            trade,
+            state,
+            command="clear-ambiguous",
+            would_apply=True,
+        )
+    if args.confirmation != expected_confirmation:
+        _fail(f"confirmation must be exactly {expected_confirmation!r}")
+
+    resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
+        state,
+        args.attempt_id,
+        datetime.datetime.now(datetime.timezone.utc),
+    )
+    trade.set_custom_data(
+        TakeProfitStageManager.STATE_KEY,
+        resolved_state.to_mapping(),
+    )
+    persisted_state = _load_state(trade)
+    if persisted_state != resolved_state:
+        _fail("take-profit state postcondition failed after commit")
+    return _summary(trade, persisted_state, command="clear-ambiguous")
+
+
+def _revalidate_terminal(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    if not args.order_id:
+        _fail("order-id must be non-empty")
+    expected_confirmation = f"RECONCILE:{trade.id}:{args.order_id}"
+    try:
+        resolved_state = TakeProfitStageManager.revalidate_unknown_terminal_fill(
+            trade,
+            state,
+            args.order_id,
+            datetime.datetime.now(datetime.timezone.utc),
+            amount_quantizer=lambda amount: _quantize_trade_amount(trade, amount),
+        )
+    except ValueError as error:
+        raise MaintenanceError(
+            f"terminal fill cannot be revalidated: {error}"
+        ) from error
+
+    if not args.apply:
+        return _summary(
+            trade,
+            state,
+            command="revalidate-terminal",
+            would_apply=True,
+        )
+    if args.confirmation != expected_confirmation:
+        _fail(f"confirmation must be exactly {expected_confirmation!r}")
+
+    trade.set_custom_data(
+        TakeProfitStageManager.STATE_KEY,
+        resolved_state.to_mapping(),
+    )
+    persisted_state = _load_state(trade)
+    if persisted_state != resolved_state:
+        _fail("take-profit state postcondition failed after commit")
+    return _summary(trade, persisted_state, command="revalidate-terminal")
+
+
+def _confirm_terminal_zero(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    if not args.order_id:
+        _fail("order-id must be non-empty")
+    expected_confirmation = f"NO-FILL:{trade.id}:{args.order_id}:{args.terminal_status}"
+    try:
+        resolved_state = TakeProfitStageManager.confirm_terminal_zero_fill(
+            trade,
+            state,
+            args.order_id,
+            args.terminal_status,
+            datetime.datetime.now(datetime.timezone.utc),
+            amount_quantizer=lambda amount: _quantize_trade_amount(trade, amount),
+        )
+    except ValueError as error:
+        raise MaintenanceError(
+            f"terminal zero fill cannot be confirmed: {error}"
+        ) from error
+
+    if not args.apply:
+        return _summary(
+            trade,
+            state,
+            command="confirm-terminal-zero",
+            would_apply=True,
+        )
+    if args.confirmation != expected_confirmation:
+        _fail(f"confirmation must be exactly {expected_confirmation!r}")
+
+    trade.set_custom_data(
+        TakeProfitStageManager.STATE_KEY,
+        resolved_state.to_mapping(),
+    )
+    persisted_state = _load_state(trade)
+    if persisted_state != resolved_state:
+        _fail("take-profit state postcondition failed after commit")
+    return _summary(trade, persisted_state, command="confirm-terminal-zero")
+
+
+def main(argv: Sequence[str] | None = None) -> int:
+    args = _parser().parse_args(argv)
+    try:
+        trade = _load_trade(args)
+        state = _load_state(trade)
+        if args.command == "inspect":
+            result = _summary(trade, state, command="inspect")
+        elif args.command == "clear-ambiguous":
+            result = _clear_ambiguous(args, trade, state)
+        elif args.command == "revalidate-terminal":
+            result = _revalidate_terminal(args, trade, state)
+        else:
+            result = _confirm_terminal_zero(args, trade, state)
+        _print_result(result, as_json=args.as_json)
+        return 0
+    except MaintenanceError as error:
+        if args.as_json:
+            print(json.dumps({"error": str(error)}, sort_keys=True), file=sys.stderr)
+        else:
+            print(f"error: {error}", file=sys.stderr)
+        return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/quickadapter/user_data/scripts/take_profit_maintenance.py
+++ b/quickadapter/user_data/scripts/take_profit_maintenance.py
@@ -6,9 +6,12 @@ history. Repair canonical Freqtrade order data before revalidating a terminal fi
 
 import argparse
 import datetime
+import hashlib
 import json
+import math
 import sys
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
+from dataclasses import replace
 from functools import partial
 from pathlib import Path
 from typing import NoReturn
@@ -23,6 +26,8 @@ STRATEGIES_DIR = Path(__file__).resolve().parents[1] / "strategies"
 sys.path.insert(0, str(STRATEGIES_DIR))
 
 from TakeProfitStageManager import (  # noqa: E402
+    TakeProfitRecoveryAction,
+    TakeProfitRecoveryInstruction,
     TakeProfitStageManager,
     TakeProfitStageState,
 )
@@ -69,6 +74,25 @@ def _parser() -> argparse.ArgumentParser:
     )
     zero_fill_parser.add_argument("--apply", action="store_true")
     zero_fill_parser.add_argument("--confirmation")
+    canceled_fill_parser = commands.add_parser(
+        "confirm-terminal-canceled",
+        help="Confirm an exact canceled positive-fill order after CEX verification",
+    )
+    canceled_fill_parser.add_argument("--order-id", required=True)
+    canceled_fill_parser.add_argument(
+        "--terminal-status",
+        required=True,
+        choices=("canceled", "cancelled"),
+    )
+    canceled_fill_parser.add_argument("--apply", action="store_true")
+    canceled_fill_parser.add_argument("--confirmation")
+    restore_partial_wallet_parser = commands.add_parser(
+        "restore-partial-wallet-mutation",
+        help="Restore native trade accounting for a bound terminal order",
+    )
+    restore_partial_wallet_parser.add_argument("--order-id", required=True)
+    restore_partial_wallet_parser.add_argument("--apply", action="store_true")
+    restore_partial_wallet_parser.add_argument("--confirmation")
     return parser
 
 
@@ -111,14 +135,10 @@ def _load_state(trade: Trade) -> TakeProfitStageState:
     if not isinstance(raw_state, dict):
         _fail("trade has no valid take-profit state mapping")
     try:
-        source_version = raw_state.get("version")
-        if isinstance(source_version, bool) or not isinstance(source_version, int):
-            raise ValueError("Take-profit state version must be an integer")
         state = TakeProfitStageState.from_mapping(raw_state)
-        return TakeProfitStageManager.reconcile_migrated_state(
+        return TakeProfitStageManager.reconcile(
             trade,
             state,
-            source_version,
             amount_quantizer=partial(_quantize_trade_amount, trade),
         )
     except ValueError as error:
@@ -127,19 +147,41 @@ def _load_state(trade: Trade) -> TakeProfitStageState:
 
 def _order_summary(order) -> dict[str, object]:
     return {
+        "database_id": order.id,
+        "trade_id": order.ft_trade_id,
         "order_id": order.order_id,
+        "pair": order.ft_pair,
         "tag": order.ft_order_tag,
         "side": order.ft_order_side,
+        "exchange_side": order.side,
         "status": order.status,
         "is_open": order.ft_is_open,
+        "type": order.order_type,
+        "symbol": order.symbol,
+        "cancel_reason": order.ft_cancel_reason,
+        "ft_amount": order.ft_amount,
+        "ft_price": order.ft_price,
         "amount": order.amount,
+        "safe_amount": order.safe_amount,
+        "safe_amount_after_fee": order.safe_amount_after_fee,
         "filled": order.filled,
         "remaining": order.remaining,
         "fee_base": order.ft_fee_base,
+        "price": order.price,
+        "average": order.average,
+        "stop_price": order.stop_price,
+        "safe_price": order.safe_price,
+        "cost": order.cost,
+        "funding_fee": order.funding_fee,
         "order_date": order.order_date_utc.isoformat(),
         "filled_date": (
             order.order_filled_utc.isoformat()
             if order.order_filled_utc is not None
+            else None
+        ),
+        "update_date": (
+            order.order_update_date.isoformat()
+            if order.order_update_date is not None
             else None
         ),
     }
@@ -152,6 +194,165 @@ def _quantize_trade_amount(trade: Trade, amount: float) -> float:
         trade.precision_mode,
         trade.contract_size,
     )
+
+
+def _recovery_confirmation_token(
+    trade: Trade,
+    state: TakeProfitStageState,
+    recovery: TakeProfitRecoveryInstruction,
+) -> str:
+    """Bind an operator confirmation to the complete inspected recovery evidence."""
+    prefixes = {
+        "confirm_terminal_canceled": "CANCELED-FILL",
+        "confirm_terminal_zero": "NO-FILL",
+        "restore_partial_wallet_mutation": "RESTORE-PARTIAL-WALLET",
+        "revalidate_terminal": "RECONCILE",
+    }
+    prefix = prefixes[recovery.action]
+    # Recalculated accounting outputs are intentionally absent so a token remains
+    # valid if the process stops after the first commit. The ordered source orders
+    # and stable calculation inputs below still bind the operation exactly.
+    evidence = {
+        "version": 1,
+        "instruction": {
+            "action": recovery.action,
+            "attempt_id": recovery.attempt_id,
+            "order_id": recovery.order_id,
+            "terminal_status": recovery.terminal_status,
+        },
+        "trade": {
+            "id": trade.id,
+            "pair": trade.pair,
+            "exchange": trade.exchange,
+            "strategy": trade.strategy,
+            "is_open": trade.is_open,
+            "is_short": trade.is_short,
+            "direction": trade.trade_direction,
+            "entry_side": trade.entry_side,
+            "exit_side": trade.exit_side,
+            "trading_mode": getattr(
+                trade.trading_mode,
+                "value",
+                trade.trading_mode,
+            ),
+            "leverage": trade.leverage,
+            "fee_open": trade.fee_open,
+            "fee_close": trade.fee_close,
+            "amount_precision": trade.amount_precision,
+            "precision_mode": trade.precision_mode,
+            "contract_size": trade.contract_size,
+            "price_precision": trade.price_precision,
+            "precision_mode_price": trade.precision_mode_price,
+            "stop_loss_pct": trade.stop_loss_pct,
+        },
+        "state": state.to_mapping(),
+        "orders": [
+            {"sequence": sequence, **_order_summary(order)}
+            for sequence, order in enumerate(trade.orders)
+        ],
+    }
+    try:
+        canonical_evidence = json.dumps(
+            evidence,
+            allow_nan=False,
+            separators=(",", ":"),
+            sort_keys=True,
+        ).encode()
+    except (TypeError, ValueError) as error:
+        raise MaintenanceError(
+            "recovery evidence cannot be represented canonically"
+        ) from error
+    digest = hashlib.sha256(canonical_evidence).hexdigest()
+    token_parts = [prefix, str(trade.id)]
+    if recovery.attempt_id is not None:
+        token_parts.append(recovery.attempt_id)
+    token_parts.append(recovery.order_id)
+    if recovery.terminal_status is not None:
+        token_parts.append(recovery.terminal_status)
+    token_parts.extend(("v1", digest))
+    return ":".join(token_parts)
+
+
+def _require_recovery_instruction(
+    trade: Trade,
+    state: TakeProfitStageState,
+    *,
+    action: TakeProfitRecoveryAction,
+    order_id: str,
+    terminal_status: str | None = None,
+) -> TakeProfitRecoveryInstruction:
+    recovery = TakeProfitStageManager.get_recovery_instruction(
+        trade,
+        state,
+        amount_quantizer=partial(_quantize_trade_amount, trade),
+    )
+    if (
+        recovery is None
+        or recovery.action != action
+        or recovery.order_id != order_id
+        or (
+            terminal_status is not None
+            and recovery.terminal_status != terminal_status.lower()
+        )
+    ):
+        _fail("canonical evidence does not support the requested recovery")
+    return recovery
+
+
+def _require_current_confirmation(
+    supplied_confirmation: str | None,
+    expected_confirmation: str,
+) -> None:
+    if supplied_confirmation != expected_confirmation:
+        _fail("confirmation is stale or invalid; rerun inspect")
+
+
+def _require_replayable_recalculation(trade: Trade) -> None:
+    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
+    if trading_mode == "margin":
+        _fail(
+            "automatic order recalculation is not replay-safe in margin mode; "
+            "automatic state recovery is unavailable; reconcile and close the "
+            "position manually"
+        )
+
+
+def _validate_state_roundtrip(state: TakeProfitStageState) -> dict[str, object]:
+    payload = state.to_mapping()
+    try:
+        validated_state = TakeProfitStageState.from_mapping(payload)
+    except ValueError as error:
+        raise MaintenanceError(
+            f"take-profit state failed round-trip validation: {error}"
+        ) from error
+    if validated_state != state or validated_state.to_mapping() != payload:
+        _fail("take-profit state failed full round-trip validation")
+    return payload
+
+
+def _persist_state(
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> TakeProfitStageState:
+    """Prevalidate the complete payload before the only custom-state write."""
+    payload = _validate_state_roundtrip(state)
+    try:
+        trade.set_custom_data(TakeProfitStageManager.STATE_KEY, payload)
+        persisted_payload = trade.get_custom_data(TakeProfitStageManager.STATE_KEY)
+        if persisted_payload != payload:
+            _fail("take-profit state persistence verification failed")
+        persisted_state = _load_state(trade)
+        if persisted_state != state:
+            _fail("take-profit state postcondition failed after commit")
+        return persisted_state
+    except MaintenanceError:
+        Trade.session.rollback()
+        raise
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            "take-profit state persistence failed; inspect the trade before retrying"
+        ) from error
 
 
 def _summary(
@@ -172,12 +373,34 @@ def _summary(
         state,
         amount_quantizer=amount_quantizer,
     )
-    blocked_order = next(
-        (order for order in trade.orders if order.order_id == state.blocked_order_id),
-        None,
+    recovery = TakeProfitStageManager.get_recovery_instruction(
+        trade,
+        state,
+        amount_quantizer=amount_quantizer,
     )
-    zero_fill_status = (
-        (blocked_order.status or "").lower() if blocked_order is not None else None
+    clearable_attempt = (
+        attempt
+        if attempt is not None
+        and attempt.status == "ambiguous"
+        and recovery is None
+        and (
+            state.blocked_reason is None
+            or (
+                state.blocked_reason == "partial_wallet_mutation"
+                and state.partial_wallet_mutation is not None
+                and state.partial_wallet_mutation.order_id is None
+                and state.partial_wallet_mutation.attempt_id == attempt.attempt_id
+            )
+        )
+        and (
+            state.partial_wallet_mutation is None
+            or state.partial_wallet_mutation.order_id is None
+        )
+        else None
+    )
+    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
+    requires_margin_recalculation = (
+        trading_mode == "margin" and state.partial_wallet_mutation is not None
     )
     return {
         "command": command,
@@ -197,28 +420,44 @@ def _summary(
             "blocked_order_id": state.blocked_order_id,
             "active_attempt": attempt.to_mapping() if attempt is not None else None,
             "clear_eligible_at": (
-                attempt.recovery_deadline
-                if attempt is not None and attempt.status == "ambiguous"
+                clearable_attempt.recovery_deadline
+                if clearable_attempt is not None
                 else None
             ),
             "required_clear_confirmation": (
-                f"NO-ORDER:{trade.id}:{attempt.attempt_id}"
-                if attempt is not None and attempt.status == "ambiguous"
+                f"NO-ORDER:{trade.id}:{clearable_attempt.attempt_id}"
+                if clearable_attempt is not None and not requires_margin_recalculation
                 else None
             ),
             "required_revalidation_confirmation": (
-                f"RECONCILE:{trade.id}:{state.blocked_order_id}"
-                if state.blocked_reason
-                in {"unknown_terminal_fill", "unattributed_exit_fill"}
-                and state.blocked_order_id is not None
+                _recovery_confirmation_token(trade, state, recovery)
+                if recovery is not None and recovery.action == "revalidate_terminal"
                 else None
             ),
             "required_zero_fill_confirmation": (
-                f"NO-FILL:{trade.id}:{state.blocked_order_id}:{zero_fill_status}"
-                if state.blocked_reason
-                in {"unknown_terminal_fill", "unknown_external_exit_fill"}
-                and state.blocked_order_id is not None
-                and zero_fill_status in {"canceled", "cancelled"}
+                _recovery_confirmation_token(trade, state, recovery)
+                if recovery is not None
+                and recovery.action == "confirm_terminal_zero"
+                and not requires_margin_recalculation
+                else None
+            ),
+            "required_canceled_fill_confirmation": (
+                _recovery_confirmation_token(trade, state, recovery)
+                if recovery is not None
+                and recovery.action == "confirm_terminal_canceled"
+                and not requires_margin_recalculation
+                else None
+            ),
+            "required_partial_wallet_restoration_confirmation": (
+                _recovery_confirmation_token(trade, state, recovery)
+                if recovery is not None
+                and recovery.action == "restore_partial_wallet_mutation"
+                and not requires_margin_recalculation
+                else None
+            ),
+            "recovery_blocked_reason": (
+                "margin_recalculation_not_replay_safe"
+                if requires_margin_recalculation
                 else None
             ),
             "ledger": {
@@ -236,12 +475,20 @@ def _summary(
                     for adjustment in state.exposure_adjustments
                     if adjustment.is_active
                 ),
+                "compacted_exposure_adjustment_count": (
+                    state.compacted_exposure_adjustment_count
+                ),
+                "compacted_exposure_adjustment_amount": (
+                    state.compacted_exposure_adjustment_amount
+                ),
                 "stage_targets": [
                     {"stage": stage, "amount": amount}
                     for stage, amount in state.stage_targets
                 ],
                 "deferred_stages": list(state.deferred_stages),
-                "attributed_order_ids": list(state.attributed_order_ids),
+                "order_attributions": [
+                    attribution.to_mapping() for attribution in state.order_attributions
+                ],
                 "credited_order_amounts": [
                     {"order_id": order_id, "amount": amount}
                     for order_id, amount in state.credited_order_amounts
@@ -260,16 +507,20 @@ def _summary(
                 "confirmed_zero_fill_orders": [
                     proof.to_mapping() for proof in state.confirmed_zero_fill_orders
                 ],
+                "confirmed_canceled_fill_orders": [
+                    proof.to_mapping() for proof in state.confirmed_canceled_fill_orders
+                ],
+                "partial_wallet_mutation": (
+                    state.partial_wallet_mutation.to_mapping()
+                    if state.partial_wallet_mutation is not None
+                    else None
+                ),
             },
             "operator_resolutions": [
                 resolution.to_mapping() for resolution in state.operator_resolutions
             ],
         },
-        "orders": [
-            _order_summary(order)
-            for order in trade.orders
-            if order.ft_order_side != trade.entry_side
-        ],
+        "orders": [_order_summary(order) for order in trade.orders],
     }
 
 
@@ -290,9 +541,23 @@ def _validate_ambiguous_attempt(
     state: TakeProfitStageState,
     attempt_id: str,
 ) -> None:
-    if not attempt_id or "_" in attempt_id:
-        _fail("attempt-id must be non-empty and contain no underscore")
-    if state.blocked_reason is not None:
+    if not attempt_id:
+        _fail("attempt-id must be non-empty")
+    partial_wallet_mutation = state.partial_wallet_mutation
+    if (
+        partial_wallet_mutation is not None
+        and partial_wallet_mutation.order_id is not None
+    ):
+        _fail(
+            "ambiguous attempt is bound to a canonical order; use the terminal "
+            "recovery action reported by inspect"
+        )
+    has_recoverable_partial_wallet_mutation = (
+        state.blocked_reason == "partial_wallet_mutation"
+        and partial_wallet_mutation is not None
+        and partial_wallet_mutation.attempt_id == attempt_id
+    )
+    if state.blocked_reason is not None and not has_recoverable_partial_wallet_mutation:
         _fail(f"take-profit state is blocked: {state.blocked_reason}")
     attempt = state.active_attempt
     if (
@@ -302,7 +567,7 @@ def _validate_ambiguous_attempt(
     ):
         _fail("no matching ambiguous attempt")
     parsed_tag = TakeProfitStageManager.parse_order_tag(attempt.tag)
-    if parsed_tag != (trade.trade_direction, attempt.stage, attempt.attempt_id):
+    if parsed_tag != (trade.trade_direction, attempt.stage):
         _fail("active attempt tag does not match the trade")
 
     reconciled_state = TakeProfitStageManager.reconcile(
@@ -327,6 +592,9 @@ def _clear_ambiguous(
     state: TakeProfitStageState,
 ) -> dict[str, object]:
     _validate_ambiguous_attempt(trade, state, args.attempt_id)
+    partial_wallet_mutation = state.partial_wallet_mutation
+    if partial_wallet_mutation is not None:
+        _require_replayable_recalculation(trade)
     expected_confirmation = f"NO-ORDER:{trade.id}:{args.attempt_id}"
     if not args.apply:
         return _summary(
@@ -338,18 +606,72 @@ def _clear_ambiguous(
     if args.confirmation != expected_confirmation:
         _fail(f"confirmation must be exactly {expected_confirmation!r}")
 
-    resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
-        state,
-        args.attempt_id,
-        datetime.datetime.now(datetime.timezone.utc),
-    )
-    trade.set_custom_data(
-        TakeProfitStageManager.STATE_KEY,
-        resolved_state.to_mapping(),
-    )
-    persisted_state = _load_state(trade)
-    if persisted_state != resolved_state:
-        _fail("take-profit state postcondition failed after commit")
+    try:
+        candidate_state = state
+        if partial_wallet_mutation is not None:
+            trade.recalc_trade_from_orders()
+            _validate_ambiguous_attempt(trade, state, args.attempt_id)
+            observed_amount = _quantize_trade_amount(trade, trade.amount)
+            expected_amount = _quantize_trade_amount(
+                trade,
+                partial_wallet_mutation.expected_trade_amount,
+            )
+            if not math.isclose(
+                observed_amount,
+                expected_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            ):
+                _fail(
+                    "recalculated trade amount does not restore the partial "
+                    "wallet mutation baseline"
+                )
+            candidate_state = replace(
+                state,
+                partial_wallet_mutation=None,
+                blocked_reason=None,
+                blocked_order_id=None,
+            )
+        candidate_state = TakeProfitStageManager.reconcile(
+            trade,
+            candidate_state,
+            amount_quantizer=partial(_quantize_trade_amount, trade),
+        )
+        if candidate_state.blocked_reason is not None:
+            _fail(
+                "recalculated trade does not validate before ambiguity resolution: "
+                f"{candidate_state.blocked_reason}"
+            )
+        resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
+            candidate_state,
+            args.attempt_id,
+            datetime.datetime.now(datetime.timezone.utc),
+        )
+        resolved_state = TakeProfitStageManager.reconcile(
+            trade,
+            resolved_state,
+            amount_quantizer=partial(_quantize_trade_amount, trade),
+        )
+        if resolved_state.blocked_reason is not None:
+            _fail(
+                "recalculated trade does not validate after ambiguity resolution: "
+                f"{resolved_state.blocked_reason}"
+            )
+        _validate_state_roundtrip(resolved_state)
+    except MaintenanceError:
+        Trade.session.rollback()
+        raise
+    except ValueError as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            f"ambiguous attempt cannot be cleared: {error}"
+        ) from error
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError("failed to prepare ambiguity resolution") from error
+    if partial_wallet_mutation is not None:
+        _commit_recalculated_trade()
+    persisted_state = _persist_state(trade, resolved_state)
     return _summary(trade, persisted_state, command="clear-ambiguous")
 
 
@@ -360,7 +682,15 @@ def _revalidate_terminal(
 ) -> dict[str, object]:
     if not args.order_id:
         _fail("order-id must be non-empty")
-    expected_confirmation = f"RECONCILE:{trade.id}:{args.order_id}"
+    recovery = _require_recovery_instruction(
+        trade,
+        state,
+        action="revalidate_terminal",
+        order_id=args.order_id,
+    )
+    expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
+    if args.apply:
+        _require_current_confirmation(args.confirmation, expected_confirmation)
     try:
         resolved_state = TakeProfitStageManager.revalidate_unknown_terminal_fill(
             trade,
@@ -381,16 +711,7 @@ def _revalidate_terminal(
             command="revalidate-terminal",
             would_apply=True,
         )
-    if args.confirmation != expected_confirmation:
-        _fail(f"confirmation must be exactly {expected_confirmation!r}")
-
-    trade.set_custom_data(
-        TakeProfitStageManager.STATE_KEY,
-        resolved_state.to_mapping(),
-    )
-    persisted_state = _load_state(trade)
-    if persisted_state != resolved_state:
-        _fail("take-profit state postcondition failed after commit")
+    persisted_state = _persist_state(trade, resolved_state)
     return _summary(trade, persisted_state, command="revalidate-terminal")
 
 
@@ -399,41 +720,193 @@ def _confirm_terminal_zero(
     trade: Trade,
     state: TakeProfitStageState,
 ) -> dict[str, object]:
+    return _confirm_terminal(
+        args,
+        trade,
+        state,
+        command="confirm-terminal-zero",
+        recovery_action="confirm_terminal_zero",
+        failure_label="terminal zero fill",
+        confirm=TakeProfitStageManager.confirm_terminal_zero_fill,
+        validate=TakeProfitStageManager.validate_terminal_zero_fill_confirmation,
+    )
+
+
+def _confirm_terminal_canceled(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    return _confirm_terminal(
+        args,
+        trade,
+        state,
+        command="confirm-terminal-canceled",
+        recovery_action="confirm_terminal_canceled",
+        failure_label="terminal canceled fill",
+        confirm=TakeProfitStageManager.confirm_terminal_canceled_fill,
+        validate=(TakeProfitStageManager.validate_terminal_canceled_fill_confirmation),
+    )
+
+
+def _confirm_terminal(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+    *,
+    command: str,
+    recovery_action: str,
+    failure_label: str,
+    confirm: Callable[..., TakeProfitStageState],
+    validate: Callable[..., None],
+) -> dict[str, object]:
     if not args.order_id:
         _fail("order-id must be non-empty")
-    expected_confirmation = f"NO-FILL:{trade.id}:{args.order_id}:{args.terminal_status}"
+    recovery = _require_recovery_instruction(
+        trade,
+        state,
+        action=recovery_action,
+        order_id=args.order_id,
+        terminal_status=args.terminal_status,
+    )
+    expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
+    bound_mutation = state.partial_wallet_mutation
+    requires_trade_recalculation = (
+        bound_mutation is not None and bound_mutation.order_id == args.order_id
+    )
+    if requires_trade_recalculation:
+        _require_replayable_recalculation(trade)
+    if args.apply:
+        _require_current_confirmation(args.confirmation, expected_confirmation)
+    resolved_at = datetime.datetime.now(datetime.timezone.utc)
+    amount_quantizer = partial(_quantize_trade_amount, trade)
     try:
-        resolved_state = TakeProfitStageManager.confirm_terminal_zero_fill(
+        if requires_trade_recalculation and not args.apply:
+            validate(
+                trade,
+                state,
+                args.order_id,
+                args.terminal_status,
+                resolved_at,
+                amount_quantizer=amount_quantizer,
+            )
+            return _summary(
+                trade,
+                state,
+                command=command,
+                would_apply=True,
+            )
+        if requires_trade_recalculation:
+            trade.recalc_trade_from_orders()
+        resolved_state = confirm(
             trade,
             state,
             args.order_id,
             args.terminal_status,
-            datetime.datetime.now(datetime.timezone.utc),
-            amount_quantizer=lambda amount: _quantize_trade_amount(trade, amount),
+            resolved_at,
+            amount_quantizer=amount_quantizer,
         )
+        _validate_state_roundtrip(resolved_state)
     except ValueError as error:
+        Trade.session.rollback()
         raise MaintenanceError(
-            f"terminal zero fill cannot be confirmed: {error}"
+            f"{failure_label} cannot be confirmed: {error}"
         ) from error
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError(f"failed to prepare {failure_label} recovery") from error
 
     if not args.apply:
         return _summary(
             trade,
             state,
-            command="confirm-terminal-zero",
+            command=command,
             would_apply=True,
         )
-    if args.confirmation != expected_confirmation:
-        _fail(f"confirmation must be exactly {expected_confirmation!r}")
+    if requires_trade_recalculation:
+        _commit_recalculated_trade()
 
-    trade.set_custom_data(
-        TakeProfitStageManager.STATE_KEY,
-        resolved_state.to_mapping(),
+    persisted_state = _persist_state(trade, resolved_state)
+    return _summary(trade, persisted_state, command=command)
+
+
+def _commit_recalculated_trade() -> None:
+    try:
+        Trade.commit()
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            "failed to commit recalculated canonical trade accounting"
+        ) from error
+
+
+def _restore_partial_wallet_mutation(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    if not args.order_id:
+        _fail("order-id must be non-empty")
+    mutation = state.partial_wallet_mutation
+    if mutation is None or mutation.order_id != args.order_id:
+        _fail("no matching bound partial-wallet mutation")
+    _require_replayable_recalculation(trade)
+    recovery = _require_recovery_instruction(
+        trade,
+        state,
+        action="restore_partial_wallet_mutation",
+        order_id=args.order_id,
     )
-    persisted_state = _load_state(trade)
-    if persisted_state != resolved_state:
-        _fail("take-profit state postcondition failed after commit")
-    return _summary(trade, persisted_state, command="confirm-terminal-zero")
+    expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
+    if args.apply:
+        _require_current_confirmation(args.confirmation, expected_confirmation)
+    amount_quantizer = partial(_quantize_trade_amount, trade)
+    if not args.apply:
+        try:
+            TakeProfitStageManager.validate_partial_wallet_mutation_restoration(
+                trade,
+                state,
+                args.order_id,
+                amount_quantizer=amount_quantizer,
+            )
+        except ValueError as error:
+            raise MaintenanceError(
+                f"partial-wallet mutation cannot be restored: {error}"
+            ) from error
+        return _summary(
+            trade,
+            state,
+            command="restore-partial-wallet-mutation",
+            would_apply=True,
+        )
+
+    try:
+        trade.recalc_trade_from_orders()
+        resolved_state = TakeProfitStageManager.restore_partial_wallet_mutation(
+            trade,
+            state,
+            args.order_id,
+            datetime.datetime.now(datetime.timezone.utc),
+            amount_quantizer=amount_quantizer,
+        )
+        _validate_state_roundtrip(resolved_state)
+    except ValueError as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            f"partial-wallet mutation cannot be restored: {error}"
+        ) from error
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            "failed to prepare partial-wallet mutation restoration"
+        ) from error
+    _commit_recalculated_trade()
+    persisted_state = _persist_state(trade, resolved_state)
+    return _summary(
+        trade,
+        persisted_state,
+        command="restore-partial-wallet-mutation",
+    )
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -447,8 +920,12 @@ def main(argv: Sequence[str] | None = None) -> int:
             result = _clear_ambiguous(args, trade, state)
         elif args.command == "revalidate-terminal":
             result = _revalidate_terminal(args, trade, state)
-        else:
+        elif args.command == "confirm-terminal-zero":
             result = _confirm_terminal_zero(args, trade, state)
+        elif args.command == "confirm-terminal-canceled":
+            result = _confirm_terminal_canceled(args, trade, state)
+        else:
+            result = _restore_partial_wallet_mutation(args, trade, state)
         _print_result(result, as_json=args.as_json)
         return 0
     except MaintenanceError as error:

--- a/quickadapter/user_data/scripts/take_profit_maintenance.py
+++ b/quickadapter/user_data/scripts/take_profit_maintenance.py
@@ -5,6 +5,7 @@ history. Repair canonical Freqtrade order data before revalidating a terminal fi
 """
 
 import argparse
+import copy
 import datetime
 import hashlib
 import json
@@ -33,6 +34,9 @@ from TakeProfitStageManager import (  # noqa: E402
 )
 
 
+_CONFIRMATION_VERSION = 1
+
+
 class MaintenanceError(RuntimeError):
     """Refuse an unsafe or inconsistent maintenance request."""
 
@@ -56,14 +60,20 @@ def _parser() -> argparse.ArgumentParser:
     clear_parser.add_argument("--apply", action="store_true")
     clear_parser.add_argument("--confirmation")
     revalidate_parser = commands.add_parser(
-        "revalidate-terminal",
+        "revalidate-terminal-order",
         help="Reconcile a repaired canonical terminal order",
     )
     revalidate_parser.add_argument("--order-id", required=True)
     revalidate_parser.add_argument("--apply", action="store_true")
     revalidate_parser.add_argument("--confirmation")
+    revalidate_state_parser = commands.add_parser(
+        "revalidate-state",
+        help="Clear an eligible block after the complete state was repaired",
+    )
+    revalidate_state_parser.add_argument("--apply", action="store_true")
+    revalidate_state_parser.add_argument("--confirmation")
     zero_fill_parser = commands.add_parser(
-        "confirm-terminal-zero",
+        "confirm-terminal-zero-fill",
         help="Confirm an exact canceled zero-fill order after CEX verification",
     )
     zero_fill_parser.add_argument("--order-id", required=True)
@@ -75,7 +85,7 @@ def _parser() -> argparse.ArgumentParser:
     zero_fill_parser.add_argument("--apply", action="store_true")
     zero_fill_parser.add_argument("--confirmation")
     canceled_fill_parser = commands.add_parser(
-        "confirm-terminal-canceled",
+        "confirm-terminal-canceled-fill",
         help="Confirm an exact canceled positive-fill order after CEX verification",
     )
     canceled_fill_parser.add_argument("--order-id", required=True)
@@ -86,13 +96,6 @@ def _parser() -> argparse.ArgumentParser:
     )
     canceled_fill_parser.add_argument("--apply", action="store_true")
     canceled_fill_parser.add_argument("--confirmation")
-    restore_partial_wallet_parser = commands.add_parser(
-        "restore-partial-wallet-mutation",
-        help="Restore native trade accounting for a bound terminal order",
-    )
-    restore_partial_wallet_parser.add_argument("--order-id", required=True)
-    restore_partial_wallet_parser.add_argument("--apply", action="store_true")
-    restore_partial_wallet_parser.add_argument("--confirmation")
     return parser
 
 
@@ -125,8 +128,6 @@ def _load_trade(args: argparse.Namespace) -> Trade:
         _fail("trade pair does not match expected-pair")
     if trade.strategy != "QuickAdapterV3":
         _fail("trade does not belong to QuickAdapterV3")
-    if not trade.is_open:
-        _fail("trade is not open")
     return trade
 
 
@@ -187,6 +188,71 @@ def _order_summary(order) -> dict[str, object]:
     }
 
 
+def _confirmation_trade_summary(trade: Trade) -> dict[str, object]:
+    """Return the raw trade fields that can affect recovery or accounting."""
+    return {
+        "id": trade.id,
+        "exchange": trade.exchange,
+        "pair": trade.pair,
+        "base_currency": trade.base_currency,
+        "stake_currency": trade.stake_currency,
+        "is_open": trade.is_open,
+        "fee_open": trade.fee_open,
+        "fee_open_cost": trade.fee_open_cost,
+        "fee_open_currency": trade.fee_open_currency,
+        "fee_close": trade.fee_close,
+        "fee_close_cost": trade.fee_close_cost,
+        "fee_close_currency": trade.fee_close_currency,
+        "open_rate": trade.open_rate,
+        "open_rate_requested": trade.open_rate_requested,
+        "open_trade_value": trade.open_trade_value,
+        "close_rate": trade.close_rate,
+        "close_rate_requested": trade.close_rate_requested,
+        "realized_profit": trade.realized_profit,
+        "close_profit": trade.close_profit,
+        "close_profit_abs": trade.close_profit_abs,
+        "stake_amount": trade.stake_amount,
+        "max_stake_amount": trade.max_stake_amount,
+        "amount": trade.amount,
+        "amount_requested": trade.amount_requested,
+        "open_date": trade.open_date_utc.isoformat(),
+        "close_date": (
+            trade.close_date_utc.isoformat()
+            if trade.close_date_utc is not None
+            else None
+        ),
+        "stop_loss": trade.stop_loss,
+        "stop_loss_pct": trade.stop_loss_pct,
+        "initial_stop_loss": trade.initial_stop_loss,
+        "initial_stop_loss_pct": trade.initial_stop_loss_pct,
+        "is_stop_loss_trailing": trade.is_stop_loss_trailing,
+        "max_rate": trade.max_rate,
+        "min_rate": trade.min_rate,
+        "exit_reason": trade.exit_reason,
+        "exit_order_status": trade.exit_order_status,
+        "strategy": trade.strategy,
+        "enter_tag": trade.enter_tag,
+        "timeframe": trade.timeframe,
+        "trading_mode": getattr(
+            trade.trading_mode,
+            "value",
+            trade.trading_mode,
+        ),
+        "amount_precision": trade.amount_precision,
+        "price_precision": trade.price_precision,
+        "precision_mode": trade.precision_mode,
+        "precision_mode_price": trade.precision_mode_price,
+        "contract_size": trade.contract_size,
+        "leverage": trade.leverage,
+        "is_short": trade.is_short,
+        "liquidation_price": trade.liquidation_price,
+        "interest_rate": trade.interest_rate,
+        "funding_fees": trade.funding_fees,
+        "funding_fee_running": trade.funding_fee_running,
+        "record_version": trade.record_version,
+    }
+
+
 def _quantize_trade_amount(trade: Trade, amount: float) -> float:
     return amount_to_contract_precision(
         amount,
@@ -196,55 +262,37 @@ def _quantize_trade_amount(trade: Trade, amount: float) -> float:
     )
 
 
-def _recovery_confirmation_token(
+def _finite_number(value: object, label: str) -> float:
+    if isinstance(value, bool):
+        _fail(f"{label} is not a finite number")
+    try:
+        number = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise MaintenanceError(f"{label} is not a finite number") from error
+    if not math.isfinite(number):
+        _fail(f"{label} is not a finite number")
+    return number
+
+
+def _positive_number(value: object, label: str) -> float:
+    number = _finite_number(value, label)
+    if number <= 0.0:
+        _fail(f"{label} must be positive")
+    return number
+
+
+def _evidence_confirmation_token(
+    *,
+    prefix: str,
+    token_parts: Sequence[str],
     trade: Trade,
     state: TakeProfitStageState,
-    recovery: TakeProfitRecoveryInstruction,
+    instruction: dict[str, object],
 ) -> str:
-    """Bind an operator confirmation to the complete inspected recovery evidence."""
-    prefixes = {
-        "confirm_terminal_canceled": "CANCELED-FILL",
-        "confirm_terminal_zero": "NO-FILL",
-        "restore_partial_wallet_mutation": "RESTORE-PARTIAL-WALLET",
-        "revalidate_terminal": "RECONCILE",
-    }
-    prefix = prefixes[recovery.action]
-    # Recalculated accounting outputs are intentionally absent so a token remains
-    # valid if the process stops after the first commit. The ordered source orders
-    # and stable calculation inputs below still bind the operation exactly.
     evidence = {
-        "version": 1,
-        "instruction": {
-            "action": recovery.action,
-            "attempt_id": recovery.attempt_id,
-            "order_id": recovery.order_id,
-            "terminal_status": recovery.terminal_status,
-        },
-        "trade": {
-            "id": trade.id,
-            "pair": trade.pair,
-            "exchange": trade.exchange,
-            "strategy": trade.strategy,
-            "is_open": trade.is_open,
-            "is_short": trade.is_short,
-            "direction": trade.trade_direction,
-            "entry_side": trade.entry_side,
-            "exit_side": trade.exit_side,
-            "trading_mode": getattr(
-                trade.trading_mode,
-                "value",
-                trade.trading_mode,
-            ),
-            "leverage": trade.leverage,
-            "fee_open": trade.fee_open,
-            "fee_close": trade.fee_close,
-            "amount_precision": trade.amount_precision,
-            "precision_mode": trade.precision_mode,
-            "contract_size": trade.contract_size,
-            "price_precision": trade.price_precision,
-            "precision_mode_price": trade.precision_mode_price,
-            "stop_loss_pct": trade.stop_loss_pct,
-        },
+        "version": _CONFIRMATION_VERSION,
+        "instruction": instruction,
+        "trade": _confirmation_trade_summary(trade),
         "state": state.to_mapping(),
         "orders": [
             {"sequence": sequence, **_order_summary(order)}
@@ -263,14 +311,58 @@ def _recovery_confirmation_token(
             "recovery evidence cannot be represented canonically"
         ) from error
     digest = hashlib.sha256(canonical_evidence).hexdigest()
-    token_parts = [prefix, str(trade.id)]
-    if recovery.attempt_id is not None:
-        token_parts.append(recovery.attempt_id)
-    token_parts.append(recovery.order_id)
+    return ":".join((prefix, *token_parts, f"v{_CONFIRMATION_VERSION}", digest))
+
+
+def _recovery_confirmation_token(
+    trade: Trade,
+    state: TakeProfitStageState,
+    recovery: TakeProfitRecoveryInstruction,
+) -> str:
+    """Bind an operator confirmation to the complete inspected recovery evidence."""
+    prefixes = {
+        "confirm_terminal_canceled_fill": "CANCELED-FILL",
+        "confirm_terminal_zero_fill": "ZERO-FILL",
+        "revalidate_state": "REVALIDATE-STATE",
+        "revalidate_terminal_order": "REVALIDATE-ORDER",
+    }
+    prefix = prefixes[recovery.action]
+    token_parts = [str(trade.id)]
+    if recovery.order_id is not None:
+        token_parts.append(recovery.order_id)
     if recovery.terminal_status is not None:
         token_parts.append(recovery.terminal_status)
-    token_parts.extend(("v1", digest))
-    return ":".join(token_parts)
+    return _evidence_confirmation_token(
+        prefix=prefix,
+        token_parts=token_parts,
+        trade=trade,
+        state=state,
+        instruction={
+            "action": recovery.action,
+            "expected_trade_amount": recovery.expected_trade_amount,
+            "order_id": recovery.order_id,
+            "terminal_status": recovery.terminal_status,
+            "trade_accounting_action": recovery.trade_accounting_action,
+        },
+    )
+
+
+def _ambiguous_confirmation_token(
+    trade: Trade,
+    state: TakeProfitStageState,
+    attempt_id: str,
+) -> str:
+    return _evidence_confirmation_token(
+        prefix="NO-ORDER",
+        token_parts=(str(trade.id), attempt_id),
+        trade=trade,
+        state=state,
+        instruction={
+            "action": "clear_ambiguous",
+            "attempt_id": attempt_id,
+            "trade_accounting_action": "none",
+        },
+    )
 
 
 def _require_recovery_instruction(
@@ -278,7 +370,7 @@ def _require_recovery_instruction(
     state: TakeProfitStageState,
     *,
     action: TakeProfitRecoveryAction,
-    order_id: str,
+    order_id: str | None = None,
     terminal_status: str | None = None,
 ) -> TakeProfitRecoveryInstruction:
     recovery = TakeProfitStageManager.get_recovery_instruction(
@@ -286,6 +378,8 @@ def _require_recovery_instruction(
         state,
         amount_quantizer=partial(_quantize_trade_amount, trade),
     )
+    if recovery is not None:
+        recovery = _effective_recovery_instruction(trade, recovery)
     if (
         recovery is None
         or recovery.action != action
@@ -296,7 +390,23 @@ def _require_recovery_instruction(
         )
     ):
         _fail("canonical evidence does not support the requested recovery")
+    blocked_reason = _automatic_accounting_block_reason(trade, state, recovery)
+    if blocked_reason is not None:
+        try:
+            _validate_trade_accounting_recovery(trade, recovery)
+        except MaintenanceError as error:
+            _fail(f"automatic recovery is unavailable: {blocked_reason}: {error}")
+        _fail(f"automatic recovery is unavailable: {blocked_reason}")
     return recovery
+
+
+def _validate_trade_lifecycle_for_command(
+    args: argparse.Namespace,
+    trade: Trade,
+) -> None:
+    if trade.is_open or args.command == "inspect":
+        return
+    _fail("closed trades are inspect-only; no take-profit state recovery is required")
 
 
 def _require_current_confirmation(
@@ -307,14 +417,365 @@ def _require_current_confirmation(
         _fail("confirmation is stale or invalid; rerun inspect")
 
 
-def _require_replayable_recalculation(trade: Trade) -> None:
+def _require_spot_accounting_recalculation(trade: Trade) -> None:
     trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
-    if trading_mode == "margin":
+    if trading_mode != "spot":
         _fail(
-            "automatic order recalculation is not replay-safe in margin mode; "
-            "automatic state recovery is unavailable; reconcile and close the "
-            "position manually"
+            "offline trade-accounting recalculation is supported only in spot mode; "
+            "use the native Freqtrade lifecycle for futures or margin"
         )
+
+
+def _recovery_order(
+    trade: Trade,
+    recovery: TakeProfitRecoveryInstruction,
+):
+    if recovery.order_id is None:
+        _fail("trade-accounting recovery has no canonical order")
+    matching_orders = [
+        order for order in trade.orders if order.order_id == recovery.order_id
+    ]
+    if len(matching_orders) != 1:
+        _fail("trade-accounting recovery order is not unique")
+    return matching_orders[0]
+
+
+def _validate_recalculation_sources(trade: Trade) -> None:
+    for order in trade.orders:
+        if order.ft_is_open or not order.filled:
+            continue
+        _positive_number(
+            order.safe_price,
+            f"filled order {order.order_id!r} price",
+        )
+
+
+def _validate_funding_accounting(trade: Trade) -> None:
+    filled_order_funding_fees = []
+    for order in trade.orders:
+        funding_fee = _finite_number(order.funding_fee or 0.0, "order funding fee")
+        if order.ft_is_open or not order.filled:
+            if not math.isclose(funding_fee, 0.0, rel_tol=1e-9, abs_tol=1e-12):
+                _fail("open and zero-fill orders cannot contain funding fees")
+            continue
+        filled_order_funding_fees.append(funding_fee)
+    running_funding_fee = _finite_number(
+        trade.funding_fee_running or 0.0,
+        "running trade funding fee",
+    )
+    observed_funding_fees = _finite_number(
+        trade.funding_fees or 0.0,
+        "trade funding fees",
+    )
+    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
+    if trading_mode != "futures" and any(
+        not math.isclose(value, 0.0, rel_tol=1e-9, abs_tol=1e-12)
+        for value in (
+            *filled_order_funding_fees,
+            running_funding_fee,
+            observed_funding_fees,
+        )
+    ):
+        _fail("funding fees are supported only in futures mode")
+    expected_funding_fees = math.fsum((*filled_order_funding_fees, running_funding_fee))
+    if not math.isclose(
+        observed_funding_fees,
+        expected_funding_fees,
+        rel_tol=1e-9,
+        abs_tol=1e-12,
+    ):
+        _fail(
+            "canonical trade funding fees do not match filled orders and "
+            "running accrual"
+        )
+
+
+def _open_trade_accounting_fingerprint(
+    trade: Trade,
+) -> dict[str, float | bool | None]:
+    return {
+        "amount": trade.amount,
+        "stake_amount": trade.stake_amount,
+        "open_rate": trade.open_rate,
+        "open_trade_value": trade.open_trade_value,
+        "max_stake_amount": trade.max_stake_amount,
+        "fee_open_cost": trade.fee_open_cost,
+        "realized_profit": trade.realized_profit,
+        "close_profit": trade.close_profit,
+        "close_profit_abs": trade.close_profit_abs,
+        "stop_loss": trade.stop_loss,
+        "stop_loss_pct": trade.stop_loss_pct,
+        "initial_stop_loss": trade.initial_stop_loss,
+        "initial_stop_loss_pct": trade.initial_stop_loss_pct,
+        "is_stop_loss_trailing": trade.is_stop_loss_trailing,
+    }
+
+
+def _reset_native_recalculation_outputs(trade: Trade) -> None:
+    """Clear profit outputs that Freqtrade assigns only for non-zero exits."""
+    trade.realized_profit = 0.0
+    trade.close_profit = None
+    trade.close_profit_abs = None
+
+
+def _recalculated_trade_copy(
+    trade: Trade,
+    *,
+    expected_trade_amount: float | None = None,
+) -> Trade:
+    loaded_order_count = len(trade.orders)
+    try:
+        canonical_trade = copy.deepcopy(trade)
+        if len(canonical_trade.orders) != loaded_order_count:
+            _fail("canonical trade clone lost order evidence")
+        _reset_native_recalculation_outputs(canonical_trade)
+        canonical_trade.recalc_trade_from_orders()
+        if expected_trade_amount is not None:
+            canonical_trade.amount = _quantize_trade_amount(
+                canonical_trade,
+                expected_trade_amount,
+            )
+    except MaintenanceError:
+        raise
+    except Exception as error:
+        raise MaintenanceError(
+            "canonical trade accounting cannot be rebuilt from orders"
+        ) from error
+    return canonical_trade
+
+
+def _validate_canonical_open_trade_accounting(
+    trade: Trade,
+    *,
+    expected_trade_amount: float,
+) -> None:
+    """Compare persisted accounting with the native rebuild plus ledger exposure."""
+    observed = _open_trade_accounting_fingerprint(trade)
+    canonical_trade = _recalculated_trade_copy(
+        trade,
+        expected_trade_amount=expected_trade_amount,
+    )
+    expected = _open_trade_accounting_fingerprint(canonical_trade)
+    for field, expected_value in expected.items():
+        observed_value = observed[field]
+        if isinstance(observed_value, bool) or isinstance(expected_value, bool):
+            if observed_value is not expected_value:
+                _fail(f"canonical trade {field} does not match filled orders")
+            continue
+        if observed_value is None or expected_value is None:
+            if observed_value != expected_value:
+                _fail(f"canonical trade {field} does not match filled orders")
+            continue
+        observed_number = _finite_number(observed_value, f"trade {field}")
+        expected_number = _finite_number(expected_value, f"rebuilt trade {field}")
+        if not math.isclose(
+            observed_number,
+            expected_number,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            _fail(f"canonical trade {field} does not match filled orders")
+
+
+def _validate_ambiguous_accounting_recovery(
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> None:
+    if not trade.is_open:
+        _fail("closed trades are inspect-only")
+    _validate_recalculation_sources(trade)
+    _validate_funding_accounting(trade)
+    if state.partial_wallet_mutation is not None:
+        _fail("partial wallet mutation requires a fresh wallet and CEX audit")
+    expected_amount = TakeProfitStageManager.get_expected_trade_amount(
+        state,
+        amount_quantizer=partial(_quantize_trade_amount, trade),
+    )
+    _validate_canonical_open_trade_accounting(
+        trade,
+        expected_trade_amount=expected_amount,
+    )
+
+
+def _validate_trade_accounting_recovery(
+    trade: Trade,
+    recovery: TakeProfitRecoveryInstruction,
+) -> None:
+    _validate_recalculation_sources(trade)
+    _validate_funding_accounting(trade)
+    action = recovery.trade_accounting_action
+    if action == "native_freqtrade_lifecycle":
+        _fail("full-exposure recovery requires the native Freqtrade close lifecycle")
+    if action == "none":
+        if not trade.is_open or not recovery.expected_trade_is_open:
+            _fail("canonical trade lifecycle does not match the recovery state")
+        _validate_canonical_open_trade_accounting(
+            trade,
+            expected_trade_amount=recovery.expected_trade_amount,
+        )
+        return
+
+    _require_spot_accounting_recalculation(trade)
+    if not trade.is_open or not recovery.expected_trade_is_open:
+        _fail("automatic trade-accounting recovery requires an open trade")
+    order = _recovery_order(trade, recovery)
+    if order.ft_is_open or order.ft_order_side != trade.exit_side:
+        _fail("trade-accounting recovery order is not a terminal exit")
+
+    if action != "recalculate_from_orders":
+        _fail("unknown trade-accounting recovery action")
+    canonical_trade = _recalculated_trade_copy(
+        trade,
+        expected_trade_amount=recovery.expected_trade_amount,
+    )
+    if canonical_trade.is_open != recovery.expected_trade_is_open:
+        _fail("rebuilt trade accounting has an unexpected lifecycle state")
+    _validate_funding_accounting(canonical_trade)
+    _validate_canonical_open_trade_accounting(
+        canonical_trade,
+        expected_trade_amount=recovery.expected_trade_amount,
+    )
+
+
+def _apply_trade_accounting_recovery(
+    trade: Trade,
+    recovery: TakeProfitRecoveryInstruction,
+) -> None:
+    _validate_trade_accounting_recovery(trade, recovery)
+    action = recovery.trade_accounting_action
+    if action == "none":
+        return
+    try:
+        _reset_native_recalculation_outputs(trade)
+        trade.recalc_trade_from_orders()
+        trade.amount = _quantize_trade_amount(
+            trade,
+            recovery.expected_trade_amount,
+        )
+        if trade.is_open != recovery.expected_trade_is_open:
+            _fail("native trade accounting produced an unexpected lifecycle state")
+        _validate_funding_accounting(trade)
+        _validate_canonical_open_trade_accounting(
+            trade,
+            expected_trade_amount=recovery.expected_trade_amount,
+        )
+        _commit_trade_accounting()
+    except MaintenanceError:
+        Trade.session.rollback()
+        raise
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError("failed to update canonical trade accounting") from error
+
+
+def _effective_recovery_instruction(
+    trade: Trade,
+    recovery: TakeProfitRecoveryInstruction,
+) -> TakeProfitRecoveryInstruction:
+    """Select a safe native rebuild when the manager cannot see full accounting."""
+    if recovery.trade_accounting_action == "native_freqtrade_lifecycle":
+        return recovery
+    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
+    if (
+        recovery.trade_accounting_action == "recalculate_from_orders"
+        and trading_mode == "spot"
+    ):
+        state_only_recovery = replace(
+            recovery,
+            trade_accounting_action="none",
+        )
+        try:
+            _validate_trade_accounting_recovery(trade, state_only_recovery)
+        except MaintenanceError:
+            pass
+        else:
+            return state_only_recovery
+    try:
+        _validate_trade_accounting_recovery(trade, recovery)
+    except MaintenanceError:
+        if recovery.trade_accounting_action != "none" or recovery.order_id is None:
+            return recovery
+        recalculated_recovery = replace(
+            recovery,
+            trade_accounting_action="recalculate_from_orders",
+        )
+        try:
+            _validate_trade_accounting_recovery(trade, recalculated_recovery)
+        except MaintenanceError:
+            return recovery
+        return recalculated_recovery
+    return recovery
+
+
+def _automatic_accounting_block_reason(
+    trade: Trade,
+    state: TakeProfitStageState,
+    recovery: TakeProfitRecoveryInstruction | None,
+) -> str | None:
+    if not trade.is_open:
+        return "closed_trade_is_inspect_only"
+    if state.partial_wallet_mutation is not None:
+        return "fresh_wallet_and_cex_audit_required"
+    recovery_order_id = (
+        state.blocked_order_id
+        if state.blocked_order_id is not None
+        else recovery.order_id
+        if recovery is not None
+        else None
+    )
+    blocked_order = next(
+        (
+            order
+            for order in trade.orders
+            if recovery_order_id is not None and order.order_id == recovery_order_id
+        ),
+        None,
+    )
+    try:
+        blocked_fill = (
+            _finite_number(blocked_order.filled or 0.0, "blocked order fill")
+            if blocked_order is not None and not blocked_order.ft_is_open
+            else 0.0
+        )
+    except MaintenanceError:
+        blocked_fill = 0.0
+    has_positive_blocked_fill = blocked_fill > 0.0
+    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
+    if (
+        recovery is not None
+        and recovery.trade_accounting_action == "native_freqtrade_lifecycle"
+    ):
+        return "positive_fill_requires_native_freqtrade_lifecycle"
+    if has_positive_blocked_fill and trading_mode != "spot":
+        return "positive_fill_requires_native_freqtrade_lifecycle"
+    if blocked_order is not None:
+        try:
+            blocked_order_funding = _finite_number(
+                blocked_order.funding_fee or 0.0,
+                "blocked order funding fee",
+            )
+        except MaintenanceError:
+            return "automatic_trade_accounting_precondition_failed"
+        if (blocked_order.ft_is_open or not blocked_fill) and not math.isclose(
+            blocked_order_funding,
+            0.0,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            return "automatic_trade_accounting_precondition_failed"
+    if recovery is None:
+        return (
+            "automatic_trade_accounting_precondition_failed"
+            if has_positive_blocked_fill
+            else None
+        )
+    try:
+        _validate_trade_accounting_recovery(trade, recovery)
+    except MaintenanceError:
+        if trading_mode != "spot":
+            return "non_spot_trade_accounting_not_replay_safe"
+        return "automatic_trade_accounting_precondition_failed"
+    return None
 
 
 def _validate_state_roundtrip(state: TakeProfitStageState) -> dict[str, object]:
@@ -378,30 +839,33 @@ def _summary(
         state,
         amount_quantizer=amount_quantizer,
     )
+    if recovery is not None:
+        recovery = _effective_recovery_instruction(trade, recovery)
     clearable_attempt = (
         attempt
         if attempt is not None
         and attempt.status == "ambiguous"
         and recovery is None
-        and (
-            state.blocked_reason is None
-            or (
-                state.blocked_reason == "partial_wallet_mutation"
-                and state.partial_wallet_mutation is not None
-                and state.partial_wallet_mutation.order_id is None
-                and state.partial_wallet_mutation.attempt_id == attempt.attempt_id
-            )
-        )
-        and (
-            state.partial_wallet_mutation is None
-            or state.partial_wallet_mutation.order_id is None
-        )
+        and state.blocked_reason is None
+        and state.partial_wallet_mutation is None
         else None
     )
-    trading_mode = getattr(trade.trading_mode, "value", trade.trading_mode)
-    requires_margin_recalculation = (
-        trading_mode == "margin" and state.partial_wallet_mutation is not None
+    recovery_blocked_reason = _automatic_accounting_block_reason(
+        trade,
+        state,
+        recovery,
     )
+    clear_blocked_reason = None
+    if clearable_attempt is not None:
+        try:
+            _validate_ambiguous_accounting_recovery(trade, state)
+        except MaintenanceError:
+            clear_blocked_reason = (
+                "closed_trade_is_inspect_only"
+                if not trade.is_open
+                else "automatic_trade_accounting_precondition_failed"
+            )
+    recovery_is_available = recovery is not None and recovery_blocked_reason is None
     return {
         "command": command,
         "would_apply": would_apply,
@@ -425,40 +889,56 @@ def _summary(
                 else None
             ),
             "required_clear_confirmation": (
-                f"NO-ORDER:{trade.id}:{clearable_attempt.attempt_id}"
-                if clearable_attempt is not None and not requires_margin_recalculation
+                _ambiguous_confirmation_token(
+                    trade,
+                    state,
+                    clearable_attempt.attempt_id,
+                )
+                if clearable_attempt is not None and clear_blocked_reason is None
                 else None
             ),
-            "required_revalidation_confirmation": (
+            "recovery_action": recovery.action if recovery is not None else None,
+            "recovery_trade_accounting_action": (
+                recovery.trade_accounting_action if recovery is not None else None
+            ),
+            "recovery_expected_trade_amount": (
+                recovery.expected_trade_amount if recovery is not None else None
+            ),
+            "recovery_expected_trade_is_open": (
+                recovery.expected_trade_is_open if recovery is not None else None
+            ),
+            "required_state_revalidation_confirmation": (
                 _recovery_confirmation_token(trade, state, recovery)
-                if recovery is not None and recovery.action == "revalidate_terminal"
+                if recovery_is_available
+                and recovery is not None
+                and recovery.action == "revalidate_state"
                 else None
             ),
-            "required_zero_fill_confirmation": (
+            "required_terminal_order_revalidation_confirmation": (
                 _recovery_confirmation_token(trade, state, recovery)
-                if recovery is not None
-                and recovery.action == "confirm_terminal_zero"
-                and not requires_margin_recalculation
+                if recovery_is_available
+                and recovery is not None
+                and recovery.action == "revalidate_terminal_order"
                 else None
             ),
-            "required_canceled_fill_confirmation": (
+            "required_terminal_zero_fill_confirmation": (
                 _recovery_confirmation_token(trade, state, recovery)
-                if recovery is not None
-                and recovery.action == "confirm_terminal_canceled"
-                and not requires_margin_recalculation
+                if recovery_is_available
+                and recovery is not None
+                and recovery.action == "confirm_terminal_zero_fill"
                 else None
             ),
-            "required_partial_wallet_restoration_confirmation": (
+            "required_terminal_canceled_fill_confirmation": (
                 _recovery_confirmation_token(trade, state, recovery)
-                if recovery is not None
-                and recovery.action == "restore_partial_wallet_mutation"
-                and not requires_margin_recalculation
+                if recovery_is_available
+                and recovery is not None
+                and recovery.action == "confirm_terminal_canceled_fill"
                 else None
             ),
             "recovery_blocked_reason": (
-                "margin_recalculation_not_replay_safe"
-                if requires_margin_recalculation
-                else None
+                clear_blocked_reason
+                if clear_blocked_reason is not None
+                else recovery_blocked_reason
             ),
             "ledger": {
                 "initial_amount": state.initial_amount,
@@ -515,6 +995,11 @@ def _summary(
                     if state.partial_wallet_mutation is not None
                     else None
                 ),
+                "retry_gate": (
+                    state.retry_gate.to_mapping()
+                    if state.retry_gate is not None
+                    else None
+                ),
             },
             "operator_resolutions": [
                 resolution.to_mapping() for resolution in state.operator_resolutions
@@ -543,22 +1028,10 @@ def _validate_ambiguous_attempt(
 ) -> None:
     if not attempt_id:
         _fail("attempt-id must be non-empty")
-    partial_wallet_mutation = state.partial_wallet_mutation
-    if (
-        partial_wallet_mutation is not None
-        and partial_wallet_mutation.order_id is not None
-    ):
-        _fail(
-            "ambiguous attempt is bound to a canonical order; use the terminal "
-            "recovery action reported by inspect"
-        )
-    has_recoverable_partial_wallet_mutation = (
-        state.blocked_reason == "partial_wallet_mutation"
-        and partial_wallet_mutation is not None
-        and partial_wallet_mutation.attempt_id == attempt_id
-    )
-    if state.blocked_reason is not None and not has_recoverable_partial_wallet_mutation:
+    if state.blocked_reason is not None:
         _fail(f"take-profit state is blocked: {state.blocked_reason}")
+    if state.partial_wallet_mutation is not None:
+        _fail("partial wallet mutation requires a fresh wallet and CEX audit")
     attempt = state.active_attempt
     if (
         attempt is None
@@ -592,10 +1065,12 @@ def _clear_ambiguous(
     state: TakeProfitStageState,
 ) -> dict[str, object]:
     _validate_ambiguous_attempt(trade, state, args.attempt_id)
-    partial_wallet_mutation = state.partial_wallet_mutation
-    if partial_wallet_mutation is not None:
-        _require_replayable_recalculation(trade)
-    expected_confirmation = f"NO-ORDER:{trade.id}:{args.attempt_id}"
+    _validate_ambiguous_accounting_recovery(trade, state)
+    expected_confirmation = _ambiguous_confirmation_token(
+        trade,
+        state,
+        args.attempt_id,
+    )
     if not args.apply:
         return _summary(
             trade,
@@ -603,35 +1078,10 @@ def _clear_ambiguous(
             command="clear-ambiguous",
             would_apply=True,
         )
-    if args.confirmation != expected_confirmation:
-        _fail(f"confirmation must be exactly {expected_confirmation!r}")
+    _require_current_confirmation(args.confirmation, expected_confirmation)
 
     try:
         candidate_state = state
-        if partial_wallet_mutation is not None:
-            trade.recalc_trade_from_orders()
-            _validate_ambiguous_attempt(trade, state, args.attempt_id)
-            observed_amount = _quantize_trade_amount(trade, trade.amount)
-            expected_amount = _quantize_trade_amount(
-                trade,
-                partial_wallet_mutation.expected_trade_amount,
-            )
-            if not math.isclose(
-                observed_amount,
-                expected_amount,
-                rel_tol=1e-9,
-                abs_tol=1e-12,
-            ):
-                _fail(
-                    "recalculated trade amount does not restore the partial "
-                    "wallet mutation baseline"
-                )
-            candidate_state = replace(
-                state,
-                partial_wallet_mutation=None,
-                blocked_reason=None,
-                blocked_order_id=None,
-            )
         candidate_state = TakeProfitStageManager.reconcile(
             trade,
             candidate_state,
@@ -639,7 +1089,8 @@ def _clear_ambiguous(
         )
         if candidate_state.blocked_reason is not None:
             _fail(
-                "recalculated trade does not validate before ambiguity resolution: "
+                "canonical trade and state do not validate before ambiguity "
+                "resolution: "
                 f"{candidate_state.blocked_reason}"
             )
         resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
@@ -654,7 +1105,8 @@ def _clear_ambiguous(
         )
         if resolved_state.blocked_reason is not None:
             _fail(
-                "recalculated trade does not validate after ambiguity resolution: "
+                "canonical trade and state do not validate after ambiguity "
+                "resolution: "
                 f"{resolved_state.blocked_reason}"
             )
         _validate_state_roundtrip(resolved_state)
@@ -669,13 +1121,11 @@ def _clear_ambiguous(
     except Exception as error:
         Trade.session.rollback()
         raise MaintenanceError("failed to prepare ambiguity resolution") from error
-    if partial_wallet_mutation is not None:
-        _commit_recalculated_trade()
     persisted_state = _persist_state(trade, resolved_state)
     return _summary(trade, persisted_state, command="clear-ambiguous")
 
 
-def _revalidate_terminal(
+def _revalidate_terminal_order(
     args: argparse.Namespace,
     trade: Trade,
     state: TakeProfitStageState,
@@ -685,77 +1135,131 @@ def _revalidate_terminal(
     recovery = _require_recovery_instruction(
         trade,
         state,
-        action="revalidate_terminal",
+        action="revalidate_terminal_order",
         order_id=args.order_id,
     )
+    expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
+    _validate_trade_accounting_recovery(trade, recovery)
+    if args.apply:
+        _require_current_confirmation(args.confirmation, expected_confirmation)
+    resolved_at = datetime.datetime.now(datetime.timezone.utc)
+    amount_quantizer = partial(_quantize_trade_amount, trade)
+    try:
+        if not args.apply:
+            TakeProfitStageManager.validate_terminal_order_revalidation(
+                trade,
+                state,
+                args.order_id,
+                resolved_at,
+                amount_quantizer=amount_quantizer,
+            )
+            return _summary(
+                trade,
+                state,
+                command="revalidate-terminal-order",
+                would_apply=True,
+            )
+        _apply_trade_accounting_recovery(trade, recovery)
+        resolved_state = TakeProfitStageManager.revalidate_terminal_order(
+            trade,
+            state,
+            args.order_id,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+        )
+        _validate_state_roundtrip(resolved_state)
+    except ValueError as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            f"terminal order cannot be revalidated: {error}"
+        ) from error
+    except Exception as error:
+        Trade.session.rollback()
+        raise MaintenanceError(
+            "failed to prepare terminal-order revalidation"
+        ) from error
+
+    persisted_state = _persist_state(trade, resolved_state)
+    return _summary(trade, persisted_state, command="revalidate-terminal-order")
+
+
+def _revalidate_state(
+    args: argparse.Namespace,
+    trade: Trade,
+    state: TakeProfitStageState,
+) -> dict[str, object]:
+    recovery = _require_recovery_instruction(
+        trade,
+        state,
+        action="revalidate_state",
+    )
+    _validate_trade_accounting_recovery(trade, recovery)
     expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
     if args.apply:
         _require_current_confirmation(args.confirmation, expected_confirmation)
     try:
-        resolved_state = TakeProfitStageManager.revalidate_unknown_terminal_fill(
+        resolved_state = TakeProfitStageManager.revalidate_state(
             trade,
             state,
-            args.order_id,
             datetime.datetime.now(datetime.timezone.utc),
-            amount_quantizer=lambda amount: _quantize_trade_amount(trade, amount),
+            amount_quantizer=partial(_quantize_trade_amount, trade),
         )
+        _validate_state_roundtrip(resolved_state)
     except ValueError as error:
-        raise MaintenanceError(
-            f"terminal fill cannot be revalidated: {error}"
-        ) from error
+        raise MaintenanceError(f"state cannot be revalidated: {error}") from error
 
     if not args.apply:
         return _summary(
             trade,
             state,
-            command="revalidate-terminal",
+            command="revalidate-state",
             would_apply=True,
         )
     persisted_state = _persist_state(trade, resolved_state)
-    return _summary(trade, persisted_state, command="revalidate-terminal")
+    return _summary(trade, persisted_state, command="revalidate-state")
 
 
-def _confirm_terminal_zero(
+def _confirm_terminal_zero_fill(
     args: argparse.Namespace,
     trade: Trade,
     state: TakeProfitStageState,
 ) -> dict[str, object]:
-    return _confirm_terminal(
+    return _confirm_terminal_fill(
         args,
         trade,
         state,
-        command="confirm-terminal-zero",
-        recovery_action="confirm_terminal_zero",
+        command="confirm-terminal-zero-fill",
+        recovery_action="confirm_terminal_zero_fill",
         failure_label="terminal zero fill",
         confirm=TakeProfitStageManager.confirm_terminal_zero_fill,
         validate=TakeProfitStageManager.validate_terminal_zero_fill_confirmation,
     )
 
 
-def _confirm_terminal_canceled(
+def _confirm_terminal_canceled_fill(
     args: argparse.Namespace,
     trade: Trade,
     state: TakeProfitStageState,
 ) -> dict[str, object]:
-    return _confirm_terminal(
+    return _confirm_terminal_fill(
         args,
         trade,
         state,
-        command="confirm-terminal-canceled",
-        recovery_action="confirm_terminal_canceled",
+        command="confirm-terminal-canceled-fill",
+        recovery_action="confirm_terminal_canceled_fill",
         failure_label="terminal canceled fill",
         confirm=TakeProfitStageManager.confirm_terminal_canceled_fill,
         validate=(TakeProfitStageManager.validate_terminal_canceled_fill_confirmation),
     )
 
 
-def _confirm_terminal(
+def _confirm_terminal_fill(
     args: argparse.Namespace,
     trade: Trade,
     state: TakeProfitStageState,
     *,
     command: str,
-    recovery_action: str,
+    recovery_action: TakeProfitRecoveryAction,
     failure_label: str,
     confirm: Callable[..., TakeProfitStageState],
     validate: Callable[..., None],
@@ -770,18 +1274,13 @@ def _confirm_terminal(
         terminal_status=args.terminal_status,
     )
     expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
-    bound_mutation = state.partial_wallet_mutation
-    requires_trade_recalculation = (
-        bound_mutation is not None and bound_mutation.order_id == args.order_id
-    )
-    if requires_trade_recalculation:
-        _require_replayable_recalculation(trade)
+    _validate_trade_accounting_recovery(trade, recovery)
     if args.apply:
         _require_current_confirmation(args.confirmation, expected_confirmation)
     resolved_at = datetime.datetime.now(datetime.timezone.utc)
     amount_quantizer = partial(_quantize_trade_amount, trade)
     try:
-        if requires_trade_recalculation and not args.apply:
+        if not args.apply:
             validate(
                 trade,
                 state,
@@ -796,8 +1295,7 @@ def _confirm_terminal(
                 command=command,
                 would_apply=True,
             )
-        if requires_trade_recalculation:
-            trade.recalc_trade_from_orders()
+        _apply_trade_accounting_recovery(trade, recovery)
         resolved_state = confirm(
             trade,
             state,
@@ -816,97 +1314,16 @@ def _confirm_terminal(
         Trade.session.rollback()
         raise MaintenanceError(f"failed to prepare {failure_label} recovery") from error
 
-    if not args.apply:
-        return _summary(
-            trade,
-            state,
-            command=command,
-            would_apply=True,
-        )
-    if requires_trade_recalculation:
-        _commit_recalculated_trade()
-
     persisted_state = _persist_state(trade, resolved_state)
     return _summary(trade, persisted_state, command=command)
 
 
-def _commit_recalculated_trade() -> None:
+def _commit_trade_accounting() -> None:
     try:
         Trade.commit()
     except Exception as error:
         Trade.session.rollback()
-        raise MaintenanceError(
-            "failed to commit recalculated canonical trade accounting"
-        ) from error
-
-
-def _restore_partial_wallet_mutation(
-    args: argparse.Namespace,
-    trade: Trade,
-    state: TakeProfitStageState,
-) -> dict[str, object]:
-    if not args.order_id:
-        _fail("order-id must be non-empty")
-    mutation = state.partial_wallet_mutation
-    if mutation is None or mutation.order_id != args.order_id:
-        _fail("no matching bound partial-wallet mutation")
-    _require_replayable_recalculation(trade)
-    recovery = _require_recovery_instruction(
-        trade,
-        state,
-        action="restore_partial_wallet_mutation",
-        order_id=args.order_id,
-    )
-    expected_confirmation = _recovery_confirmation_token(trade, state, recovery)
-    if args.apply:
-        _require_current_confirmation(args.confirmation, expected_confirmation)
-    amount_quantizer = partial(_quantize_trade_amount, trade)
-    if not args.apply:
-        try:
-            TakeProfitStageManager.validate_partial_wallet_mutation_restoration(
-                trade,
-                state,
-                args.order_id,
-                amount_quantizer=amount_quantizer,
-            )
-        except ValueError as error:
-            raise MaintenanceError(
-                f"partial-wallet mutation cannot be restored: {error}"
-            ) from error
-        return _summary(
-            trade,
-            state,
-            command="restore-partial-wallet-mutation",
-            would_apply=True,
-        )
-
-    try:
-        trade.recalc_trade_from_orders()
-        resolved_state = TakeProfitStageManager.restore_partial_wallet_mutation(
-            trade,
-            state,
-            args.order_id,
-            datetime.datetime.now(datetime.timezone.utc),
-            amount_quantizer=amount_quantizer,
-        )
-        _validate_state_roundtrip(resolved_state)
-    except ValueError as error:
-        Trade.session.rollback()
-        raise MaintenanceError(
-            f"partial-wallet mutation cannot be restored: {error}"
-        ) from error
-    except Exception as error:
-        Trade.session.rollback()
-        raise MaintenanceError(
-            "failed to prepare partial-wallet mutation restoration"
-        ) from error
-    _commit_recalculated_trade()
-    persisted_state = _persist_state(trade, resolved_state)
-    return _summary(
-        trade,
-        persisted_state,
-        command="restore-partial-wallet-mutation",
-    )
+        raise MaintenanceError("failed to commit canonical trade accounting") from error
 
 
 def main(argv: Sequence[str] | None = None) -> int:
@@ -914,18 +1331,21 @@ def main(argv: Sequence[str] | None = None) -> int:
     try:
         trade = _load_trade(args)
         state = _load_state(trade)
+        _validate_trade_lifecycle_for_command(args, trade)
         if args.command == "inspect":
             result = _summary(trade, state, command="inspect")
         elif args.command == "clear-ambiguous":
             result = _clear_ambiguous(args, trade, state)
-        elif args.command == "revalidate-terminal":
-            result = _revalidate_terminal(args, trade, state)
-        elif args.command == "confirm-terminal-zero":
-            result = _confirm_terminal_zero(args, trade, state)
-        elif args.command == "confirm-terminal-canceled":
-            result = _confirm_terminal_canceled(args, trade, state)
+        elif args.command == "revalidate-terminal-order":
+            result = _revalidate_terminal_order(args, trade, state)
+        elif args.command == "revalidate-state":
+            result = _revalidate_state(args, trade, state)
+        elif args.command == "confirm-terminal-zero-fill":
+            result = _confirm_terminal_zero_fill(args, trade, state)
+        elif args.command == "confirm-terminal-canceled-fill":
+            result = _confirm_terminal_canceled_fill(args, trade, state)
         else:
-            result = _restore_partial_wallet_mutation(args, trade, state)
+            raise AssertionError(f"Unhandled command {args.command!r}")
         _print_result(result, as_json=args.as_json)
         return 0
     except MaintenanceError as error:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -2,7 +2,8 @@ import datetime
 import hashlib
 import logging
 import math
-from functools import cached_property, lru_cache, reduce
+import uuid
+from functools import cached_property, lru_cache, partial, reduce
 from pathlib import Path
 from typing import (
     Any,
@@ -17,7 +18,11 @@ from typing import (
 import numpy as np
 import pandas_ta as pta
 import talib.abstract as ta
-from freqtrade.exchange import timeframe_to_minutes, timeframe_to_prev_date
+from freqtrade.exchange import (
+    amount_to_contract_precision,
+    timeframe_to_minutes,
+    timeframe_to_prev_date,
+)
 from freqtrade.persistence import Trade
 from freqtrade.strategy import AnnotationType, stoploss_from_absolute
 from freqtrade.strategy.interface import IStrategy
@@ -30,7 +35,13 @@ from LabelTransformer import (
 )
 from pandas import DataFrame, Series, isna
 from scipy.stats import pearsonr, t
-from TakeProfitStageManager import TakeProfitStageManager
+from TakeProfitStageManager import (
+    TakeProfitFinalStageDefinition,
+    TakeProfitPlanSignature,
+    TakeProfitStageDefinition,
+    TakeProfitStageManager,
+    TakeProfitStageState,
+)
 from technical.pivots_points import pivots_points
 
 from Utils import (
@@ -123,6 +134,20 @@ class QuickAdapterV3(IStrategy):
 
     _CUSTOM_STOPLOSS_NATR_MULTIPLIER_FRACTION: Final[float] = 0.7860
 
+    _TAKE_PROFIT_STATE_KEY: Final[str] = TakeProfitStageManager.STATE_KEY
+    _TIMEOUT_UNIT_SECONDS: Final[dict[str, int]] = {
+        "seconds": 1,
+        "minutes": 60,
+        "hours": 60 * 60,
+        "days": 24 * 60 * 60,
+    }
+    _PROTECTIVE_EXIT_REASONS: Final[frozenset[str]] = frozenset(
+        {"stop_loss", "stoploss_on_exchange", "trailing_stop_loss"}
+    )
+    _OPERATOR_EXIT_REASONS: Final[frozenset[str]] = frozenset(
+        {"emergency_exit", "force_exit"}
+    )
+
     _ANNOTATION_LINE_OFFSET_CANDLES: Final[int] = 10
 
     def version(self) -> str:
@@ -152,14 +177,14 @@ class QuickAdapterV3(IStrategy):
 
     position_adjustment_enable = True
 
-    # {stage: (natr_multiplier_fraction, stake_percent, color)}
+    # {stage: (natr_multiplier_fraction, stake_fraction, color)}
     partial_exit_stages: ClassVar[dict[int, tuple[float, float, str]]] = {
         0: (0.4858, 0.4, "lime"),
         1: (0.6180, 0.3, "yellow"),
         2: (0.7640, 0.2, "coral"),
     }
 
-    # (natr_multiplier_fraction, stake_percent, color)
+    # (natr_multiplier_fraction, stake_fraction, color)
     _FINAL_EXIT_STAGE: Final[tuple[float, float, str]] = (1.0, 1.0, "deepskyblue")
 
     minimal_roi = {str(timeframe_minutes * 864): -1}
@@ -422,6 +447,20 @@ class QuickAdapterV3(IStrategy):
         return get_label_defaults(feature_parameters, logger)
 
     def bot_start(self, **kwargs) -> None:
+        exit_timeout_count = self.config.get("unfilledtimeout", {}).get(
+            "exit_timeout_count",
+            0,
+        )
+        if exit_timeout_count != 0:
+            raise ValueError(
+                "QuickAdapter requires unfilledtimeout.exit_timeout_count = 0 "
+                "so one component owns partial-exit retries"
+            )
+        if self.order_types.get("exit", "limit") != "limit":
+            raise ValueError(
+                "QuickAdapter requires limit exit orders so custom_exit_price can "
+                "persist the take-profit submission boundary"
+            )
         self.pairs: list[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
@@ -603,16 +642,21 @@ class QuickAdapterV3(IStrategy):
         logger.info("Partial Exit Stages:")
         for stage, (
             natr_multiplier_fraction,
-            stake_percent,
+            exit_fraction_of_remaining,
             color,
         ) in QuickAdapterV3.partial_exit_stages.items():
             logger.info(
-                f"  stage {stage}: natr_multiplier_fraction={format_number(natr_multiplier_fraction)}, stake_percent={format_number(stake_percent)}, color={color}"
+                f"  stage {stage}: natr_multiplier_fraction={format_number(natr_multiplier_fraction)}, "
+                f"exit_fraction_of_remaining={format_number(exit_fraction_of_remaining)}, "
+                f"color={color}"
             )
 
         final_stage = max(QuickAdapterV3.partial_exit_stages.keys(), default=-1) + 1
         logger.info(
-            f"Final Exit Stage: stage {final_stage}: natr_multiplier_fraction={format_number(QuickAdapterV3._FINAL_EXIT_STAGE[0])}, stake_percent={format_number(QuickAdapterV3._FINAL_EXIT_STAGE[1])}, color={QuickAdapterV3._FINAL_EXIT_STAGE[2]}"
+            f"Final Exit Stage: stage {final_stage}: "
+            f"natr_multiplier_fraction={format_number(QuickAdapterV3._FINAL_EXIT_STAGE[0])}, "
+            f"exit_fraction_of_remaining={format_number(QuickAdapterV3._FINAL_EXIT_STAGE[1])}, "
+            f"color={QuickAdapterV3._FINAL_EXIT_STAGE[2]}"
         )
 
         logger.info("Protections:")
@@ -1261,18 +1305,144 @@ class QuickAdapterV3(IStrategy):
         return trade_price_target_method_fn()
 
     @classmethod
-    def get_partial_exit_stake_fractions(cls) -> dict[int, float]:
-        return {
-            stage: stage_config[1]
-            for stage, stage_config in cls.partial_exit_stages.items()
-        }
+    def get_take_profit_plan_signature(cls) -> TakeProfitPlanSignature:
+        partial_stages = tuple(
+            TakeProfitStageDefinition(
+                stage=stage,
+                trigger_natr_fraction=stage_config[0],
+                exit_fraction_of_remaining=stage_config[1],
+            )
+            for stage, stage_config in sorted(cls.partial_exit_stages.items())
+        )
+        return TakeProfitPlanSignature(
+            partial_stages=partial_stages,
+            final_stage=TakeProfitFinalStageDefinition(
+                stage=max(cls.partial_exit_stages, default=-1) + 1,
+                trigger_natr_fraction=cls._FINAL_EXIT_STAGE[0],
+            ),
+        )
+
+    @staticmethod
+    def _quantize_trade_amount(trade: Trade, amount: float) -> float:
+        return amount_to_contract_precision(
+            amount,
+            trade.amount_precision,
+            trade.precision_mode,
+            trade.contract_size,
+        )
+
+    @classmethod
+    def _save_take_profit_state(
+        cls,
+        trade: Trade,
+        state: TakeProfitStageState,
+    ) -> None:
+        trade.set_custom_data(cls._TAKE_PROFIT_STATE_KEY, state.to_mapping())
+
+    @classmethod
+    def _get_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
+        amount_quantizer = partial(cls._quantize_trade_amount, trade)
+        raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+        if raw_state is None:
+            try:
+                state = TakeProfitStageManager.initialize(
+                    trade,
+                    cls.get_take_profit_plan_signature(),
+                    amount_quantizer=amount_quantizer,
+                )
+            except ValueError as error:
+                logger.error(
+                    f"[{trade.pair}] Cannot initialize take-profit state for trade "
+                    f"{trade.id}: {error}. Automatic take-profit is disabled"
+                )
+                return None
+            if state.blocked_reason == "open_entry_order":
+                return None
+            cls._save_take_profit_state(trade, state)
+            if state.blocked_reason is not None:
+                cls._log_take_profit_block(trade, state)
+        else:
+            try:
+                if not isinstance(raw_state, dict):
+                    raise ValueError("Take-profit state must be a mapping")
+                state = TakeProfitStageState.from_mapping(raw_state)
+            except ValueError as error:
+                logger.error(
+                    f"[{trade.pair}] Invalid take-profit state for trade {trade.id}: "
+                    f"{error}. Automatic take-profit is disabled for this trade"
+                )
+                return None
+
+        current_plan_signature = cls.get_take_profit_plan_signature()
+        if state.plan_signature != current_plan_signature:
+            logger.error(
+                f"[{trade.pair}] Take-profit plan configuration changed for trade "
+                f"{trade.id}. "
+                "Automatic take-profit is disabled for this trade"
+            )
+            return None
+
+        reconciled_state = TakeProfitStageManager.reconcile(
+            trade,
+            state,
+            amount_quantizer=amount_quantizer,
+        )
+        if reconciled_state != state:
+            cls._save_take_profit_state(trade, reconciled_state)
+            if (
+                state.blocked_reason is None
+                and reconciled_state.blocked_reason is not None
+            ):
+                cls._log_take_profit_block(trade, reconciled_state)
+        return reconciled_state
+
+    @staticmethod
+    def _log_take_profit_block(trade: Trade, state: TakeProfitStageState) -> None:
+        order_context = (
+            f", order {state.blocked_order_id}"
+            if state.blocked_order_id is not None
+            else ""
+        )
+        logger.error(
+            f"[{trade.pair}] Take-profit reconciliation blocked for trade "
+            f"{trade.id}: {state.blocked_reason}{order_context}"
+        )
+
+    @staticmethod
+    def _allows_discretionary_exit(
+        trade: Trade,
+        state: Optional[TakeProfitStageState],
+    ) -> bool:
+        return (
+            not trade.has_open_orders
+            and state is not None
+            and state.blocked_reason is None
+            and state.active_attempt is None
+        )
+
+    @classmethod
+    def resolve_take_profit_ambiguity(
+        cls,
+        trade: Trade,
+        attempt_id: str,
+    ) -> None:
+        """Re-enable take-profit after an operator proves no remote order exists."""
+        state = cls._get_take_profit_state(trade)
+        if state is None:
+            raise ValueError("Take-profit state cannot be loaded")
+        resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
+            state,
+            attempt_id,
+            datetime.datetime.now(datetime.timezone.utc),
+        )
+        cls._save_take_profit_state(trade, resolved_state)
 
     @classmethod
     def get_trade_exit_stage(cls, trade: Trade) -> int:
-        return TakeProfitStageManager.get_exit_stage(
-            trade,
-            cls.get_partial_exit_stake_fractions(),
-        )
+        state = cls._get_take_profit_state(trade)
+        if state is None:
+            return min(cls.partial_exit_stages, default=0)
+        return TakeProfitStageManager.get_exit_stage(trade, state)
 
     @staticmethod
     @lru_cache(maxsize=128)
@@ -1285,11 +1455,14 @@ class QuickAdapterV3(IStrategy):
         trade: Trade,
         current_rate: float,
         natr_multiplier_fraction: float,
+        take_profit_stage: int,
     ) -> Optional[float]:
         if not (0.0 <= natr_multiplier_fraction <= 1.0):
             raise ValueError(
                 f"Invalid natr_multiplier_fraction value {natr_multiplier_fraction!r}: must be in range [0, 1]"
             )
+        if take_profit_stage < 0:
+            raise ValueError("Take-profit stage must be non-negative")
         trade_duration_candles = self.get_trade_duration_candles(df, trade)
         if not QuickAdapterV3.is_trade_duration_valid(trade_duration_candles):
             return None
@@ -1303,8 +1476,7 @@ class QuickAdapterV3(IStrategy):
                 trade.pair, natr_multiplier_fraction
             )
             * QuickAdapterV3.get_stoploss_factor(
-                trade_duration_candles
-                + int(round(QuickAdapterV3.get_trade_exit_stage(trade) ** 1.5))
+                trade_duration_candles + int(round(take_profit_stage**1.5))
             )
         )
 
@@ -1377,6 +1549,16 @@ class QuickAdapterV3(IStrategy):
         after_fill: bool,
         **kwargs,
     ) -> Optional[float]:
+        # Backtesting reports fills before recalculating trade exposure; reconcile next cycle.
+        if after_fill:
+            return None
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        if take_profit_state is None or take_profit_state.blocked_reason is not None:
+            return None
+        take_profit_stage = TakeProfitStageManager.get_exit_stage(
+            trade,
+            take_profit_state,
+        )
         df, _ = self.dp.get_analyzed_dataframe(
             pair=pair, timeframe=self.config.get("timeframe")
         )
@@ -1388,6 +1570,7 @@ class QuickAdapterV3(IStrategy):
             trade,
             current_rate,
             QuickAdapterV3._CUSTOM_STOPLOSS_NATR_MULTIPLIER_FRACTION,
+            take_profit_stage,
         )
         if isna(stoploss_distance) or stoploss_distance <= 0:
             return None
@@ -1512,6 +1695,33 @@ class QuickAdapterV3(IStrategy):
             )
         return trade_take_profit_price_history
 
+    def _get_take_profit_recovery_deadline(
+        self,
+        current_time: datetime.datetime,
+    ) -> datetime.datetime:
+        unfilled_timeout = self.config.get("unfilledtimeout", {})
+        timeout = max(1.0, float(unfilled_timeout.get("exit", 1.0)))
+        unit = str(unfilled_timeout.get("unit", "minutes"))
+        unit_seconds = QuickAdapterV3._TIMEOUT_UNIT_SECONDS.get(unit)
+        if unit_seconds is None:
+            raise ValueError(f"Unsupported unfilledtimeout unit {unit!r}")
+        return current_time + datetime.timedelta(seconds=timeout * unit_seconds)
+
+    @classmethod
+    def _defer_take_profit_stage(
+        cls,
+        trade: Trade,
+        state: TakeProfitStageState,
+        stage: int,
+        reason: str,
+    ) -> None:
+        deferred_state = TakeProfitStageManager.defer_stage(state, stage)
+        cls._save_take_profit_state(trade, deferred_state)
+        logger.info(
+            f"[{trade.pair}] Trade {trade.trade_direction} stage {stage} | "
+            f"Deferring non-executable take-profit remainder: {reason}"
+        )
+
     def adjust_trade_position(
         self,
         trade: Trade,
@@ -1527,11 +1737,47 @@ class QuickAdapterV3(IStrategy):
         **kwargs,
     ) -> Optional[float] | tuple[Optional[float], Optional[str]]:
         pair = trade.pair
+
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        if take_profit_state is None or take_profit_state.blocked_reason is not None:
+            return None
+
+        active_attempt = take_profit_state.active_attempt
+        if active_attempt is not None:
+            if active_attempt.status == "proposed":
+                take_profit_state = TakeProfitStageManager.discard_proposed_attempt(
+                    take_profit_state
+                )
+                QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+                logger.info(
+                    f"[{pair}] Take-profit attempt {active_attempt.attempt_id} for "
+                    f"trade {trade.id} was not submitted; stage "
+                    f"{active_attempt.stage} remains retryable"
+                )
+                return None
+            elif active_attempt.status == "submitting":
+                take_profit_state = TakeProfitStageManager.mark_ambiguous(
+                    take_profit_state,
+                    active_attempt.attempt_id,
+                )
+                QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+                logger.error(
+                    f"[{pair}] Take-profit attempt {active_attempt.attempt_id} for "
+                    f"trade {trade.id} has no persisted order; automatic take-profit "
+                    "is fail-closed until exchange reconciliation"
+                )
+                return None
+            else:
+                return None
+
         if trade.has_open_orders:
             return None
 
-        trade_exit_stage = QuickAdapterV3.get_trade_exit_stage(trade)
-        if trade_exit_stage not in QuickAdapterV3.partial_exit_stages:
+        take_profit_stage = TakeProfitStageManager.get_exit_stage(
+            trade,
+            take_profit_state,
+        )
+        if take_profit_stage not in QuickAdapterV3.partial_exit_stages:
             return None
 
         df, _ = self.dp.get_analyzed_dataframe(
@@ -1541,65 +1787,99 @@ class QuickAdapterV3(IStrategy):
             return None
 
         trade_take_profit_price = self.get_take_profit_price(
-            df, trade, trade_exit_stage
+            df, trade, take_profit_stage
         )
         if isna(trade_take_profit_price):
             return None
 
         self.safe_append_trade_take_profit_price(
-            trade, trade_take_profit_price, trade_exit_stage
+            trade, trade_take_profit_price, take_profit_stage
         )
 
         trade_partial_exit = QuickAdapterV3.can_take_profit(
-            trade, current_rate, trade_take_profit_price
+            trade, current_exit_rate, trade_take_profit_price
         )
         if not trade_partial_exit:
             self.throttle_callback(
                 pair=pair,
                 current_time=current_time,
                 callback=lambda: logger.info(
-                    f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
-                    f"Take Profit: {format_number(trade_take_profit_price)}, Rate: {format_number(current_rate)}"
+                    f"[{pair}] Trade {trade.trade_direction} stage {take_profit_stage} | "
+                    f"Take Profit: {format_number(trade_take_profit_price)}, Exit Rate: {format_number(current_exit_rate)}"
                 ),
             )
         if trade_partial_exit:
-            if min_stake is None:
-                min_stake = 0.0
-            if min_stake > trade.stake_amount:
-                return None
-            trade_stake_percent = QuickAdapterV3.partial_exit_stages[trade_exit_stage][
-                1
-            ]
             stage_progress = TakeProfitStageManager.get_stage_progress(
                 trade,
-                trade_exit_stage,
-                trade_stake_percent,
+                take_profit_state,
+                take_profit_stage,
             )
-            trade_partial_stake_amount = (
-                TakeProfitStageManager.get_remaining_stake_amount(
-                    trade,
-                    stage_progress,
-                )
-            )
-            if trade_partial_stake_amount <= 0.0:
+            if trade.amount <= 0.0 or trade.stake_amount <= 0.0:
                 return None
-            remaining_stake_amount = trade.stake_amount - trade_partial_stake_amount
-            if remaining_stake_amount < min_stake:
-                initial_trade_partial_stake_amount = trade_partial_stake_amount
-                trade_partial_stake_amount = trade.stake_amount - min_stake
-                logger.info(
-                    f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
-                    f"Partial stake amount adjusted from {format_number(initial_trade_partial_stake_amount)} to {format_number(trade_partial_stake_amount)} to respect min_stake {format_number(min_stake)}"
+            requested_amount = QuickAdapterV3._quantize_trade_amount(
+                trade,
+                min(trade.amount, stage_progress.remaining_amount),
+            )
+            if requested_amount <= 0.0:
+                QuickAdapterV3._defer_take_profit_stage(
+                    trade,
+                    take_profit_state,
+                    take_profit_stage,
+                    "amount rounds to zero",
                 )
+                return None
+            adjustment_stake_amount = (
+                requested_amount * trade.stake_amount / trade.amount
+            )
+            take_profit_state = TakeProfitStageManager.start_attempt(
+                trade,
+                take_profit_state,
+                stage=take_profit_stage,
+                amount=requested_amount,
+                stake_amount=adjustment_stake_amount,
+                attempt_id=uuid.uuid4().hex,
+                status="proposed",
+                current_time=current_time,
+                recovery_deadline=self._get_take_profit_recovery_deadline(current_time),
+            )
+            QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            active_attempt = take_profit_state.active_attempt
+            if active_attempt is None:
+                return None
             return (
-                -trade_partial_stake_amount,
-                TakeProfitStageManager.order_tag(
-                    trade.trade_direction,
-                    trade_exit_stage,
-                ),
+                -adjustment_stake_amount,
+                active_attempt.tag,
             )
 
         return None
+
+    def custom_exit_price(
+        self,
+        pair: str,
+        trade: Trade,
+        current_time: datetime.datetime,
+        proposed_rate: float,
+        current_profit: float,
+        exit_tag: Optional[str],
+        **kwargs,
+    ) -> float:
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        if take_profit_state is None:
+            return proposed_rate
+        active_attempt = take_profit_state.active_attempt
+        if (
+            active_attempt is not None
+            and active_attempt.stage in QuickAdapterV3.partial_exit_stages
+            and exit_tag == active_attempt.tag
+        ):
+            submitting_state = TakeProfitStageManager.mark_submitting(
+                take_profit_state,
+                active_attempt.attempt_id,
+                current_time,
+            )
+            if submitting_state != take_profit_state:
+                QuickAdapterV3._save_take_profit_state(trade, submitting_state)
+        return proposed_rate
 
     @staticmethod
     def weighted_close(series: Series, weight: float = 2.0) -> float:
@@ -2039,6 +2319,32 @@ class QuickAdapterV3(IStrategy):
     ) -> Optional[str]:
         self.safe_append_trade_unrealized_pnl(trade, current_profit)
 
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        if take_profit_state is None or take_profit_state.blocked_reason is not None:
+            return None
+        active_attempt = take_profit_state.active_attempt
+        if active_attempt is not None:
+            if active_attempt.status == "proposed":
+                take_profit_state = TakeProfitStageManager.discard_proposed_attempt(
+                    take_profit_state
+                )
+                QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            elif active_attempt.status == "submitting":
+                take_profit_state = TakeProfitStageManager.mark_ambiguous(
+                    take_profit_state,
+                    active_attempt.attempt_id,
+                )
+                QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+                logger.error(
+                    f"[{pair}] Final take-profit attempt {active_attempt.attempt_id} "
+                    f"for trade {trade.id} has no persisted order; automatic "
+                    "take-profit is fail-closed until exchange reconciliation"
+                )
+            return None
+
+        if trade.has_open_orders:
+            return None
+
         df, _ = self.dp.get_analyzed_dataframe(
             pair=pair, timeframe=self.config.get("timeframe")
         )
@@ -2102,7 +2408,10 @@ class QuickAdapterV3(IStrategy):
         ):
             return "maxima_detected_long"
 
-        trade_exit_stage = QuickAdapterV3.get_trade_exit_stage(trade)
+        trade_exit_stage = TakeProfitStageManager.get_exit_stage(
+            trade,
+            take_profit_state,
+        )
         if trade_exit_stage in QuickAdapterV3.partial_exit_stages:
             return None
 
@@ -2207,12 +2516,122 @@ class QuickAdapterV3(IStrategy):
             )
 
         if trade_exit:
-            return TakeProfitStageManager.order_tag(
-                trade.trade_direction,
-                trade_exit_stage,
+            requested_amount = QuickAdapterV3._quantize_trade_amount(
+                trade,
+                trade.amount,
             )
+            if requested_amount <= 0.0 or trade.stake_amount <= 0.0:
+                return None
+            take_profit_state = TakeProfitStageManager.start_attempt(
+                trade,
+                take_profit_state,
+                stage=trade_exit_stage,
+                amount=requested_amount,
+                stake_amount=trade.stake_amount,
+                attempt_id=uuid.uuid4().hex,
+                status="proposed",
+                current_time=current_time,
+                recovery_deadline=self._get_take_profit_recovery_deadline(current_time),
+            )
+            QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            active_attempt = take_profit_state.active_attempt
+            return active_attempt.tag if active_attempt is not None else None
 
         return None
+
+    def confirm_trade_exit(
+        self,
+        pair: str,
+        trade: Trade,
+        order_type: str,
+        amount: float,
+        rate: float,
+        time_in_force: str,
+        exit_reason: str,
+        current_time: datetime.datetime,
+        **kwargs,
+    ) -> bool:
+        parsed_tag = TakeProfitStageManager.parse_order_tag(exit_reason)
+        if parsed_tag is None:
+            if TakeProfitStageManager.has_order_tag_prefix(exit_reason):
+                logger.error(
+                    f"[{pair}] Denied malformed take-profit exit tag "
+                    f"{exit_reason!r} for trade {trade.id}"
+                )
+                return False
+            if exit_reason in QuickAdapterV3._PROTECTIVE_EXIT_REASONS:
+                return True
+
+            take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+            if exit_reason in QuickAdapterV3._OPERATOR_EXIT_REASONS:
+                if not QuickAdapterV3._allows_discretionary_exit(
+                    trade,
+                    take_profit_state,
+                ):
+                    logger.warning(
+                        f"[{pair}] Allowing operator safety exit {exit_reason!r} for "
+                        f"trade {trade.id} while take-profit execution is not idle"
+                    )
+                return True
+            if not QuickAdapterV3._allows_discretionary_exit(
+                trade,
+                take_profit_state,
+            ):
+                logger.warning(
+                    f"[{pair}] Denied discretionary exit {exit_reason!r} for trade "
+                    f"{trade.id} while take-profit execution is not idle"
+                )
+                return False
+            return True
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        if take_profit_state is None or take_profit_state.blocked_reason is not None:
+            return False
+        if trade.has_open_orders:
+            logger.error(
+                f"[{pair}] Denied take-profit exit tag {exit_reason!r} for trade "
+                f"{trade.id} while another order is open"
+            )
+            return False
+        active_attempt = take_profit_state.active_attempt
+        final_stage = take_profit_state.plan_signature.final_stage.stage
+        if active_attempt is None or (
+            active_attempt.stage != final_stage
+            or active_attempt.tag != exit_reason
+            or active_attempt.exit_side != trade.exit_side
+            or parsed_tag
+            != (
+                trade.trade_direction,
+                final_stage,
+                active_attempt.attempt_id,
+            )
+        ):
+            logger.error(
+                f"[{pair}] Denied untracked take-profit exit tag {exit_reason!r} "
+                f"for trade {trade.id}"
+            )
+            return False
+
+        if (
+            not math.isfinite(amount)
+            or amount <= 0.0
+            or trade.amount <= 0.0
+            or trade.stake_amount <= 0.0
+        ):
+            return False
+        stake_amount = amount * trade.stake_amount / trade.amount
+        take_profit_state = TakeProfitStageManager.update_attempt_amount(
+            take_profit_state,
+            active_attempt.attempt_id,
+            amount,
+            stake_amount,
+        )
+        take_profit_state = TakeProfitStageManager.mark_submitting(
+            take_profit_state,
+            active_attempt.attempt_id,
+            current_time,
+        )
+        QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+        return True
 
     def confirm_trade_entry(
         self,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1340,6 +1340,9 @@ class QuickAdapterV3(IStrategy):
         state: TakeProfitStageState,
     ) -> None:
         payload = state.to_mapping()
+        validated_state = TakeProfitStageState.from_mapping(payload)
+        if validated_state != state:
+            raise RuntimeError("Take-profit state failed round-trip validation")
         trade.set_custom_data(cls._TAKE_PROFIT_STATE_KEY, payload)
         persisted_payload = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
         if persisted_payload != payload:
@@ -1351,7 +1354,7 @@ class QuickAdapterV3(IStrategy):
         trade: Trade,
         *,
         validate_trade_amount_on_initialize: bool = True,
-    ) -> Optional[tuple[TakeProfitStageState, int]]:
+    ) -> Optional[TakeProfitStageState]:
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
         raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
         if raw_state is None:
@@ -1370,17 +1373,10 @@ class QuickAdapterV3(IStrategy):
                 return None
             if state.blocked_reason == "open_entry_order":
                 return None
-            source_version = TakeProfitStageState.SCHEMA_VERSION
         else:
             try:
                 if not isinstance(raw_state, dict):
                     raise ValueError("Take-profit state must be a mapping")
-                source_version = raw_state.get("version")
-                if isinstance(source_version, bool) or not isinstance(
-                    source_version,
-                    int,
-                ):
-                    raise ValueError("Take-profit state version must be an integer")
                 state = TakeProfitStageState.from_mapping(raw_state)
             except ValueError as error:
                 logger.error(
@@ -1398,34 +1394,53 @@ class QuickAdapterV3(IStrategy):
             )
             return None
 
-        return state, source_version
+        return state
 
     @classmethod
     def _get_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
-        loaded_state = cls._load_take_profit_state(trade)
-        if loaded_state is None:
+        state = cls._load_take_profit_state(trade)
+        if state is None:
             return None
-        state, source_version = loaded_state
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
 
-        reconciled_state = TakeProfitStageManager.reconcile_migrated_state(
+        reconciled_state = TakeProfitStageManager.reconcile(
             trade,
             state,
-            source_version,
             amount_quantizer=amount_quantizer,
         )
         was_unpersisted = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY) is None
-        if (
-            source_version != TakeProfitStageState.SCHEMA_VERSION
-            or reconciled_state != state
-            or was_unpersisted
-        ):
+        if reconciled_state != state or was_unpersisted:
             cls._save_take_profit_state(trade, reconciled_state)
             if (
                 was_unpersisted or state.blocked_reason is None
             ) and reconciled_state.blocked_reason is not None:
                 cls._log_take_profit_block(trade, reconciled_state)
         return reconciled_state
+
+    @classmethod
+    def _peek_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
+        """Read an existing take-profit snapshot without reconciling or persisting it."""
+        raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+        if raw_state is None:
+            return None
+        try:
+            if not isinstance(raw_state, dict):
+                raise ValueError("Take-profit state must be a mapping")
+            state = TakeProfitStageState.from_mapping(raw_state)
+        except ValueError as error:
+            logger.error(
+                f"[{trade.pair}] Invalid take-profit state for trade {trade.id}: "
+                f"{error}. Take-profit annotations are disabled for this trade"
+            )
+            return None
+
+        if state.plan_signature != cls.get_take_profit_plan_signature():
+            logger.error(
+                f"[{trade.pair}] Take-profit plan configuration changed for trade "
+                f"{trade.id}. Take-profit annotations are disabled for this trade"
+            )
+            return None
+        return state
 
     @staticmethod
     def _log_take_profit_block(trade: Trade, state: TakeProfitStageState) -> None:
@@ -1452,28 +1467,11 @@ class QuickAdapterV3(IStrategy):
         )
 
     @classmethod
-    def resolve_take_profit_ambiguity(
-        cls,
-        trade: Trade,
-        attempt_id: str,
-    ) -> None:
-        """Re-enable take-profit after an operator proves no remote order exists."""
-        state = cls._get_take_profit_state(trade)
-        if state is None:
-            raise ValueError("Take-profit state cannot be loaded")
-        resolved_state = TakeProfitStageManager.resolve_ambiguous_attempt(
-            state,
-            attempt_id,
-            datetime.datetime.now(datetime.timezone.utc),
-        )
-        cls._save_take_profit_state(trade, resolved_state)
-
-    @classmethod
     def get_trade_exit_stage(cls, trade: Trade) -> int:
-        state = cls._get_take_profit_state(trade)
+        state = cls._peek_take_profit_state(trade)
         if state is None:
             return min(cls.partial_exit_stages, default=0)
-        return TakeProfitStageManager.get_exit_stage(trade, state)
+        return TakeProfitStageManager.get_execution_stage(state)
 
     @staticmethod
     @lru_cache(maxsize=128)
@@ -1586,10 +1584,7 @@ class QuickAdapterV3(IStrategy):
         take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
         if take_profit_state is None or take_profit_state.blocked_reason is not None:
             return None
-        take_profit_stage = TakeProfitStageManager.get_exit_stage(
-            trade,
-            take_profit_state,
-        )
+        take_profit_stage = TakeProfitStageManager.get_credited_stage(take_profit_state)
         df, _ = self.dp.get_analyzed_dataframe(
             pair=pair, timeframe=self.config.get("timeframe")
         )
@@ -1771,6 +1766,87 @@ class QuickAdapterV3(IStrategy):
         runmode = self.config.get("runmode")
         return getattr(runmode, "value", runmode) in {"live", "dry_run"}
 
+    def _preflight_partial_exit_amount(
+        self,
+        trade: Trade,
+        requested_amount: float,
+    ) -> Optional[float]:
+        """Clamp a live spot-like partial exit before Freqtrade mutates the trade."""
+        if not self._uses_live_exit_minimums():
+            return requested_amount
+
+        trading_mode = self.config.get("trading_mode", "spot")
+        if getattr(trading_mode, "value", trading_mode) == "futures":
+            return requested_amount
+
+        wallets = getattr(self, "wallets", None)
+        if wallets is None:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: wallets are unavailable"
+            )
+            return None
+
+        try:
+            wallets.update()
+            base_currency = trade.safe_base_currency
+            if not base_currency:
+                market = self.dp.market(trade.pair)
+                base_currency = market.get("base") if market is not None else None
+            if not base_currency:
+                raise ValueError("base currency is unavailable")
+            wallet_amount = float(wallets.get_free(base_currency)) + float(
+                wallets.get_used(base_currency)
+            )
+        except Exception as error:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: {error}"
+            )
+            return None
+
+        if not math.isfinite(wallet_amount) or wallet_amount < 0.0:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: invalid wallet amount {wallet_amount!r}"
+            )
+            return None
+        if wallet_amount >= requested_amount:
+            return requested_amount
+        if wallet_amount <= requested_amount * 0.98:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: wallet amount {wallet_amount} is not within 2% of "
+                f"requested amount {requested_amount}"
+            )
+            return None
+
+        executable_amount = QuickAdapterV3._quantize_trade_amount(
+            trade,
+            wallet_amount,
+        )
+        rounds_above_wallet = executable_amount > wallet_amount and not math.isclose(
+            executable_amount,
+            wallet_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        )
+        if (
+            not math.isfinite(executable_amount)
+            or rounds_above_wallet
+            or executable_amount < requested_amount * 0.98
+        ):
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: wallet amount rounds below the 2% safety bound"
+            )
+            return None
+        logger.info(
+            f"[{trade.pair}] Clamping partial take-profit for trade {trade.id} "
+            f"from {requested_amount} to wallet amount {executable_amount}"
+        )
+        return executable_amount
+
     def _effective_exit_min_stake(
         self,
         min_stake: Optional[float],
@@ -1862,9 +1938,8 @@ class QuickAdapterV3(IStrategy):
         if trade.has_open_orders:
             return None
 
-        take_profit_stage = TakeProfitStageManager.get_exit_stage(
-            trade,
-            take_profit_state,
+        take_profit_stage = TakeProfitStageManager.get_execution_stage(
+            take_profit_state
         )
         if take_profit_stage not in QuickAdapterV3.partial_exit_stages:
             return None
@@ -1899,7 +1974,6 @@ class QuickAdapterV3(IStrategy):
             )
         if trade_partial_exit:
             stage_progress = TakeProfitStageManager.get_stage_progress(
-                trade,
                 take_profit_state,
                 take_profit_stage,
             )
@@ -1916,6 +1990,12 @@ class QuickAdapterV3(IStrategy):
                     take_profit_stage,
                     "amount rounds to zero",
                 )
+                return None
+            requested_amount = self._preflight_partial_exit_amount(
+                trade,
+                requested_amount,
+            )
+            if requested_amount is None:
                 return None
             adjustment_stake_amount = (
                 requested_amount * trade.stake_amount / trade.amount
@@ -1962,7 +2042,11 @@ class QuickAdapterV3(IStrategy):
                 return None
             minimum_leverage = leverage if self._uses_live_exit_minimums() else 1.0
             outgoing_stake = executable_amount * current_exit_rate / minimum_leverage
-            remaining_stake = (trade.amount - executable_amount) * current_exit_rate
+            remaining_stake = (
+                (trade.amount - executable_amount)
+                * current_exit_rate
+                / minimum_leverage
+            )
             if effective_min_stake is not None and outgoing_stake < effective_min_stake:
                 QuickAdapterV3._defer_take_profit_stage(
                     trade,
@@ -2551,10 +2635,7 @@ class QuickAdapterV3(IStrategy):
         ):
             return "maxima_detected_long"
 
-        trade_exit_stage = TakeProfitStageManager.get_exit_stage(
-            trade,
-            take_profit_state,
-        )
+        trade_exit_stage = TakeProfitStageManager.get_execution_stage(take_profit_state)
         if trade_exit_stage in QuickAdapterV3.partial_exit_stages:
             return None
 
@@ -2717,11 +2798,7 @@ class QuickAdapterV3(IStrategy):
                     )
                     return True
                 return False
-            take_profit_state, source_version = loaded_state
-            take_profit_state = TakeProfitStageManager.prepare_migrated_state(
-                take_profit_state,
-                source_version,
-            )
+            take_profit_state = loaded_state
             active_attempt = take_profit_state.active_attempt
             adjustment_id = (
                 active_attempt.attempt_id
@@ -2783,11 +2860,11 @@ class QuickAdapterV3(IStrategy):
                     or active_attempt.stage != final_stage
                     or active_attempt.tag != exit_reason
                     or active_attempt.exit_side != trade.exit_side
+                    or parsed_tag is None
                     or parsed_tag
                     != (
                         trade.trade_direction,
                         final_stage,
-                        active_attempt.attempt_id,
                     )
                 ):
                     logger.error(

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -30,6 +30,7 @@ from LabelTransformer import (
 )
 from pandas import DataFrame, Series, isna
 from scipy.stats import pearsonr, t
+from TakeProfitStageManager import TakeProfitStageManager
 from technical.pivots_points import pivots_points
 
 from Utils import (
@@ -1259,16 +1260,19 @@ class QuickAdapterV3(IStrategy):
             )
         return trade_price_target_method_fn()
 
-    @staticmethod
-    def get_trade_exit_stage(trade: Trade) -> int:
-        n_open_orders = 0
-        if trade.has_open_orders:
-            n_open_orders = sum(
-                1
-                for open_order in trade.open_orders
-                if open_order.side == ("buy" if trade.is_short else "sell")
-            )
-        return trade.nr_of_successful_exits + n_open_orders
+    @classmethod
+    def get_partial_exit_stake_fractions(cls) -> dict[int, float]:
+        return {
+            stage: stage_config[1]
+            for stage, stage_config in cls.partial_exit_stages.items()
+        }
+
+    @classmethod
+    def get_trade_exit_stage(cls, trade: Trade) -> int:
+        return TakeProfitStageManager.get_exit_stage(
+            trade,
+            cls.get_partial_exit_stake_fractions(),
+        )
 
     @staticmethod
     @lru_cache(maxsize=128)
@@ -1299,7 +1303,8 @@ class QuickAdapterV3(IStrategy):
                 trade.pair, natr_multiplier_fraction
             )
             * QuickAdapterV3.get_stoploss_factor(
-                trade_duration_candles + int(round(trade.nr_of_successful_exits**1.5))
+                trade_duration_candles
+                + int(round(QuickAdapterV3.get_trade_exit_stage(trade) ** 1.5))
             )
         )
 
@@ -1565,7 +1570,19 @@ class QuickAdapterV3(IStrategy):
             trade_stake_percent = QuickAdapterV3.partial_exit_stages[trade_exit_stage][
                 1
             ]
-            trade_partial_stake_amount = trade_stake_percent * trade.stake_amount
+            stage_progress = TakeProfitStageManager.get_stage_progress(
+                trade,
+                trade_exit_stage,
+                trade_stake_percent,
+            )
+            trade_partial_stake_amount = (
+                TakeProfitStageManager.get_remaining_stake_amount(
+                    trade,
+                    stage_progress,
+                )
+            )
+            if trade_partial_stake_amount <= 0.0:
+                return None
             remaining_stake_amount = trade.stake_amount - trade_partial_stake_amount
             if remaining_stake_amount < min_stake:
                 initial_trade_partial_stake_amount = trade_partial_stake_amount
@@ -1576,7 +1593,10 @@ class QuickAdapterV3(IStrategy):
                 )
             return (
                 -trade_partial_stake_amount,
-                f"take_profit_{trade.trade_direction}_{trade_exit_stage}",
+                TakeProfitStageManager.order_tag(
+                    trade.trade_direction,
+                    trade_exit_stage,
+                ),
             )
 
         return None
@@ -2187,7 +2207,10 @@ class QuickAdapterV3(IStrategy):
             )
 
         if trade_exit:
-            return f"take_profit_{trade.trade_direction}_{trade_exit_stage}"
+            return TakeProfitStageManager.order_tag(
+                trade.trade_direction,
+                trade_exit_stage,
+            )
 
         return None
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1934,7 +1934,7 @@ class QuickAdapterV3(IStrategy):
         trade: Trade,
         requested_amount: float,
     ) -> Optional[float]:
-        """Require the live wallet to cover the complete spot-like exposure."""
+        """Require live base-wallet coverage and sell-side availability."""
         if not self._uses_live_exit_constraints():
             return requested_amount
 
@@ -1958,9 +1958,8 @@ class QuickAdapterV3(IStrategy):
                 base_currency = market.get("base") if market is not None else None
             if not base_currency:
                 raise ValueError("base currency is unavailable")
-            wallet_amount = float(wallets.get_free(base_currency)) + float(
-                wallets.get_used(base_currency)
-            )
+            free_wallet_amount = float(wallets.get_free(base_currency))
+            used_wallet_amount = float(wallets.get_used(base_currency))
         except Exception as error:
             logger.error(
                 f"[{trade.pair}] Cannot preflight partial take-profit for trade "
@@ -1968,10 +1967,21 @@ class QuickAdapterV3(IStrategy):
             )
             return None
 
-        if not math.isfinite(wallet_amount) or wallet_amount < 0.0:
+        if any(
+            not math.isfinite(amount) or amount < 0.0
+            for amount in (free_wallet_amount, used_wallet_amount)
+        ):
             logger.error(
                 f"[{trade.pair}] Cannot preflight partial take-profit for trade "
-                f"{trade.id}: invalid wallet amount {wallet_amount!r}"
+                f"{trade.id}: invalid wallet balances free={free_wallet_amount!r}, "
+                f"used={used_wallet_amount!r}"
+            )
+            return None
+        total_wallet_amount = free_wallet_amount + used_wallet_amount
+        if not math.isfinite(total_wallet_amount):
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: invalid total wallet amount {total_wallet_amount!r}"
             )
             return None
         required_wallet_amount = max(requested_amount, float(trade.amount))
@@ -1981,14 +1991,21 @@ class QuickAdapterV3(IStrategy):
                 f"{trade.id}: invalid canonical exposure {trade.amount!r}"
             )
             return None
-        if wallet_amount >= required_wallet_amount:
-            return requested_amount
-        logger.error(
-            f"[{trade.pair}] Cannot preflight partial take-profit for trade "
-            f"{trade.id}: wallet amount {wallet_amount} is below canonical "
-            f"exposure {required_wallet_amount}"
-        )
-        return None
+        if total_wallet_amount < required_wallet_amount:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: total wallet amount {total_wallet_amount} is below "
+                f"canonical exposure {required_wallet_amount}"
+            )
+            return None
+        if trade.exit_side == "sell" and free_wallet_amount < requested_amount:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: free wallet amount {free_wallet_amount} is below "
+                f"requested exit amount {requested_amount}"
+            )
+            return None
+        return requested_amount
 
     def _get_exit_min_stake(
         self,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1349,11 +1349,50 @@ class QuickAdapterV3(IStrategy):
             raise RuntimeError("Take-profit state persistence verification failed")
 
     @classmethod
+    def _restore_unpersisted_exit_adjustment(
+        cls,
+        trade: Trade,
+        previous_state: TakeProfitStageState,
+        candidate_state: TakeProfitStageState,
+        adjustment_id: str,
+        persisted_payload_before: object,
+    ) -> None:
+        """Restore a denied exit amount only when its adjustment was not persisted."""
+        previous_adjustment_ids = {
+            adjustment.adjustment_id
+            for adjustment in previous_state.exposure_adjustments
+        }
+        matching_adjustments = tuple(
+            adjustment
+            for adjustment in candidate_state.exposure_adjustments
+            if adjustment.is_active
+            and adjustment.adjustment_id == adjustment_id
+            and adjustment.adjustment_id not in previous_adjustment_ids
+        )
+        if len(matching_adjustments) != 1:
+            return
+        adjustment = matching_adjustments[0]
+        if not math.isclose(
+            trade.amount,
+            adjustment.adjusted_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            return
+        try:
+            persisted_payload = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+        except Exception:
+            return
+        if persisted_payload == persisted_payload_before:
+            trade.amount = adjustment.previous_amount
+
+    @classmethod
     def _load_take_profit_state(
         cls,
         trade: Trade,
         *,
         validate_trade_amount_on_initialize: bool = True,
+        current_time: Optional[datetime.datetime] = None,
     ) -> Optional[TakeProfitStageState]:
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
         raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
@@ -1364,6 +1403,7 @@ class QuickAdapterV3(IStrategy):
                     cls.get_take_profit_plan_signature(),
                     amount_quantizer=amount_quantizer,
                     validate_trade_amount=validate_trade_amount_on_initialize,
+                    current_time=current_time,
                 )
             except ValueError as error:
                 logger.error(
@@ -1397,8 +1437,12 @@ class QuickAdapterV3(IStrategy):
         return state
 
     @classmethod
-    def _get_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
-        state = cls._load_take_profit_state(trade)
+    def _get_take_profit_state(
+        cls,
+        trade: Trade,
+        current_time: Optional[datetime.datetime] = None,
+    ) -> Optional[TakeProfitStageState]:
+        state = cls._load_take_profit_state(trade, current_time=current_time)
         if state is None:
             return None
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
@@ -1407,6 +1451,7 @@ class QuickAdapterV3(IStrategy):
             trade,
             state,
             amount_quantizer=amount_quantizer,
+            current_time=current_time,
         )
         was_unpersisted = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY) is None
         if reconciled_state != state or was_unpersisted:
@@ -1581,7 +1626,7 @@ class QuickAdapterV3(IStrategy):
         # Backtesting reports fills before recalculating trade exposure; reconcile next cycle.
         if after_fill:
             return None
-        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade, current_time)
         if take_profit_state is None or take_profit_state.blocked_reason is not None:
             return None
         take_profit_stage = TakeProfitStageManager.get_credited_stage(take_profit_state)
@@ -1762,7 +1807,7 @@ class QuickAdapterV3(IStrategy):
         )
         return QuickAdapterV3._quantize_trade_amount(trade, amount)
 
-    def _uses_live_exit_minimums(self) -> bool:
+    def _uses_live_exit_constraints(self) -> bool:
         runmode = self.config.get("runmode")
         return getattr(runmode, "value", runmode) in {"live", "dry_run"}
 
@@ -1771,8 +1816,8 @@ class QuickAdapterV3(IStrategy):
         trade: Trade,
         requested_amount: float,
     ) -> Optional[float]:
-        """Clamp a live spot-like partial exit before Freqtrade mutates the trade."""
-        if not self._uses_live_exit_minimums():
+        """Require the live wallet to cover the complete spot-like exposure."""
+        if not self._uses_live_exit_constraints():
             return requested_amount
 
         trading_mode = self.config.get("trading_mode", "spot")
@@ -1811,41 +1856,21 @@ class QuickAdapterV3(IStrategy):
                 f"{trade.id}: invalid wallet amount {wallet_amount!r}"
             )
             return None
-        if wallet_amount >= requested_amount:
+        required_wallet_amount = max(requested_amount, float(trade.amount))
+        if not math.isfinite(required_wallet_amount) or required_wallet_amount <= 0.0:
+            logger.error(
+                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+                f"{trade.id}: invalid canonical exposure {trade.amount!r}"
+            )
+            return None
+        if wallet_amount >= required_wallet_amount:
             return requested_amount
-        if wallet_amount <= requested_amount * 0.98:
-            logger.error(
-                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
-                f"{trade.id}: wallet amount {wallet_amount} is not within 2% of "
-                f"requested amount {requested_amount}"
-            )
-            return None
-
-        executable_amount = QuickAdapterV3._quantize_trade_amount(
-            trade,
-            wallet_amount,
+        logger.error(
+            f"[{trade.pair}] Cannot preflight partial take-profit for trade "
+            f"{trade.id}: wallet amount {wallet_amount} is below canonical "
+            f"exposure {required_wallet_amount}"
         )
-        rounds_above_wallet = executable_amount > wallet_amount and not math.isclose(
-            executable_amount,
-            wallet_amount,
-            rel_tol=1e-9,
-            abs_tol=1e-12,
-        )
-        if (
-            not math.isfinite(executable_amount)
-            or rounds_above_wallet
-            or executable_amount < requested_amount * 0.98
-        ):
-            logger.error(
-                f"[{trade.pair}] Cannot preflight partial take-profit for trade "
-                f"{trade.id}: wallet amount rounds below the 2% safety bound"
-            )
-            return None
-        logger.info(
-            f"[{trade.pair}] Clamping partial take-profit for trade {trade.id} "
-            f"from {requested_amount} to wallet amount {executable_amount}"
-        )
-        return executable_amount
+        return None
 
     def _effective_exit_min_stake(
         self,
@@ -1865,7 +1890,7 @@ class QuickAdapterV3(IStrategy):
         ):
             raise ValueError("Invalid take-profit minimum-stake inputs")
 
-        if not self._uses_live_exit_minimums():
+        if not self._uses_live_exit_constraints():
             return min_stake
 
         margin_reserve = 1.0 + float(
@@ -1903,7 +1928,7 @@ class QuickAdapterV3(IStrategy):
     ) -> Optional[float] | tuple[Optional[float], Optional[str]]:
         pair = trade.pair
 
-        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade, current_time)
         if take_profit_state is None or take_profit_state.blocked_reason is not None:
             return None
 
@@ -1942,6 +1967,12 @@ class QuickAdapterV3(IStrategy):
             take_profit_state
         )
         if take_profit_stage not in QuickAdapterV3.partial_exit_stages:
+            return None
+        if not TakeProfitStageManager.is_attempt_due(
+            take_profit_state,
+            take_profit_stage,
+            current_time,
+        ):
             return None
 
         df, _ = self.dp.get_analyzed_dataframe(
@@ -2040,7 +2071,7 @@ class QuickAdapterV3(IStrategy):
             leverage = float(trade.leverage)
             if not math.isfinite(leverage) or leverage <= 0.0:
                 return None
-            minimum_leverage = leverage if self._uses_live_exit_minimums() else 1.0
+            minimum_leverage = leverage if self._uses_live_exit_constraints() else 1.0
             outgoing_stake = executable_amount * current_exit_rate / minimum_leverage
             remaining_stake = (
                 (trade.amount - executable_amount)
@@ -2546,7 +2577,7 @@ class QuickAdapterV3(IStrategy):
     ) -> Optional[str]:
         self.safe_append_trade_unrealized_pnl(trade, current_profit)
 
-        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
+        take_profit_state = QuickAdapterV3._get_take_profit_state(trade, current_time)
         if take_profit_state is None or take_profit_state.blocked_reason is not None:
             return None
         active_attempt = take_profit_state.active_attempt
@@ -2563,7 +2594,7 @@ class QuickAdapterV3(IStrategy):
                 )
                 QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
                 logger.error(
-                    f"[{pair}] Final take-profit attempt {active_attempt.attempt_id} "
+                    f"[{pair}] Take-profit attempt {active_attempt.attempt_id} "
                     f"for trade {trade.id} has no persisted order; automatic "
                     "take-profit is fail-closed until exchange reconciliation"
                 )
@@ -2637,6 +2668,12 @@ class QuickAdapterV3(IStrategy):
 
         trade_exit_stage = TakeProfitStageManager.get_execution_stage(take_profit_state)
         if trade_exit_stage in QuickAdapterV3.partial_exit_stages:
+            return None
+        if not TakeProfitStageManager.is_attempt_due(
+            take_profit_state,
+            trade_exit_stage,
+            current_time,
+        ):
             return None
 
         trade_take_profit_price = self.get_take_profit_price(
@@ -2740,18 +2777,31 @@ class QuickAdapterV3(IStrategy):
             )
 
         if trade_exit:
-            requested_amount = QuickAdapterV3._quantize_trade_amount(
-                trade,
-                trade.amount,
-            )
-            if requested_amount <= 0.0 or trade.stake_amount <= 0.0:
+            # Freqtrade confirms the raw trade amount before exchange quantization.
+            try:
+                requested_amount = float(trade.amount)
+                requested_stake_amount = float(trade.stake_amount)
+                executable_amount = QuickAdapterV3._quantize_trade_amount(
+                    trade,
+                    requested_amount,
+                )
+            except (TypeError, ValueError, OverflowError):
+                return None
+            if (
+                not math.isfinite(requested_amount)
+                or requested_amount <= 0.0
+                or not math.isfinite(executable_amount)
+                or executable_amount <= 0.0
+                or not math.isfinite(requested_stake_amount)
+                or requested_stake_amount <= 0.0
+            ):
                 return None
             take_profit_state = TakeProfitStageManager.start_attempt(
                 trade,
                 take_profit_state,
                 stage=trade_exit_stage,
                 amount=requested_amount,
-                stake_amount=trade.stake_amount,
+                stake_amount=requested_stake_amount,
                 attempt_id=uuid.uuid4().hex,
                 status="proposed",
                 current_time=current_time,
@@ -2784,8 +2834,15 @@ class QuickAdapterV3(IStrategy):
             exit_reason in QuickAdapterV3._PROTECTIVE_EXIT_REASONS
             or exit_reason in QuickAdapterV3._OPERATOR_EXIT_REASONS
         )
+        loaded_state: TakeProfitStageState | None = None
+        take_profit_state: TakeProfitStageState | None = None
+        adjustment_id: str | None = None
+        persisted_payload_before: object = None
 
         try:
+            persisted_payload_before = trade.get_custom_data(
+                QuickAdapterV3._TAKE_PROFIT_STATE_KEY
+            )
             loaded_state = QuickAdapterV3._load_take_profit_state(
                 trade,
                 validate_trade_amount_on_initialize=False,
@@ -2905,6 +2962,18 @@ class QuickAdapterV3(IStrategy):
                     f"{trade.id} although its wallet adjustment could not be audited"
                 )
                 return True
+            if (
+                loaded_state is not None
+                and take_profit_state is not None
+                and adjustment_id is not None
+            ):
+                QuickAdapterV3._restore_unpersisted_exit_adjustment(
+                    trade,
+                    loaded_state,
+                    take_profit_state,
+                    adjustment_id,
+                    persisted_payload_before,
+                )
             logger.exception(
                 f"[{pair}] Denied exit {exit_reason!r} for trade {trade.id} "
                 "because its execution state could not be persisted"

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -11,6 +11,7 @@ from typing import (
     ClassVar,
     Final,
     Literal,
+    NamedTuple,
     Optional,
     Sequence,
 )
@@ -18,13 +19,13 @@ from typing import (
 import numpy as np
 import pandas_ta as pta
 import talib.abstract as ta
-from freqtrade.constants import DEFAULT_AMOUNT_RESERVE_PERCENT
 from freqtrade.exchange import (
     amount_to_contract_precision,
     timeframe_to_minutes,
     timeframe_to_prev_date,
 )
 from freqtrade.persistence import Trade
+from freqtrade.persistence.custom_data import _CustomData as FreqtradeCustomData
 from freqtrade.strategy import AnnotationType, stoploss_from_absolute
 from freqtrade.strategy.interface import IStrategy
 from freqtrade.util import FtPrecise
@@ -37,6 +38,7 @@ from LabelTransformer import (
 )
 from pandas import DataFrame, Series, isna
 from scipy.stats import pearsonr, t
+from sqlalchemy import inspect as sqlalchemy_inspect
 from TakeProfitStageManager import (
     TakeProfitFinalStageDefinition,
     TakeProfitPlanSignature,
@@ -101,6 +103,12 @@ CandleDeviationCacheKey = tuple[
 CandleThresholdCacheKey = tuple[str, DfSignature, str, int, float, float]
 
 logger = logging.getLogger(__name__)
+
+
+class _SafeExitAmountMutation(NamedTuple):
+    trade: Trade
+    previous_amount: float
+    adjusted_amount: float
 
 
 class QuickAdapterV3(IStrategy):
@@ -1348,43 +1356,151 @@ class QuickAdapterV3(IStrategy):
         if persisted_payload != payload:
             raise RuntimeError("Take-profit state persistence verification failed")
 
+    @staticmethod
+    def _capture_safe_exit_amount_mutation(
+        trade: Trade,
+        confirmed_amount: float,
+        *,
+        allow_wallet_adjustment: bool,
+    ) -> Optional[_SafeExitAmountMutation]:
+        """Capture Freqtrade's pre-callback wallet fallback on the ORM trade."""
+        if (
+            not allow_wallet_adjustment
+            or not isinstance(trade, Trade)
+            or trade.id is None
+        ):
+            return None
+
+        session = getattr(Trade, "session", None)
+        if session is None:
+            return None
+        canonical_trade = session.get(Trade, trade.id)
+        if canonical_trade is None:
+            return None
+        amount_history = sqlalchemy_inspect(canonical_trade).attrs.amount.history
+        if len(amount_history.added) != 1 or len(amount_history.deleted) != 1:
+            return None
+
+        previous_amount = float(amount_history.deleted[0])
+        adjusted_amount = float(amount_history.added[0])
+        if (
+            not math.isfinite(previous_amount)
+            or previous_amount <= 0.0
+            or not math.isfinite(adjusted_amount)
+            or adjusted_amount <= 0.0
+            or adjusted_amount >= previous_amount
+            or adjusted_amount <= previous_amount * 0.98
+            or not math.isclose(
+                float(canonical_trade.amount),
+                adjusted_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            or not math.isclose(
+                float(trade.amount),
+                adjusted_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            or not math.isclose(
+                float(confirmed_amount),
+                adjusted_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+        ):
+            return None
+        return _SafeExitAmountMutation(
+            trade=canonical_trade,
+            previous_amount=previous_amount,
+            adjusted_amount=adjusted_amount,
+        )
+
+    @staticmethod
+    def _has_matching_exit_adjustment(
+        state: TakeProfitStageState,
+        mutation: _SafeExitAmountMutation,
+        *,
+        adjustment_id: Optional[str] = None,
+    ) -> bool:
+        return any(
+            adjustment.is_active
+            and (adjustment_id is None or adjustment.adjustment_id == adjustment_id)
+            and math.isclose(
+                adjustment.previous_amount,
+                mutation.previous_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            and math.isclose(
+                adjustment.adjusted_amount,
+                mutation.adjusted_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            for adjustment in state.exposure_adjustments
+        )
+
+    @staticmethod
+    def _restore_safe_exit_amount_mutation(
+        mutation: _SafeExitAmountMutation,
+    ) -> None:
+        if math.isclose(
+            float(mutation.trade.amount),
+            mutation.adjusted_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            mutation.trade.amount = mutation.previous_amount
+
+    @classmethod
+    def _read_take_profit_payload(
+        cls,
+        trade: Trade,
+    ) -> tuple[bool, object]:
+        """Read persisted state, recovering Freqtrade's dedicated data session once."""
+        try:
+            return True, trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+        except Exception:
+            try:
+                FreqtradeCustomData.session.rollback()
+                return True, trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+            except Exception:
+                return False, None
+
     @classmethod
     def _restore_unpersisted_exit_adjustment(
         cls,
-        trade: Trade,
+        mutation: _SafeExitAmountMutation,
         previous_state: TakeProfitStageState,
         candidate_state: TakeProfitStageState,
         adjustment_id: str,
         persisted_payload_before: object,
     ) -> None:
         """Restore a denied exit amount only when its adjustment was not persisted."""
-        previous_adjustment_ids = {
-            adjustment.adjustment_id
-            for adjustment in previous_state.exposure_adjustments
-        }
-        matching_adjustments = tuple(
-            adjustment
-            for adjustment in candidate_state.exposure_adjustments
-            if adjustment.is_active
-            and adjustment.adjustment_id == adjustment_id
-            and adjustment.adjustment_id not in previous_adjustment_ids
-        )
-        if len(matching_adjustments) != 1:
-            return
-        adjustment = matching_adjustments[0]
-        if not math.isclose(
-            trade.amount,
-            adjustment.adjusted_amount,
-            rel_tol=1e-9,
-            abs_tol=1e-12,
+        if cls._has_matching_exit_adjustment(
+            previous_state,
+            mutation,
+            adjustment_id=adjustment_id,
         ):
             return
-        try:
-            persisted_payload = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
-        except Exception:
+        if not cls._has_matching_exit_adjustment(
+            candidate_state,
+            mutation,
+            adjustment_id=adjustment_id,
+        ):
+            cls._restore_safe_exit_amount_mutation(mutation)
             return
-        if persisted_payload == persisted_payload_before:
-            trade.amount = adjustment.previous_amount
+        payload_read, persisted_payload = cls._read_take_profit_payload(mutation.trade)
+        if payload_read and persisted_payload == persisted_payload_before:
+            cls._restore_safe_exit_amount_mutation(mutation)
+
+    @staticmethod
+    def _is_entry_exposure_finalized(trade: Trade) -> bool:
+        trading_mode = getattr(trade, "trading_mode", "spot")
+        if getattr(trading_mode, "value", trading_mode) == "futures":
+            return True
+        return trade.fee_updated(trade.entry_side)
 
     @classmethod
     def _load_take_profit_state(
@@ -1397,6 +1513,8 @@ class QuickAdapterV3(IStrategy):
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
         raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
         if raw_state is None:
+            if not cls._is_entry_exposure_finalized(trade):
+                return None
             try:
                 state = TakeProfitStageManager.initialize(
                     trade,
@@ -1872,45 +1990,33 @@ class QuickAdapterV3(IStrategy):
         )
         return None
 
-    def _effective_exit_min_stake(
+    def _get_exit_min_stake(
         self,
-        min_stake: Optional[float],
-        current_entry_rate: float,
+        trade: Trade,
+        callback_min_stake: Optional[float],
         current_exit_rate: float,
     ) -> Optional[float]:
-        if min_stake is None or min_stake == 0.0:
-            return None
-        if (
-            not math.isfinite(min_stake)
-            or min_stake < 0.0
-            or not math.isfinite(current_entry_rate)
-            or current_entry_rate <= 0.0
-            or not math.isfinite(current_exit_rate)
-            or current_exit_rate <= 0.0
-        ):
-            raise ValueError("Invalid take-profit minimum-stake inputs")
-
         if not self._uses_live_exit_constraints():
-            return min_stake
-
-        margin_reserve = 1.0 + float(
-            self.config.get(
-                "amount_reserve_percent",
-                DEFAULT_AMOUNT_RESERVE_PERCENT,
+            exit_min_stake = callback_min_stake
+        else:
+            if not math.isfinite(current_exit_rate) or current_exit_rate <= 0.0:
+                raise ValueError("Invalid current exit rate")
+            data_provider = getattr(self, "dp", None)
+            exchange = getattr(data_provider, "_exchange", None)
+            if exchange is None:
+                raise ValueError("Exchange is unavailable")
+            exit_min_stake = exchange.get_min_pair_stake_amount(
+                trade.pair,
+                current_exit_rate,
+                self.stoploss,
+                trade.leverage,
             )
-        )
-        if not math.isfinite(margin_reserve) or margin_reserve <= 0.0:
-            raise ValueError("Invalid amount_reserve_percent")
-        stoploss = abs(float(self.stoploss))
-        if not math.isfinite(stoploss) or stoploss > 1.0:
-            raise ValueError("Invalid stoploss")
-        stoploss_reserve = margin_reserve / (1.0 - stoploss) if stoploss != 1.0 else 1.5
-        stoploss_reserve = max(1.0, min(stoploss_reserve, 1.5))
-        return min_stake * max(
-            1.0,
-            current_exit_rate / current_entry_rate,
-            stoploss_reserve / margin_reserve,
-        )
+
+        if exit_min_stake is None or exit_min_stake == 0.0:
+            return None
+        if not math.isfinite(exit_min_stake) or exit_min_stake < 0.0:
+            raise ValueError("Invalid exit minimum stake")
+        return exit_min_stake
 
     def adjust_trade_position(
         self,
@@ -2057,9 +2163,9 @@ class QuickAdapterV3(IStrategy):
                 )
                 return None
             try:
-                effective_min_stake = self._effective_exit_min_stake(
+                effective_min_stake = self._get_exit_min_stake(
+                    trade,
                     min_stake,
-                    current_entry_rate,
                     current_exit_rate,
                 )
             except (TypeError, ValueError, OverflowError) as error:
@@ -2838,11 +2944,28 @@ class QuickAdapterV3(IStrategy):
         take_profit_state: TakeProfitStageState | None = None
         adjustment_id: str | None = None
         persisted_payload_before: object = None
+        safe_exit_amount_mutation: _SafeExitAmountMutation | None = None
 
         try:
-            persisted_payload_before = trade.get_custom_data(
-                QuickAdapterV3._TAKE_PROFIT_STATE_KEY
+            trading_mode = getattr(self, "config", {}).get(
+                "trading_mode",
+                "spot",
             )
+            allow_wallet_adjustment = (
+                getattr(trading_mode, "value", trading_mode) != "futures"
+            )
+            safe_exit_amount_mutation = (
+                QuickAdapterV3._capture_safe_exit_amount_mutation(
+                    trade,
+                    amount,
+                    allow_wallet_adjustment=allow_wallet_adjustment,
+                )
+            )
+            payload_read, persisted_payload_before = (
+                QuickAdapterV3._read_take_profit_payload(trade)
+            )
+            if not payload_read:
+                raise RuntimeError("Take-profit state persistence is unavailable")
             loaded_state = QuickAdapterV3._load_take_profit_state(
                 trade,
                 validate_trade_amount_on_initialize=False,
@@ -2854,7 +2977,31 @@ class QuickAdapterV3(IStrategy):
                         f"{trade.id} without a loadable take-profit audit state"
                     )
                     return True
+                if (
+                    persisted_payload_before is None
+                    and not QuickAdapterV3._is_entry_exposure_finalized(trade)
+                    and parsed_tag is None
+                    and not malformed_take_profit_tag
+                    and not trade.has_open_orders
+                ):
+                    logger.warning(
+                        f"[{pair}] Allowing non-take-profit exit {exit_reason!r} "
+                        f"for trade {trade.id} before its entry fee is finalized"
+                    )
+                    return True
+                if safe_exit_amount_mutation is not None:
+                    QuickAdapterV3._restore_safe_exit_amount_mutation(
+                        safe_exit_amount_mutation
+                    )
                 return False
+            if (
+                safe_exit_amount_mutation is not None
+                and QuickAdapterV3._has_matching_exit_adjustment(
+                    loaded_state,
+                    safe_exit_amount_mutation,
+                )
+            ):
+                safe_exit_amount_mutation = None
             take_profit_state = loaded_state
             active_attempt = take_profit_state.active_attempt
             adjustment_id = (
@@ -2864,11 +3011,6 @@ class QuickAdapterV3(IStrategy):
                 and active_attempt.tag == exit_reason
                 else uuid.uuid4().hex
             )
-            trading_mode = getattr(self, "config", {}).get(
-                "trading_mode",
-                "spot",
-            )
-            trading_mode_value = getattr(trading_mode, "value", trading_mode)
             take_profit_state = TakeProfitStageManager.reconcile_for_exit_confirmation(
                 trade,
                 take_profit_state,
@@ -2876,7 +3018,7 @@ class QuickAdapterV3(IStrategy):
                 exit_reason=exit_reason,
                 adjustment_id=adjustment_id,
                 current_time=current_time,
-                allow_wallet_adjustment=trading_mode_value != "futures",
+                allow_wallet_adjustment=allow_wallet_adjustment,
                 amount_quantizer=partial(
                     QuickAdapterV3._quantize_trade_amount,
                     trade,
@@ -2953,10 +3095,25 @@ class QuickAdapterV3(IStrategy):
                     )
                     allowed = True
 
+            if (
+                not allowed
+                and not safety_exit
+                and safe_exit_amount_mutation is not None
+                and not QuickAdapterV3._has_matching_exit_adjustment(
+                    take_profit_state,
+                    safe_exit_amount_mutation,
+                    adjustment_id=adjustment_id,
+                )
+            ):
+                QuickAdapterV3._restore_safe_exit_amount_mutation(
+                    safe_exit_amount_mutation
+                )
+
             QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
             return allowed
         except Exception:
             if safety_exit:
+                QuickAdapterV3._read_take_profit_payload(trade)
                 logger.exception(
                     f"[{pair}] Allowing safety exit {exit_reason!r} for trade "
                     f"{trade.id} although its wallet adjustment could not be audited"
@@ -2966,13 +3123,18 @@ class QuickAdapterV3(IStrategy):
                 loaded_state is not None
                 and take_profit_state is not None
                 and adjustment_id is not None
+                and safe_exit_amount_mutation is not None
             ):
                 QuickAdapterV3._restore_unpersisted_exit_adjustment(
-                    trade,
+                    safe_exit_amount_mutation,
                     loaded_state,
                     take_profit_state,
                     adjustment_id,
                     persisted_payload_before,
+                )
+            elif safe_exit_amount_mutation is not None:
+                QuickAdapterV3._restore_safe_exit_amount_mutation(
+                    safe_exit_amount_mutation
                 )
             logger.exception(
                 f"[{pair}] Denied exit {exit_reason!r} for trade {trade.id} "

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -18,6 +18,7 @@ from typing import (
 import numpy as np
 import pandas_ta as pta
 import talib.abstract as ta
+from freqtrade.constants import DEFAULT_AMOUNT_RESERVE_PERCENT
 from freqtrade.exchange import (
     amount_to_contract_precision,
     timeframe_to_minutes,
@@ -26,6 +27,7 @@ from freqtrade.exchange import (
 from freqtrade.persistence import Trade
 from freqtrade.strategy import AnnotationType, stoploss_from_absolute
 from freqtrade.strategy.interface import IStrategy
+from freqtrade.util import FtPrecise
 from LabelTransformer import (
     COMBINED_AGGREGATIONS,
     FILL_METHODS,
@@ -456,10 +458,10 @@ class QuickAdapterV3(IStrategy):
                 "QuickAdapter requires unfilledtimeout.exit_timeout_count = 0 "
                 "so one component owns partial-exit retries"
             )
-        if self.order_types.get("exit", "limit") != "limit":
+        if self.order_types.get("stoploss_on_exchange", False):
             raise ValueError(
-                "QuickAdapter requires limit exit orders so custom_exit_price can "
-                "persist the take-profit submission boundary"
+                "QuickAdapter does not support stoploss_on_exchange because "
+                "Freqtrade does not expose trustworthy stoploss cancellation provenance"
             )
         self.pairs: list[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
@@ -1337,10 +1339,19 @@ class QuickAdapterV3(IStrategy):
         trade: Trade,
         state: TakeProfitStageState,
     ) -> None:
-        trade.set_custom_data(cls._TAKE_PROFIT_STATE_KEY, state.to_mapping())
+        payload = state.to_mapping()
+        trade.set_custom_data(cls._TAKE_PROFIT_STATE_KEY, payload)
+        persisted_payload = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
+        if persisted_payload != payload:
+            raise RuntimeError("Take-profit state persistence verification failed")
 
     @classmethod
-    def _get_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
+    def _load_take_profit_state(
+        cls,
+        trade: Trade,
+        *,
+        validate_trade_amount_on_initialize: bool = True,
+    ) -> Optional[tuple[TakeProfitStageState, int]]:
         amount_quantizer = partial(cls._quantize_trade_amount, trade)
         raw_state = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY)
         if raw_state is None:
@@ -1349,6 +1360,7 @@ class QuickAdapterV3(IStrategy):
                     trade,
                     cls.get_take_profit_plan_signature(),
                     amount_quantizer=amount_quantizer,
+                    validate_trade_amount=validate_trade_amount_on_initialize,
                 )
             except ValueError as error:
                 logger.error(
@@ -1358,13 +1370,17 @@ class QuickAdapterV3(IStrategy):
                 return None
             if state.blocked_reason == "open_entry_order":
                 return None
-            cls._save_take_profit_state(trade, state)
-            if state.blocked_reason is not None:
-                cls._log_take_profit_block(trade, state)
+            source_version = TakeProfitStageState.SCHEMA_VERSION
         else:
             try:
                 if not isinstance(raw_state, dict):
                     raise ValueError("Take-profit state must be a mapping")
+                source_version = raw_state.get("version")
+                if isinstance(source_version, bool) or not isinstance(
+                    source_version,
+                    int,
+                ):
+                    raise ValueError("Take-profit state version must be an integer")
                 state = TakeProfitStageState.from_mapping(raw_state)
             except ValueError as error:
                 logger.error(
@@ -1382,17 +1398,32 @@ class QuickAdapterV3(IStrategy):
             )
             return None
 
-        reconciled_state = TakeProfitStageManager.reconcile(
+        return state, source_version
+
+    @classmethod
+    def _get_take_profit_state(cls, trade: Trade) -> Optional[TakeProfitStageState]:
+        loaded_state = cls._load_take_profit_state(trade)
+        if loaded_state is None:
+            return None
+        state, source_version = loaded_state
+        amount_quantizer = partial(cls._quantize_trade_amount, trade)
+
+        reconciled_state = TakeProfitStageManager.reconcile_migrated_state(
             trade,
             state,
+            source_version,
             amount_quantizer=amount_quantizer,
         )
-        if reconciled_state != state:
+        was_unpersisted = trade.get_custom_data(cls._TAKE_PROFIT_STATE_KEY) is None
+        if (
+            source_version != TakeProfitStageState.SCHEMA_VERSION
+            or reconciled_state != state
+            or was_unpersisted
+        ):
             cls._save_take_profit_state(trade, reconciled_state)
             if (
-                state.blocked_reason is None
-                and reconciled_state.blocked_reason is not None
-            ):
+                was_unpersisted or state.blocked_reason is None
+            ) and reconciled_state.blocked_reason is not None:
                 cls._log_take_profit_block(trade, reconciled_state)
         return reconciled_state
 
@@ -1722,6 +1753,64 @@ class QuickAdapterV3(IStrategy):
             f"Deferring non-executable take-profit remainder: {reason}"
         )
 
+    @staticmethod
+    def _position_adjustment_amount(
+        trade: Trade,
+        stake_amount: float,
+    ) -> float:
+        amount = abs(
+            float(
+                FtPrecise(stake_amount)
+                * FtPrecise(trade.amount)
+                / FtPrecise(trade.stake_amount)
+            )
+        )
+        return QuickAdapterV3._quantize_trade_amount(trade, amount)
+
+    def _uses_live_exit_minimums(self) -> bool:
+        runmode = self.config.get("runmode")
+        return getattr(runmode, "value", runmode) in {"live", "dry_run"}
+
+    def _effective_exit_min_stake(
+        self,
+        min_stake: Optional[float],
+        current_entry_rate: float,
+        current_exit_rate: float,
+    ) -> Optional[float]:
+        if min_stake is None or min_stake == 0.0:
+            return None
+        if (
+            not math.isfinite(min_stake)
+            or min_stake < 0.0
+            or not math.isfinite(current_entry_rate)
+            or current_entry_rate <= 0.0
+            or not math.isfinite(current_exit_rate)
+            or current_exit_rate <= 0.0
+        ):
+            raise ValueError("Invalid take-profit minimum-stake inputs")
+
+        if not self._uses_live_exit_minimums():
+            return min_stake
+
+        margin_reserve = 1.0 + float(
+            self.config.get(
+                "amount_reserve_percent",
+                DEFAULT_AMOUNT_RESERVE_PERCENT,
+            )
+        )
+        if not math.isfinite(margin_reserve) or margin_reserve <= 0.0:
+            raise ValueError("Invalid amount_reserve_percent")
+        stoploss = abs(float(self.stoploss))
+        if not math.isfinite(stoploss) or stoploss > 1.0:
+            raise ValueError("Invalid stoploss")
+        stoploss_reserve = margin_reserve / (1.0 - stoploss) if stoploss != 1.0 else 1.5
+        stoploss_reserve = max(1.0, min(stoploss_reserve, 1.5))
+        return min_stake * max(
+            1.0,
+            current_exit_rate / current_entry_rate,
+            stoploss_reserve / margin_reserve,
+        )
+
     def adjust_trade_position(
         self,
         trade: Trade,
@@ -1831,18 +1920,88 @@ class QuickAdapterV3(IStrategy):
             adjustment_stake_amount = (
                 requested_amount * trade.stake_amount / trade.amount
             )
+            executable_amount = QuickAdapterV3._position_adjustment_amount(
+                trade,
+                adjustment_stake_amount,
+            )
+            if executable_amount <= 0.0:
+                QuickAdapterV3._defer_take_profit_stage(
+                    trade,
+                    take_profit_state,
+                    take_profit_stage,
+                    "Freqtrade quantity rounds to zero",
+                )
+                return None
+            if executable_amount > trade.amount and not math.isclose(
+                executable_amount,
+                trade.amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            ):
+                QuickAdapterV3._defer_take_profit_stage(
+                    trade,
+                    take_profit_state,
+                    take_profit_stage,
+                    "Freqtrade quantity exceeds the remaining trade amount",
+                )
+                return None
+            try:
+                effective_min_stake = self._effective_exit_min_stake(
+                    min_stake,
+                    current_entry_rate,
+                    current_exit_rate,
+                )
+            except (TypeError, ValueError, OverflowError) as error:
+                logger.warning(
+                    f"[{pair}] Cannot validate take-profit stage {take_profit_stage} "
+                    f"against exchange minimums: {error}"
+                )
+                return None
+            leverage = float(trade.leverage)
+            if not math.isfinite(leverage) or leverage <= 0.0:
+                return None
+            minimum_leverage = leverage if self._uses_live_exit_minimums() else 1.0
+            outgoing_stake = executable_amount * current_exit_rate / minimum_leverage
+            remaining_stake = (trade.amount - executable_amount) * current_exit_rate
+            if effective_min_stake is not None and outgoing_stake < effective_min_stake:
+                QuickAdapterV3._defer_take_profit_stage(
+                    trade,
+                    take_profit_state,
+                    take_profit_stage,
+                    f"exit stake {outgoing_stake} is below {effective_min_stake}",
+                )
+                return None
+            if (
+                effective_min_stake is not None
+                and remaining_stake != 0.0
+                and remaining_stake < effective_min_stake
+            ):
+                QuickAdapterV3._defer_take_profit_stage(
+                    trade,
+                    take_profit_state,
+                    take_profit_stage,
+                    f"remaining stake {remaining_stake} is below {effective_min_stake}",
+                )
+                return None
             take_profit_state = TakeProfitStageManager.start_attempt(
                 trade,
                 take_profit_state,
                 stage=take_profit_stage,
-                amount=requested_amount,
+                amount=executable_amount,
                 stake_amount=adjustment_stake_amount,
                 attempt_id=uuid.uuid4().hex,
-                status="proposed",
+                status="submitting",
                 current_time=current_time,
                 recovery_deadline=self._get_take_profit_recovery_deadline(current_time),
             )
-            QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            try:
+                QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            except Exception:
+                logger.exception(
+                    f"[{pair}] Take-profit stage {take_profit_stage} was not "
+                    "submitted because its execution state could not be persisted"
+                )
+                return None
             active_attempt = take_profit_state.active_attempt
             if active_attempt is None:
                 return None
@@ -1863,22 +2022,6 @@ class QuickAdapterV3(IStrategy):
         exit_tag: Optional[str],
         **kwargs,
     ) -> float:
-        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
-        if take_profit_state is None:
-            return proposed_rate
-        active_attempt = take_profit_state.active_attempt
-        if (
-            active_attempt is not None
-            and active_attempt.stage in QuickAdapterV3.partial_exit_stages
-            and exit_tag == active_attempt.tag
-        ):
-            submitting_state = TakeProfitStageManager.mark_submitting(
-                take_profit_state,
-                active_attempt.attempt_id,
-                current_time,
-            )
-            if submitting_state != take_profit_state:
-                QuickAdapterV3._save_take_profit_state(trade, submitting_state)
         return proposed_rate
 
     @staticmethod
@@ -2552,86 +2695,144 @@ class QuickAdapterV3(IStrategy):
         **kwargs,
     ) -> bool:
         parsed_tag = TakeProfitStageManager.parse_order_tag(exit_reason)
-        if parsed_tag is None:
-            if TakeProfitStageManager.has_order_tag_prefix(exit_reason):
+        malformed_take_profit_tag = (
+            parsed_tag is None
+            and TakeProfitStageManager.has_order_tag_prefix(exit_reason)
+        )
+        safety_exit = (
+            exit_reason in QuickAdapterV3._PROTECTIVE_EXIT_REASONS
+            or exit_reason in QuickAdapterV3._OPERATOR_EXIT_REASONS
+        )
+
+        try:
+            loaded_state = QuickAdapterV3._load_take_profit_state(
+                trade,
+                validate_trade_amount_on_initialize=False,
+            )
+            if loaded_state is None:
+                if safety_exit:
+                    logger.warning(
+                        f"[{pair}] Allowing safety exit {exit_reason!r} for trade "
+                        f"{trade.id} without a loadable take-profit audit state"
+                    )
+                    return True
+                return False
+            take_profit_state, source_version = loaded_state
+            take_profit_state = TakeProfitStageManager.prepare_migrated_state(
+                take_profit_state,
+                source_version,
+            )
+            active_attempt = take_profit_state.active_attempt
+            adjustment_id = (
+                active_attempt.attempt_id
+                if active_attempt is not None
+                and active_attempt.status == "proposed"
+                and active_attempt.tag == exit_reason
+                else uuid.uuid4().hex
+            )
+            trading_mode = getattr(self, "config", {}).get(
+                "trading_mode",
+                "spot",
+            )
+            trading_mode_value = getattr(trading_mode, "value", trading_mode)
+            take_profit_state = TakeProfitStageManager.reconcile_for_exit_confirmation(
+                trade,
+                take_profit_state,
+                confirmed_amount=amount,
+                exit_reason=exit_reason,
+                adjustment_id=adjustment_id,
+                current_time=current_time,
+                allow_wallet_adjustment=trading_mode_value != "futures",
+                amount_quantizer=partial(
+                    QuickAdapterV3._quantize_trade_amount,
+                    trade,
+                ),
+            )
+
+            allowed = False
+            if take_profit_state.blocked_reason is not None:
+                QuickAdapterV3._log_take_profit_block(trade, take_profit_state)
+                allowed = safety_exit
+            elif safety_exit:
+                allowed = True
+            elif malformed_take_profit_tag:
                 logger.error(
                     f"[{pair}] Denied malformed take-profit exit tag "
                     f"{exit_reason!r} for trade {trade.id}"
                 )
-                return False
-            if exit_reason in QuickAdapterV3._PROTECTIVE_EXIT_REASONS:
-                return True
-
-            take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
-            if exit_reason in QuickAdapterV3._OPERATOR_EXIT_REASONS:
-                if not QuickAdapterV3._allows_discretionary_exit(
+            elif parsed_tag is None:
+                allowed = QuickAdapterV3._allows_discretionary_exit(
                     trade,
                     take_profit_state,
-                ):
+                )
+                if not allowed:
                     logger.warning(
-                        f"[{pair}] Allowing operator safety exit {exit_reason!r} for "
+                        f"[{pair}] Denied discretionary exit {exit_reason!r} for "
                         f"trade {trade.id} while take-profit execution is not idle"
                     )
-                return True
-            if not QuickAdapterV3._allows_discretionary_exit(
-                trade,
-                take_profit_state,
-            ):
-                logger.warning(
-                    f"[{pair}] Denied discretionary exit {exit_reason!r} for trade "
-                    f"{trade.id} while take-profit execution is not idle"
+            elif trade.has_open_orders:
+                logger.error(
+                    f"[{pair}] Denied take-profit exit tag {exit_reason!r} for "
+                    f"trade {trade.id} while another order is open"
                 )
-                return False
-            return True
-        take_profit_state = QuickAdapterV3._get_take_profit_state(trade)
-        if take_profit_state is None or take_profit_state.blocked_reason is not None:
-            return False
-        if trade.has_open_orders:
-            logger.error(
-                f"[{pair}] Denied take-profit exit tag {exit_reason!r} for trade "
-                f"{trade.id} while another order is open"
-            )
-            return False
-        active_attempt = take_profit_state.active_attempt
-        final_stage = take_profit_state.plan_signature.final_stage.stage
-        if active_attempt is None or (
-            active_attempt.stage != final_stage
-            or active_attempt.tag != exit_reason
-            or active_attempt.exit_side != trade.exit_side
-            or parsed_tag
-            != (
-                trade.trade_direction,
-                final_stage,
-                active_attempt.attempt_id,
-            )
-        ):
-            logger.error(
-                f"[{pair}] Denied untracked take-profit exit tag {exit_reason!r} "
-                f"for trade {trade.id}"
-            )
-            return False
+            else:
+                active_attempt = take_profit_state.active_attempt
+                final_stage = take_profit_state.plan_signature.final_stage.stage
+                if active_attempt is None or (
+                    active_attempt.status != "proposed"
+                    or active_attempt.stage != final_stage
+                    or active_attempt.tag != exit_reason
+                    or active_attempt.exit_side != trade.exit_side
+                    or parsed_tag
+                    != (
+                        trade.trade_direction,
+                        final_stage,
+                        active_attempt.attempt_id,
+                    )
+                ):
+                    logger.error(
+                        f"[{pair}] Denied untracked take-profit exit tag "
+                        f"{exit_reason!r} for trade {trade.id}"
+                    )
+                elif (
+                    not math.isfinite(amount)
+                    or amount <= 0.0
+                    or trade.amount <= 0.0
+                    or trade.stake_amount <= 0.0
+                ):
+                    logger.error(
+                        f"[{pair}] Denied take-profit exit tag {exit_reason!r} for "
+                        f"trade {trade.id} with invalid exposure"
+                    )
+                else:
+                    stake_amount = amount * trade.stake_amount / trade.amount
+                    take_profit_state = TakeProfitStageManager.update_attempt_amount(
+                        take_profit_state,
+                        active_attempt.attempt_id,
+                        amount,
+                        stake_amount,
+                    )
+                    take_profit_state = TakeProfitStageManager.mark_submitting(
+                        take_profit_state,
+                        active_attempt.attempt_id,
+                        current_time,
+                    )
+                    allowed = True
 
-        if (
-            not math.isfinite(amount)
-            or amount <= 0.0
-            or trade.amount <= 0.0
-            or trade.stake_amount <= 0.0
-        ):
+            QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
+            return allowed
+        except Exception:
+            if safety_exit:
+                logger.exception(
+                    f"[{pair}] Allowing safety exit {exit_reason!r} for trade "
+                    f"{trade.id} although its wallet adjustment could not be audited"
+                )
+                return True
+            logger.exception(
+                f"[{pair}] Denied exit {exit_reason!r} for trade {trade.id} "
+                "because its execution state could not be persisted"
+            )
             return False
-        stake_amount = amount * trade.stake_amount / trade.amount
-        take_profit_state = TakeProfitStageManager.update_attempt_amount(
-            take_profit_state,
-            active_attempt.attempt_id,
-            amount,
-            stake_amount,
-        )
-        take_profit_state = TakeProfitStageManager.mark_submitting(
-            take_profit_state,
-            active_attempt.attempt_id,
-            current_time,
-        )
-        QuickAdapterV3._save_take_profit_state(trade, take_profit_state)
-        return True
 
     def confirm_trade_entry(
         self,

--- a/quickadapter/user_data/strategies/TakeProfitStageManager.py
+++ b/quickadapter/user_data/strategies/TakeProfitStageManager.py
@@ -1,0 +1,133 @@
+import math
+from dataclasses import dataclass
+from typing import Mapping, Protocol, Sequence
+
+
+class _Order(Protocol):
+    ft_order_side: str
+    ft_order_tag: str | None
+    ft_is_open: bool
+    safe_amount: float
+    safe_filled: float
+
+
+class _Trade(Protocol):
+    amount: float
+    exit_side: str
+    orders: Sequence[_Order]
+    stake_amount: float
+    trade_direction: str
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitStageProgress:
+    stage: int
+    target_amount: float
+    filled_amount: float
+    remaining_amount: float
+    is_complete: bool
+
+
+class TakeProfitStageManager:
+    """Derive take-profit progress from persisted Freqtrade orders."""
+
+    _TAG_PREFIX = "take_profit"
+    _AMOUNT_REL_TOL = 1e-9
+    _AMOUNT_ABS_TOL = 1e-12
+
+    @classmethod
+    def order_tag(cls, trade_direction: str, stage: int) -> str:
+        if stage < 0:
+            raise ValueError(f"Invalid take-profit stage {stage!r}: must be non-negative")
+        return f"{cls._TAG_PREFIX}_{trade_direction}_{stage}"
+
+    @classmethod
+    def _stage_orders(cls, trade: _Trade, stage: int) -> list[_Order]:
+        order_tag = cls.order_tag(trade.trade_direction, stage)
+        return [
+            order
+            for order in trade.orders
+            if order.ft_order_side == trade.exit_side
+            and order.ft_order_tag == order_tag
+        ]
+
+    @staticmethod
+    def _safe_amount(value: object) -> float:
+        try:
+            amount = float(value)
+        except (TypeError, ValueError):
+            return 0.0
+        return amount if math.isfinite(amount) and amount > 0.0 else 0.0
+
+    @classmethod
+    def get_stage_progress(
+        cls,
+        trade: _Trade,
+        stage: int,
+        stake_fraction: float,
+    ) -> TakeProfitStageProgress:
+        if not 0.0 < stake_fraction <= 1.0:
+            raise ValueError(
+                f"Invalid take-profit stake fraction {stake_fraction!r}: "
+                "must be in range (0, 1]"
+            )
+
+        orders = cls._stage_orders(trade, stage)
+        target_amount = next(
+            (
+                amount
+                for order in orders
+                if (amount := cls._safe_amount(order.safe_amount)) > 0.0
+            ),
+            cls._safe_amount(trade.amount) * stake_fraction,
+        )
+        filled_amount = sum(cls._safe_amount(order.safe_filled) for order in orders)
+        remaining_amount = max(0.0, target_amount - filled_amount)
+        is_filled = filled_amount >= target_amount or math.isclose(
+            filled_amount,
+            target_amount,
+            rel_tol=cls._AMOUNT_REL_TOL,
+            abs_tol=cls._AMOUNT_ABS_TOL,
+        )
+        is_complete = bool(orders) and is_filled and not any(
+            order.ft_is_open for order in orders
+        )
+
+        return TakeProfitStageProgress(
+            stage=stage,
+            target_amount=target_amount,
+            filled_amount=filled_amount,
+            remaining_amount=remaining_amount,
+            is_complete=is_complete,
+        )
+
+    @classmethod
+    def get_exit_stage(
+        cls,
+        trade: _Trade,
+        stage_stake_fractions: Mapping[int, float],
+    ) -> int:
+        for stage in sorted(stage_stake_fractions):
+            progress = cls.get_stage_progress(
+                trade,
+                stage,
+                stage_stake_fractions[stage],
+            )
+            if not progress.is_complete:
+                return stage
+        return max(stage_stake_fractions, default=-1) + 1
+
+    @classmethod
+    def get_remaining_stake_amount(
+        cls,
+        trade: _Trade,
+        progress: TakeProfitStageProgress,
+    ) -> float:
+        trade_amount = cls._safe_amount(trade.amount)
+        trade_stake_amount = cls._safe_amount(trade.stake_amount)
+        if trade_amount == 0.0 or trade_stake_amount == 0.0:
+            return 0.0
+        remaining_stake_amount = (
+            progress.remaining_amount * trade_stake_amount / trade_amount
+        )
+        return min(trade_stake_amount, remaining_stake_amount)

--- a/quickadapter/user_data/strategies/TakeProfitStageManager.py
+++ b/quickadapter/user_data/strategies/TakeProfitStageManager.py
@@ -6,22 +6,60 @@ from decimal import Decimal
 from typing import Literal, Protocol, Self, final
 
 
-TakeProfitAttemptStatus = Literal["proposed", "submitting", "ambiguous"]
-TakeProfitRecoveryPolicy = Literal["tagged_or_unique_untagged", "tagged_only"]
+TakeProfitAttemptStatus = Literal["proposed", "submitting", "open", "ambiguous"]
 TakeProfitOperatorAction = Literal[
     "confirmed_no_remote_order",
+    "confirmed_terminal_canceled_fill",
     "confirmed_terminal_zero_fill",
     "revalidated_terminal_fill",
+    "restored_partial_wallet_mutation",
 ]
-TakeProfitOrderRole = Literal["strategy_exit", "external_exit"]
+TakeProfitRecoveryAction = Literal[
+    "confirm_terminal_canceled",
+    "confirm_terminal_zero",
+    "restore_partial_wallet_mutation",
+    "revalidate_terminal",
+]
+TakeProfitAttributionSource = Literal[
+    "attempt",
+    "operator",
+    "recovered_untagged",
+]
 
 
 _OPERATOR_ZERO_FILL_STATUSES = frozenset({"canceled", "cancelled"})
+_NATIVE_WALLET_RESTORATION_STATUSES = frozenset({"closed", "expired", "rejected"})
+_CONFIRMABLE_TERMINAL_BLOCK_REASONS = frozenset(
+    {
+        "confirmed_terminal_canceled_fill_changed",
+        "confirmed_terminal_zero_fill_changed",
+        "unknown_terminal_fill",
+    }
+)
+_REVALIDATABLE_TERMINAL_BLOCK_REASONS = frozenset(
+    {
+        "attributed_fill_regressed",
+        "attributed_order_amount_changed",
+        "attributed_order_tag_changed",
+        *_CONFIRMABLE_TERMINAL_BLOCK_REASONS,
+        "unattributed_exit_fill",
+    }
+)
 _BLOCKED_ORDER_ID_REASONS = frozenset(
     {
         "confirmed_terminal_zero_fill_changed",
         "confirmed_terminal_zero_fill_order_missing",
+        "confirmed_terminal_canceled_fill_changed",
+        "confirmed_terminal_canceled_fill_order_missing",
+        "attributed_fill_regressed",
+        "attributed_order_amount_changed",
+        "attributed_order_missing",
+        "attributed_order_provenance_changed",
+        "attributed_order_reopened",
+        "attributed_order_side_changed",
+        "attributed_order_tag_changed",
         "multiple_attempt_orders",
+        "partial_wallet_order_changed",
         "unknown_attempt_order",
         "unknown_external_exit_fill",
         "unknown_terminal_fill",
@@ -65,12 +103,6 @@ class _Order(Protocol):
     def safe_amount_after_fee(self) -> float: ...
 
     @property
-    def safe_filled(self) -> float: ...
-
-    @property
-    def safe_remaining(self) -> float: ...
-
-    @property
     def status(self) -> str | None: ...
 
 
@@ -88,10 +120,37 @@ class _Trade(Protocol):
     def orders(self) -> Sequence[_Order]: ...
 
     @property
-    def stake_amount(self) -> float: ...
-
-    @property
     def trade_direction(self) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitRecoveryInstruction:
+    """Single supported operator recovery path for the current blocked state."""
+
+    action: TakeProfitRecoveryAction
+    order_id: str
+    terminal_status: str | None = None
+    attempt_id: str | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.order_id)
+        if self.action == "restore_partial_wallet_mutation":
+            _non_empty_string(self.attempt_id)
+            if self.terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
+                raise ValueError("Wallet restoration has an invalid terminal status")
+        elif self.action in {
+            "confirm_terminal_canceled",
+            "confirm_terminal_zero",
+        }:
+            if self.attempt_id is not None:
+                raise ValueError("Terminal proof instruction has an attempt ID")
+            if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+                raise ValueError("Terminal proof instruction has an invalid status")
+        elif self.action == "revalidate_terminal":
+            if self.attempt_id is not None or self.terminal_status is not None:
+                raise ValueError("Revalidation instruction has terminal fields")
+        else:
+            raise ValueError(f"Invalid take-profit recovery action {self.action!r}")
 
 
 @dataclass(frozen=True, slots=True)
@@ -107,7 +166,6 @@ class TakeProfitAttempt:
     submitted_at: str | None
     recovery_deadline: str
     known_order_ids: tuple[str, ...]
-    recovery_policy: TakeProfitRecoveryPolicy
 
     def to_mapping(self) -> dict[str, object]:
         return {
@@ -122,13 +180,12 @@ class TakeProfitAttempt:
             "submitted_at": self.submitted_at,
             "recovery_deadline": self.recovery_deadline,
             "known_order_ids": list(self.known_order_ids),
-            "recovery_policy": self.recovery_policy,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
         status = value.get("status")
-        if status not in {"proposed", "submitting", "ambiguous"}:
+        if status not in {"proposed", "submitting", "open", "ambiguous"}:
             raise ValueError(f"Invalid take-profit attempt status {status!r}")
         submitted_at = value.get("submitted_at")
         if submitted_at is not None and not isinstance(submitted_at, str):
@@ -140,13 +197,6 @@ class TakeProfitAttempt:
             raise ValueError("Invalid take-profit attempt known_order_ids")
         if len(known_order_ids) != len(set(known_order_ids)):
             raise ValueError("Duplicate take-profit attempt known order")
-        recovery_policy = value.get("recovery_policy")
-        if recovery_policy not in {
-            "tagged_or_unique_untagged",
-            "tagged_only",
-        }:
-            raise ValueError("Invalid take-profit recovery policy")
-
         attempt_id = _required_string(value, "attempt_id")
         stage = _required_non_negative_int(value, "stage")
         amount = _required_non_negative_float(value, "amount")
@@ -161,14 +211,14 @@ class TakeProfitAttempt:
         )
         if amount == 0.0 or stake_amount == 0.0:
             raise ValueError("Take-profit attempt amounts must be positive")
-        if status in {"submitting", "ambiguous"} and submitted_time is None:
+        if status in {"submitting", "open", "ambiguous"} and submitted_time is None:
             raise ValueError("Submitted take-profit attempt has no timestamp")
         if submitted_time is not None and submitted_time < created_time:
             raise ValueError("Take-profit attempt was submitted before creation")
         if recovery_time < (submitted_time or created_time):
             raise ValueError("Take-profit recovery deadline precedes submission")
         parsed_tag = TakeProfitStageManager.parse_order_tag(tag)
-        if parsed_tag is None or parsed_tag[1] != stage or parsed_tag[2] != attempt_id:
+        if parsed_tag is None or parsed_tag[1] != stage:
             raise ValueError("Take-profit attempt tag does not match its identity")
 
         return cls(
@@ -183,7 +233,6 @@ class TakeProfitAttempt:
             submitted_at=submitted_at,
             recovery_deadline=recovery_deadline,
             known_order_ids=tuple(known_order_ids),
-            recovery_policy=recovery_policy,
         )
 
 
@@ -423,6 +472,18 @@ class TakeProfitOperatorResolution:
                 or self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES
             ):
                 raise ValueError("Terminal zero-fill resolution has invalid fields")
+        elif self.action == "confirmed_terminal_canceled_fill":
+            _non_empty_string(self.order_id)
+            if (
+                self.attempt_id is not None
+                or self.credited_amount is None
+                or self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES
+            ):
+                raise ValueError("Terminal canceled-fill resolution has invalid fields")
+            _required_positive_value(
+                self.credited_amount,
+                "terminal canceled-fill resolution credit",
+            )
         elif self.action == "revalidated_terminal_fill":
             _non_empty_string(self.order_id)
             if (
@@ -432,6 +493,17 @@ class TakeProfitOperatorResolution:
             ):
                 raise ValueError("Terminal-fill resolution has invalid fields")
             _non_negative_float(self.credited_amount)
+        elif self.action == "restored_partial_wallet_mutation":
+            _non_empty_string(self.attempt_id)
+            _non_empty_string(self.order_id)
+            if self.credited_amount is not None or self.terminal_status is None:
+                raise ValueError(
+                    "Partial-wallet restoration has invalid terminal fields"
+                )
+            if self.terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
+                raise ValueError(
+                    "Partial-wallet restoration has an invalid terminal status"
+                )
         else:
             raise ValueError(f"Invalid take-profit operator action {self.action!r}")
 
@@ -450,8 +522,10 @@ class TakeProfitOperatorResolution:
         action = value.get("action")
         if action not in {
             "confirmed_no_remote_order",
+            "confirmed_terminal_canceled_fill",
             "confirmed_terminal_zero_fill",
             "revalidated_terminal_fill",
+            "restored_partial_wallet_mutation",
         }:
             raise ValueError(f"Invalid take-profit operator action {action!r}")
         attempt_id = value.get("attempt_id")
@@ -483,8 +557,9 @@ class TakeProfitZeroFillProof:
     """Immutable canonical snapshot accepted by an explicit operator action."""
 
     order_id: str
-    order_role: TakeProfitOrderRole
+    order_date: str
     order_side: str
+    order_tag: str | None
     terminal_status: str
     amount: float
     remaining: float
@@ -493,9 +568,10 @@ class TakeProfitZeroFillProof:
 
     def __post_init__(self) -> None:
         _non_empty_string(self.order_id)
-        if self.order_role not in {"strategy_exit", "external_exit"}:
-            raise ValueError("Invalid terminal zero-fill order role")
+        order_date = _parse_iso_datetime(self.order_date)
         _non_empty_string(self.order_side)
+        if self.order_tag is not None:
+            _non_empty_string(self.order_tag)
         if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
             raise ValueError("Invalid operator-confirmed zero-fill status")
         amount = _required_positive_value(self.amount, "zero-fill proof amount")
@@ -504,13 +580,16 @@ class TakeProfitZeroFillProof:
             raise ValueError("Terminal zero-fill proof has an inconsistent remainder")
         if _non_negative_float(self.fee_base) != 0.0:
             raise ValueError("Terminal zero-fill proof has a base fee")
-        _parse_iso_datetime(self.confirmed_at)
+        confirmed_at = _parse_iso_datetime(self.confirmed_at)
+        if confirmed_at < order_date:
+            raise ValueError("Terminal zero fill was confirmed before order creation")
 
     def to_mapping(self) -> dict[str, object]:
         return {
             "order_id": self.order_id,
-            "order_role": self.order_role,
+            "order_date": self.order_date,
             "order_side": self.order_side,
+            "order_tag": self.order_tag,
             "terminal_status": self.terminal_status,
             "amount": self.amount,
             "remaining": self.remaining,
@@ -520,18 +599,304 @@ class TakeProfitZeroFillProof:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
-        order_role = value.get("order_role")
-        if order_role not in {"strategy_exit", "external_exit"}:
-            raise ValueError("Invalid terminal zero-fill order role")
+        order_tag = value.get("order_tag")
+        if order_tag is not None and not isinstance(order_tag, str):
+            raise ValueError("Invalid terminal zero-fill order tag")
         return cls(
             order_id=_required_string(value, "order_id"),
-            order_role=order_role,
+            order_date=_required_string(value, "order_date"),
             order_side=_required_string(value, "order_side"),
+            order_tag=order_tag,
             terminal_status=_required_string(value, "terminal_status"),
             amount=_required_positive_float(value, "amount"),
             remaining=_required_non_negative_float(value, "remaining"),
             fee_base=_required_non_negative_float(value, "fee_base"),
             confirmed_at=_required_string(value, "confirmed_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitCanceledFillProof:
+    """Exact canonical snapshot required for a canceled positive fill."""
+
+    order_id: str
+    order_date: str
+    order_side: str
+    order_tag: str | None
+    terminal_status: str
+    amount: float
+    filled: float
+    remaining: float
+    fee_base: float
+    filled_at: str
+    confirmed_at: str
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.order_id)
+        order_date = _parse_iso_datetime(self.order_date)
+        _non_empty_string(self.order_side)
+        if self.order_tag is not None:
+            _non_empty_string(self.order_tag)
+        if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+            raise ValueError("Invalid operator-confirmed canceled-fill status")
+        amount = _required_positive_value(self.amount, "canceled-fill proof amount")
+        filled = _required_positive_value(self.filled, "canceled-fill proof fill")
+        remaining = _non_negative_float(self.remaining)
+        fee_base = _non_negative_float(self.fee_base)
+        if filled > amount and not math.isclose(
+            filled,
+            amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Terminal canceled-fill proof exceeds its amount")
+        if not math.isclose(
+            min(filled, amount) + remaining,
+            amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError(
+                "Terminal canceled-fill proof has an inconsistent remainder"
+            )
+        if fee_base >= filled or math.isclose(
+            fee_base,
+            filled,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Terminal canceled-fill proof fee consumes its fill")
+        filled_at = _parse_iso_datetime(self.filled_at)
+        confirmed_at = _parse_iso_datetime(self.confirmed_at)
+        if filled_at < order_date or confirmed_at < filled_at:
+            raise ValueError("Terminal canceled fill has an invalid timeline")
+
+    @property
+    def credited_amount(self) -> float:
+        return min(self.filled, self.amount) - self.fee_base
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "order_id": self.order_id,
+            "order_date": self.order_date,
+            "order_side": self.order_side,
+            "order_tag": self.order_tag,
+            "terminal_status": self.terminal_status,
+            "amount": self.amount,
+            "filled": self.filled,
+            "remaining": self.remaining,
+            "fee_base": self.fee_base,
+            "filled_at": self.filled_at,
+            "confirmed_at": self.confirmed_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        order_tag = value.get("order_tag")
+        if order_tag is not None and not isinstance(order_tag, str):
+            raise ValueError("Invalid terminal canceled-fill order tag")
+        return cls(
+            order_id=_required_string(value, "order_id"),
+            order_date=_required_string(value, "order_date"),
+            order_side=_required_string(value, "order_side"),
+            order_tag=order_tag,
+            terminal_status=_required_string(value, "terminal_status"),
+            amount=_required_positive_float(value, "amount"),
+            filled=_required_positive_float(value, "filled"),
+            remaining=_required_non_negative_float(value, "remaining"),
+            fee_base=_required_non_negative_float(value, "fee_base"),
+            filled_at=_required_string(value, "filled_at"),
+            confirmed_at=_required_string(value, "confirmed_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitOrderAttribution:
+    """Immutable evidence binding one canonical order to take-profit execution."""
+
+    order_id: str
+    tag: str | None
+    side: str
+    stage: int
+    attempt_id: str | None
+    order_date: str
+    maximum_amount: float
+    order_amount: float
+    source: TakeProfitAttributionSource
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.order_id)
+        if self.tag is not None:
+            _non_empty_string(self.tag)
+        _non_empty_string(self.side)
+        _non_negative_int(self.stage)
+        if self.attempt_id is not None:
+            _non_empty_string(self.attempt_id)
+        _parse_iso_datetime(self.order_date)
+        maximum_amount = _required_positive_value(
+            self.maximum_amount,
+            "attribution maximum amount",
+        )
+        order_amount = _required_positive_value(
+            self.order_amount,
+            "attribution order amount",
+        )
+        if order_amount > maximum_amount and not math.isclose(
+            order_amount,
+            maximum_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Attributed order exceeds its maximum amount")
+        if self.source not in {
+            "attempt",
+            "operator",
+            "recovered_untagged",
+        }:
+            raise ValueError("Invalid take-profit attribution source")
+        if self.source == "attempt":
+            _non_empty_string(self.attempt_id)
+            parsed_tag = TakeProfitStageManager.parse_order_tag(self.tag)
+            if parsed_tag is None or parsed_tag[1] != self.stage:
+                raise ValueError("Attempt attribution has an invalid stable tag")
+        elif self.source == "recovered_untagged":
+            _non_empty_string(self.attempt_id)
+            if self.tag is not None:
+                raise ValueError("Recovered untagged attribution has invalid evidence")
+        else:
+            parsed_tag = TakeProfitStageManager.parse_order_tag(self.tag)
+            if parsed_tag is None or parsed_tag[1] != self.stage:
+                raise ValueError("Operator attribution has an invalid tag")
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "order_id": self.order_id,
+            "tag": self.tag,
+            "side": self.side,
+            "stage": self.stage,
+            "attempt_id": self.attempt_id,
+            "order_date": self.order_date,
+            "maximum_amount": self.maximum_amount,
+            "order_amount": self.order_amount,
+            "source": self.source,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        source = value.get("source")
+        if source not in {
+            "attempt",
+            "operator",
+            "recovered_untagged",
+        }:
+            raise ValueError("Invalid take-profit attribution source")
+        attempt_id = value.get("attempt_id")
+        return cls(
+            order_id=_required_string(value, "order_id"),
+            tag=(
+                _non_empty_string(value.get("tag"))
+                if value.get("tag") is not None
+                else None
+            ),
+            side=_required_string(value, "side"),
+            stage=_required_non_negative_int(value, "stage"),
+            attempt_id=(
+                _non_empty_string(attempt_id) if attempt_id is not None else None
+            ),
+            order_date=_required_string(value, "order_date"),
+            maximum_amount=_required_positive_float(value, "maximum_amount"),
+            order_amount=_required_positive_float(value, "order_amount"),
+            source=source,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitPartialWalletMutation:
+    """Fail-closed evidence of Freqtrade's partial-exit wallet mutation."""
+
+    attempt_id: str
+    order_id: str | None
+    expected_trade_amount: float
+    requested_exit_amount: float
+    observed_trade_amount: float
+    wallet_shortfall_amount: float
+    attempt_submitted_at: str
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.attempt_id)
+        if self.order_id is not None:
+            _non_empty_string(self.order_id)
+        expected = _required_positive_value(
+            self.expected_trade_amount,
+            "partial wallet mutation expected amount",
+        )
+        requested = _required_positive_value(
+            self.requested_exit_amount,
+            "partial wallet mutation requested amount",
+        )
+        observed = _required_positive_value(
+            self.observed_trade_amount,
+            "partial wallet mutation observed amount",
+        )
+        shortfall = _required_positive_value(
+            self.wallet_shortfall_amount,
+            "partial wallet mutation wallet shortfall",
+        )
+        if (
+            expected < requested
+            and not math.isclose(
+                expected,
+                requested,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+        ) or observed >= expected:
+            raise ValueError("Partial wallet mutation is not a partial-exit mutation")
+        if observed >= requested or observed < requested * 0.98:
+            raise ValueError("Partial wallet mutation is outside the fallback window")
+        if not math.isclose(
+            requested - observed,
+            shortfall,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Partial wallet mutation shortfall is inconsistent")
+        _parse_iso_datetime(self.attempt_submitted_at)
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "attempt_id": self.attempt_id,
+            "order_id": self.order_id,
+            "expected_trade_amount": self.expected_trade_amount,
+            "requested_exit_amount": self.requested_exit_amount,
+            "observed_trade_amount": self.observed_trade_amount,
+            "wallet_shortfall_amount": self.wallet_shortfall_amount,
+            "attempt_submitted_at": self.attempt_submitted_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        order_id = value.get("order_id")
+        return cls(
+            attempt_id=_required_string(value, "attempt_id"),
+            order_id=_non_empty_string(order_id) if order_id is not None else None,
+            expected_trade_amount=_required_positive_float(
+                value,
+                "expected_trade_amount",
+            ),
+            requested_exit_amount=_required_positive_float(
+                value,
+                "requested_exit_amount",
+            ),
+            observed_trade_amount=_required_positive_float(
+                value,
+                "observed_trade_amount",
+            ),
+            wallet_shortfall_amount=_required_positive_float(
+                value,
+                "wallet_shortfall_amount",
+            ),
+            attempt_submitted_at=_required_string(value, "attempt_submitted_at"),
         )
 
 
@@ -542,18 +907,22 @@ class TakeProfitStageState:
     initial_amount: float
     stage_targets: tuple[tuple[int, float], ...]
     deferred_stages: tuple[int, ...]
-    attributed_order_ids: tuple[str, ...]
+    order_attributions: tuple[TakeProfitOrderAttribution, ...]
     credited_order_amounts: tuple[tuple[str, float], ...]
     non_take_profit_exit_order_amounts: tuple[tuple[str, float], ...]
     entry_order_amounts: tuple[tuple[str, float], ...]
     exposure_adjustments: tuple[TakeProfitExposureAdjustment, ...]
+    compacted_exposure_adjustment_count: int
+    compacted_exposure_adjustment_amount: float
     confirmed_zero_fill_orders: tuple[TakeProfitZeroFillProof, ...]
+    confirmed_canceled_fill_orders: tuple[TakeProfitCanceledFillProof, ...]
     operator_resolutions: tuple[TakeProfitOperatorResolution, ...]
+    partial_wallet_mutation: TakeProfitPartialWalletMutation | None = None
     active_attempt: TakeProfitAttempt | None = None
     blocked_reason: str | None = None
     blocked_order_id: str | None = None
 
-    SCHEMA_VERSION = 5
+    SCHEMA_VERSION = 1
     MAX_OPERATOR_RESOLUTIONS = 32
     MAX_EXPOSURE_ADJUSTMENTS = 32
 
@@ -567,7 +936,9 @@ class TakeProfitStageState:
                 for stage, amount in self.stage_targets
             ],
             "deferred_stages": list(self.deferred_stages),
-            "attributed_order_ids": list(self.attributed_order_ids),
+            "order_attributions": [
+                attribution.to_mapping() for attribution in self.order_attributions
+            ],
             "credited_order_amounts": [
                 {"order_id": order_id, "amount": amount}
                 for order_id, amount in self.credited_order_amounts
@@ -583,12 +954,26 @@ class TakeProfitStageState:
             "exposure_adjustments": [
                 adjustment.to_mapping() for adjustment in self.exposure_adjustments
             ],
+            "compacted_exposure_adjustment_count": (
+                self.compacted_exposure_adjustment_count
+            ),
+            "compacted_exposure_adjustment_amount": (
+                self.compacted_exposure_adjustment_amount
+            ),
             "confirmed_zero_fill_orders": [
                 proof.to_mapping() for proof in self.confirmed_zero_fill_orders
+            ],
+            "confirmed_canceled_fill_orders": [
+                proof.to_mapping() for proof in self.confirmed_canceled_fill_orders
             ],
             "operator_resolutions": [
                 resolution.to_mapping() for resolution in self.operator_resolutions
             ],
+            "partial_wallet_mutation": (
+                self.partial_wallet_mutation.to_mapping()
+                if self.partial_wallet_mutation is not None
+                else None
+            ),
             "active_attempt": (
                 self.active_attempt.to_mapping()
                 if self.active_attempt is not None
@@ -601,10 +986,10 @@ class TakeProfitStageState:
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
         version = _required_non_negative_int(value, "version")
-        if version not in {4, cls.SCHEMA_VERSION}:
+        if version != cls.SCHEMA_VERSION:
             raise ValueError(
                 f"Unsupported take-profit state version {version!r}; "
-                f"expected 4 or {cls.SCHEMA_VERSION}"
+                f"expected {cls.SCHEMA_VERSION}"
             )
 
         plan_raw = value.get("plan_signature")
@@ -650,22 +1035,44 @@ class TakeProfitStageState:
         ).issubset(stages):
             raise ValueError("Invalid take-profit deferred stage")
 
-        attributed_raw = value.get("attributed_order_ids")
-        if not isinstance(attributed_raw, list) or not all(
-            isinstance(order_id, str) and order_id for order_id in attributed_raw
+        attributions_raw = value.get("order_attributions")
+        if not isinstance(attributions_raw, list) or not all(
+            isinstance(attribution, Mapping) for attribution in attributions_raw
         ):
-            raise ValueError("Invalid take-profit attributed_order_ids")
-        attributed_order_ids = tuple(attributed_raw)
-        if len(attributed_order_ids) != len(set(attributed_order_ids)):
+            raise ValueError("Invalid take-profit order attributions")
+        order_attributions = tuple(
+            TakeProfitOrderAttribution.from_mapping(attribution)
+            for attribution in attributions_raw
+            if isinstance(attribution, Mapping)
+        )
+        attribution_order_ids = tuple(
+            attribution.order_id for attribution in order_attributions
+        )
+        if len(attribution_order_ids) != len(set(attribution_order_ids)):
             raise ValueError("Duplicate attributed take-profit order")
+        attribution_attempt_ids = tuple(
+            attribution.attempt_id
+            for attribution in order_attributions
+            if attribution.attempt_id is not None
+        )
+        if len(attribution_attempt_ids) != len(set(attribution_attempt_ids)):
+            raise ValueError("Take-profit attempt is attributed to multiple orders")
+        all_stages = {
+            *planned_stages,
+            plan_signature.final_stage.stage,
+        }
+        if any(
+            attribution.stage not in all_stages for attribution in order_attributions
+        ):
+            raise ValueError("Attributed order has an invalid take-profit stage")
 
         credited_order_amounts = _parse_amount_records(
             value.get("credited_order_amounts"),
             identifier_key="order_id",
             identifier_parser=_non_empty_string,
         )
-        if not set(order_id for order_id, _ in credited_order_amounts).issubset(
-            attributed_order_ids
+        if not {order_id for order_id, _ in credited_order_amounts}.issubset(
+            attribution_order_ids
         ):
             raise ValueError("Credited take-profit order is not attributed")
         total_credited = math.fsum(amount for _, amount in credited_order_amounts)
@@ -678,13 +1085,11 @@ class TakeProfitStageState:
             raise ValueError("Credited take-profit amount exceeds the initial amount")
 
         non_take_profit_exit_order_amounts = _parse_amount_records(
-            value.get("non_take_profit_exit_order_amounts", [])
-            if version == 4
-            else value.get("non_take_profit_exit_order_amounts"),
+            value.get("non_take_profit_exit_order_amounts"),
             identifier_key="order_id",
             identifier_parser=_non_empty_string,
         )
-        take_profit_order_ids = set(attributed_order_ids)
+        take_profit_order_ids = set(attribution_order_ids)
         non_take_profit_order_ids = {
             order_id for order_id, _ in non_take_profit_exit_order_amounts
         }
@@ -699,7 +1104,7 @@ class TakeProfitStageState:
             identifier_parser=_non_empty_string,
         )
 
-        adjustments_raw = [] if version == 4 else value.get("exposure_adjustments")
+        adjustments_raw = value.get("exposure_adjustments")
         if not isinstance(adjustments_raw, list) or not all(
             isinstance(adjustment, Mapping) for adjustment in adjustments_raw
         ):
@@ -716,6 +1121,18 @@ class TakeProfitStageState:
             raise ValueError("Duplicate take-profit exposure adjustment")
         if len(exposure_adjustments) > cls.MAX_EXPOSURE_ADJUSTMENTS:
             raise ValueError("Too many take-profit exposure adjustments")
+        compacted_exposure_adjustment_count = _required_non_negative_int(
+            value,
+            "compacted_exposure_adjustment_count",
+        )
+        compacted_exposure_adjustment_amount = _required_non_negative_float(
+            value,
+            "compacted_exposure_adjustment_amount",
+        )
+        if (compacted_exposure_adjustment_count == 0) != (
+            compacted_exposure_adjustment_amount == 0.0
+        ):
+            raise ValueError("Invalid compacted exposure adjustment aggregate")
         total_exit_credited = total_credited + math.fsum(
             amount for _, amount in non_take_profit_exit_order_amounts
         )
@@ -761,6 +1178,24 @@ class TakeProfitStageState:
         if len(proof_order_ids) != len(set(proof_order_ids)):
             raise ValueError("Duplicate terminal zero-fill proof")
 
+        canceled_proofs_raw = value.get("confirmed_canceled_fill_orders")
+        if not isinstance(canceled_proofs_raw, list) or not all(
+            isinstance(proof, Mapping) for proof in canceled_proofs_raw
+        ):
+            raise ValueError("Invalid take-profit confirmed canceled-fill orders")
+        confirmed_canceled_fill_orders = tuple(
+            TakeProfitCanceledFillProof.from_mapping(proof)
+            for proof in canceled_proofs_raw
+            if isinstance(proof, Mapping)
+        )
+        canceled_proof_order_ids = tuple(
+            proof.order_id for proof in confirmed_canceled_fill_orders
+        )
+        if len(canceled_proof_order_ids) != len(set(canceled_proof_order_ids)):
+            raise ValueError("Duplicate terminal canceled-fill proof")
+        if set(canceled_proof_order_ids) & set(proof_order_ids):
+            raise ValueError("Terminal order has conflicting operator proofs")
+
         resolutions_raw = value.get("operator_resolutions")
         if not isinstance(resolutions_raw, list) or not all(
             isinstance(resolution, Mapping) for resolution in resolutions_raw
@@ -780,27 +1215,9 @@ class TakeProfitStageState:
         )
         if len(resolved_attempt_ids) != len(set(resolved_attempt_ids)):
             raise ValueError("Duplicate take-profit operator resolution")
-        revalidated_order_ids = tuple(
-            resolution.order_id
-            for resolution in operator_resolutions
-            if resolution.action == "revalidated_terminal_fill"
-        )
-        if len(revalidated_order_ids) != len(set(revalidated_order_ids)):
-            raise ValueError("Duplicate take-profit terminal-fill resolution")
-
         active_raw = value.get("active_attempt")
         if active_raw is not None and not isinstance(active_raw, Mapping):
             raise ValueError("Invalid take-profit active_attempt")
-        if version == 4 and isinstance(active_raw, Mapping):
-            active_raw = dict(active_raw)
-            active_raw.setdefault(
-                "recovery_policy",
-                "tagged_or_unique_untagged",
-            )
-            if active_raw.get("status") == "proposed":
-                active_raw["status"] = "ambiguous"
-                active_raw["submitted_at"] = active_raw.get("created_at")
-                active_raw["recovery_policy"] = "tagged_only"
         active_attempt = (
             TakeProfitAttempt.from_mapping(active_raw)
             if isinstance(active_raw, Mapping)
@@ -820,22 +1237,102 @@ class TakeProfitStageState:
             and active_attempt.attempt_id in resolved_attempt_ids
         ):
             raise ValueError("Resolved take-profit attempt cannot remain active")
-
         blocked_reason = value.get("blocked_reason")
         if blocked_reason is not None and not isinstance(blocked_reason, str):
             raise ValueError("Invalid take-profit blocked_reason")
         blocked_order_id = value.get("blocked_order_id")
         if blocked_reason in _BLOCKED_ORDER_ID_REASONS:
-            if not (
-                version == 4
-                and blocked_reason == "unattributed_exit_fill"
-                and blocked_order_id is None
-            ):
-                blocked_order_id = _non_empty_string(blocked_order_id)
+            blocked_order_id = _non_empty_string(blocked_order_id)
         elif blocked_reason is None and blocked_order_id is not None:
             raise ValueError("Take-profit blocked_order_id requires a blocked state")
         elif blocked_order_id is not None:
             blocked_order_id = _non_empty_string(blocked_order_id)
+
+        partial_wallet_raw = value.get("partial_wallet_mutation")
+        if partial_wallet_raw is not None and not isinstance(
+            partial_wallet_raw,
+            Mapping,
+        ):
+            raise ValueError("Invalid take-profit partial wallet mutation")
+        partial_wallet_mutation = (
+            TakeProfitPartialWalletMutation.from_mapping(partial_wallet_raw)
+            if isinstance(partial_wallet_raw, Mapping)
+            else None
+        )
+        if partial_wallet_mutation is not None:
+            if (
+                active_attempt is None
+                or active_attempt.attempt_id != partial_wallet_mutation.attempt_id
+                or active_attempt.status not in {"open", "ambiguous"}
+            ):
+                raise ValueError("Partial wallet mutation has no matching attempt")
+            if partial_wallet_mutation.order_id is None:
+                if active_attempt.status != "ambiguous":
+                    raise ValueError("Unbound partial wallet attempt is not ambiguous")
+                if blocked_reason != "partial_wallet_mutation":
+                    raise ValueError("Unbound partial wallet mutation must be blocked")
+            elif (
+                blocked_reason == "partial_wallet_order_changed"
+                and blocked_order_id != partial_wallet_mutation.order_id
+            ):
+                raise ValueError(
+                    "Bound partial wallet mutation has invalid order block"
+                )
+            if not math.isclose(
+                partial_wallet_mutation.requested_exit_amount,
+                active_attempt.amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            ) or partial_wallet_mutation.attempt_submitted_at != (
+                active_attempt.submitted_at or active_attempt.created_at
+            ):
+                raise ValueError("Partial wallet mutation does not match its attempt")
+        elif blocked_reason == "partial_wallet_mutation":
+            raise ValueError("Partial wallet block has no mutation evidence")
+
+        active_attributions = (
+            tuple(
+                attribution
+                for attribution in order_attributions
+                if active_attempt is not None
+                and attribution.attempt_id == active_attempt.attempt_id
+            )
+            if active_attempt is not None
+            else ()
+        )
+        if active_attributions:
+            if (
+                len(active_attributions) != 1
+                or partial_wallet_mutation is None
+                or partial_wallet_mutation.order_id != active_attributions[0].order_id
+            ):
+                raise ValueError("Active attempt has invalid attributed order evidence")
+            attribution = active_attributions[0]
+            tag_matches = (
+                attribution.tag is None
+                if attribution.source == "recovered_untagged"
+                else attribution.tag == active_attempt.tag
+            )
+            if (
+                attribution.source not in {"attempt", "recovered_untagged"}
+                or attribution.stage != active_attempt.stage
+                or attribution.side != active_attempt.exit_side
+                or not tag_matches
+                or not math.isclose(
+                    attribution.maximum_amount,
+                    active_attempt.amount,
+                    rel_tol=1e-9,
+                    abs_tol=1e-12,
+                )
+            ):
+                raise ValueError("Active attempt attribution does not match its intent")
+        elif (
+            partial_wallet_mutation is not None
+            and partial_wallet_mutation.order_id is not None
+        ):
+            raise ValueError("Bound partial wallet mutation has no attribution")
+        elif active_attempt is not None and active_attempt.status == "open":
+            raise ValueError("Open take-profit attempt has no attributed order")
 
         return cls(
             version=cls.SCHEMA_VERSION,
@@ -843,20 +1340,34 @@ class TakeProfitStageState:
             initial_amount=initial_amount,
             stage_targets=tuple(sorted(stage_targets)),
             deferred_stages=tuple(sorted(deferred_stages)),
-            attributed_order_ids=tuple(sorted(attributed_order_ids)),
+            order_attributions=tuple(
+                sorted(
+                    order_attributions,
+                    key=lambda attribution: attribution.order_id,
+                )
+            ),
             credited_order_amounts=tuple(sorted(credited_order_amounts)),
             non_take_profit_exit_order_amounts=tuple(
                 sorted(non_take_profit_exit_order_amounts)
             ),
             entry_order_amounts=tuple(sorted(entry_order_amounts)),
             exposure_adjustments=exposure_adjustments,
+            compacted_exposure_adjustment_count=(compacted_exposure_adjustment_count),
+            compacted_exposure_adjustment_amount=(compacted_exposure_adjustment_amount),
             confirmed_zero_fill_orders=tuple(
                 sorted(
                     confirmed_zero_fill_orders,
                     key=lambda proof: proof.order_id,
                 )
             ),
+            confirmed_canceled_fill_orders=tuple(
+                sorted(
+                    confirmed_canceled_fill_orders,
+                    key=lambda proof: proof.order_id,
+                )
+            ),
             operator_resolutions=operator_resolutions,
+            partial_wallet_mutation=partial_wallet_mutation,
             active_attempt=active_attempt,
             blocked_reason=blocked_reason,
             blocked_order_id=blocked_order_id,
@@ -880,7 +1391,6 @@ class TakeProfitStageManager:
 
     STATE_KEY = "take_profit_state"
     _TAG_PREFIX = "take_profit"
-    _EMERGENCY_EXIT_TAG = "emergency_exit"
     _AMOUNT_REL_TOL = 1e-9
     _AMOUNT_ABS_TOL = 1e-12
     _TERMINAL_STATUSES = frozenset(
@@ -893,18 +1403,12 @@ class TakeProfitStageManager:
         cls,
         trade_direction: str,
         stage: int,
-        attempt_id: str | None = None,
     ) -> str:
         if stage < 0:
             raise ValueError(
                 f"Invalid take-profit stage {stage!r}: must be non-negative"
             )
-        tag = f"{cls._TAG_PREFIX}_{trade_direction}_{stage}"
-        if attempt_id is not None:
-            if not attempt_id or "_" in attempt_id:
-                raise ValueError(f"Invalid take-profit attempt ID {attempt_id!r}")
-            tag = f"{tag}_{attempt_id}"
-        return tag
+        return f"{cls._TAG_PREFIX}_{trade_direction}_{stage}"
 
     @classmethod
     def has_order_tag_prefix(cls, value: object) -> bool:
@@ -914,14 +1418,14 @@ class TakeProfitStageManager:
     def parse_order_tag(
         cls,
         tag: object,
-    ) -> tuple[str, int, str | None] | None:
+    ) -> tuple[str, int] | None:
         if not isinstance(tag, str):
             return None
         prefix = f"{cls._TAG_PREFIX}_"
         if not tag.startswith(prefix):
             return None
         parts = tag.removeprefix(prefix).split("_")
-        if len(parts) not in {2, 3}:
+        if len(parts) != 2:
             return None
         try:
             stage = int(parts[1])
@@ -929,8 +1433,7 @@ class TakeProfitStageManager:
             return None
         if stage < 0 or not parts[0]:
             return None
-        attempt_id = parts[2] if len(parts) == 3 and parts[2] else None
-        return parts[0], stage, attempt_id
+        return parts[0], stage
 
     @classmethod
     def initialize(
@@ -968,12 +1471,15 @@ class TakeProfitStageManager:
             initial_amount=initial_amount,
             stage_targets=plan_signature.derive_stage_targets(initial_amount),
             deferred_stages=(),
-            attributed_order_ids=(),
+            order_attributions=(),
             credited_order_amounts=(),
             non_take_profit_exit_order_amounts=(),
             entry_order_amounts=tuple(sorted(entry_order_amounts.items())),
             exposure_adjustments=(),
+            compacted_exposure_adjustment_count=0,
+            compacted_exposure_adjustment_amount=0.0,
             confirmed_zero_fill_orders=(),
+            confirmed_canceled_fill_orders=(),
             operator_resolutions=(),
             blocked_reason=blocked_reason,
         )
@@ -1038,6 +1544,23 @@ class TakeProfitStageManager:
                     "confirmed_terminal_zero_fill_changed",
                     order_id=proof.order_id,
                 )
+        confirmed_canceled_fill_orders = {
+            proof.order_id: proof for proof in state.confirmed_canceled_fill_orders
+        }
+        for proof in state.confirmed_canceled_fill_orders:
+            order = orders_by_id.get(proof.order_id)
+            if order is None:
+                return cls._block(
+                    state,
+                    "confirmed_terminal_canceled_fill_order_missing",
+                    order_id=proof.order_id,
+                )
+            if not cls._canceled_fill_proof_matches(trade, order, proof):
+                return cls._block(
+                    state,
+                    "confirmed_terminal_canceled_fill_changed",
+                    order_id=proof.order_id,
+                )
 
         if any(
             order.ft_order_side == trade.entry_side and order.ft_is_open
@@ -1061,8 +1584,14 @@ class TakeProfitStageManager:
         if not cls._amounts_close(canonical_initial_amount, state.initial_amount):
             return cls._block(state, "initial_exposure_mismatch")
 
-        configured_stages = {stage for stage, _ in state.stage_targets}
-        attributed_order_ids = set(state.attributed_order_ids)
+        configured_stages = {
+            *(stage for stage, _ in state.stage_targets),
+            state.plan_signature.final_stage.stage,
+        }
+        order_attributions = {
+            attribution.order_id: attribution
+            for attribution in state.order_attributions
+        }
         credited_order_amounts = dict(state.credited_order_amounts)
         non_take_profit_exit_order_amounts = dict(
             state.non_take_profit_exit_order_amounts
@@ -1075,7 +1604,6 @@ class TakeProfitStageManager:
                 continue
             external_block = cls._external_exit_block(
                 order,
-                confirmed_zero_fill_orders.get(order.order_id),
             )
             if external_block is not None:
                 return cls._block(
@@ -1092,6 +1620,7 @@ class TakeProfitStageManager:
                 terminal_credits[order.order_id] = cls._terminal_credited_amount(
                     order,
                     confirmed_zero_fill_orders.get(order.order_id),
+                    confirmed_canceled_fill_orders.get(order.order_id),
                 )
             except ValueError:
                 return cls._block(
@@ -1100,106 +1629,205 @@ class TakeProfitStageManager:
                     order_id=order.order_id,
                 )
 
-        active_attempt = state.active_attempt
-        matching_attempt_orders: list[_Order] = []
-        if active_attempt is not None:
-            same_attempt_orders = [
-                order
-                for order in strategy_exit_orders
-                if (parsed_tag := cls.parse_order_tag(order.ft_order_tag)) is not None
-                and parsed_tag[2] == active_attempt.attempt_id
-            ]
-            if len(same_attempt_orders) > 1:
-                return cls._block(
-                    state,
-                    "multiple_attempt_orders",
-                    order_id=same_attempt_orders[0].order_id,
-                )
-            matching_attempt_orders = [
-                order
-                for order in same_attempt_orders
-                if order.ft_order_tag == active_attempt.tag
-                and order.ft_order_side == active_attempt.exit_side
-            ]
-
-        for order in strategy_exit_orders:
-            if order.order_id in attributed_order_ids:
-                continue
-            parsed_tag = cls.parse_order_tag(order.ft_order_tag)
-            if parsed_tag is None:
-                if cls.has_order_tag_prefix(order.ft_order_tag):
-                    if order.order_id in confirmed_zero_fill_orders:
-                        continue
-                    return cls._block(
-                        state,
-                        "unknown_attempt_order",
-                        order_id=order.order_id,
-                    )
-                continue
-            if order in matching_attempt_orders:
-                continue
-            direction, stage, attempt_id = parsed_tag
-            if (
-                attempt_id is None
-                and direction == trade.trade_direction
-                and stage in configured_stages
-            ):
-                attributed_order_ids.add(order.order_id)
-                continue
-            if order.order_id in confirmed_zero_fill_orders:
-                continue
-            return cls._block(
-                state,
-                "unknown_attempt_order",
-                order_id=order.order_id,
-            )
-
-        for index, order in enumerate(strategy_exit_orders):
-            if order.order_id in attributed_order_ids:
-                continue
-            predecessor = strategy_exit_orders[index - 1] if index > 0 else None
-            if (
-                order.ft_order_tag == cls._EMERGENCY_EXIT_TAG
-                and predecessor is not None
-                and cls._is_legacy_emergency_successor(
-                    trade,
-                    predecessor,
-                    order,
-                    configured_stages,
-                )
-            ):
-                attributed_order_ids.add(order.order_id)
-
-        if active_attempt is not None:
-            attributed_order_ids.update(
-                order.order_id for order in matching_attempt_orders
-            )
-
-            if not matching_attempt_orders and active_attempt.status in {
-                "submitting",
-                "ambiguous",
-            }:
-                recovered_candidates = [
-                    order
-                    for order in strategy_exit_orders
-                    if cls._is_recovered_attempt_candidate(order, active_attempt)
-                ]
-                if len(recovered_candidates) == 1:
-                    matching_attempt_orders = recovered_candidates
-                    attributed_order_ids.add(recovered_candidates[0].order_id)
-                elif len(recovered_candidates) > 1:
-                    return cls._block(state, "ambiguous_recovered_exit")
-
-        for order_id in attributed_order_ids:
+        for attribution in order_attributions.values():
+            order_id = attribution.order_id
             order = orders_by_id.get(order_id)
             if order is None:
-                return cls._block(state, "attributed_order_missing")
-            if order.ft_order_side != trade.exit_side:
-                return cls._block(state, "attributed_order_side_changed")
+                return cls._block(
+                    state,
+                    "attributed_order_missing",
+                    order_id=order_id,
+                )
+            if (
+                attribution.side != trade.exit_side
+                or order.ft_order_side != attribution.side
+            ):
+                return cls._block(
+                    state,
+                    "attributed_order_side_changed",
+                    order_id=order_id,
+                )
+            if order.ft_order_tag != attribution.tag:
+                return cls._block(
+                    state,
+                    "attributed_order_tag_changed",
+                    order_id=order_id,
+                )
+            order_amount = cls._safe_amount(order.safe_amount)
+            if (
+                not cls._amounts_close(order_amount, attribution.order_amount)
+                or order_amount > attribution.maximum_amount
+                and not cls._amounts_close(
+                    order_amount,
+                    attribution.maximum_amount,
+                )
+            ):
+                return cls._block(
+                    state,
+                    "attributed_order_amount_changed",
+                    order_id=order_id,
+                )
+            if not cls._attribution_provenance_matches(
+                trade,
+                attribution,
+                order,
+                configured_stages,
+            ):
+                return cls._block(
+                    state,
+                    "attributed_order_provenance_changed",
+                    order_id=order_id,
+                )
+
+        active_attempt = state.active_attempt
+        partial_wallet_mutation = state.partial_wallet_mutation
+        matching_attempt_orders: list[_Order] = []
+        pending_partial_wallet_order_id: str | None = None
+        if active_attempt is not None and active_attempt.status in {
+            "submitting",
+            "open",
+            "ambiguous",
+        }:
+            bound_attributions = [
+                attribution
+                for attribution in order_attributions.values()
+                if attribution.attempt_id == active_attempt.attempt_id
+            ]
+            if bound_attributions:
+                if len(bound_attributions) != 1:
+                    return cls._block(state, "multiple_attempt_orders")
+                bound_order = orders_by_id.get(bound_attributions[0].order_id)
+                if bound_order is None:
+                    return cls._block(
+                        state,
+                        "attributed_order_missing",
+                        order_id=bound_attributions[0].order_id,
+                    )
+                matching_attempt_orders = [bound_order]
+                pending_partial_wallet_order_id = bound_order.order_id
+            else:
+                matching_attempt_orders = [
+                    order
+                    for order in strategy_exit_orders
+                    if order.order_id not in order_attributions
+                    and cls._is_recovered_attempt_candidate(order, active_attempt)
+                ]
+            if len(matching_attempt_orders) > 1:
+                block_reason = (
+                    "ambiguous_recovered_exit"
+                    if all(
+                        order.ft_order_tag is None for order in matching_attempt_orders
+                    )
+                    else "multiple_attempt_orders"
+                )
+                return cls._block(
+                    state,
+                    block_reason,
+                    order_id=matching_attempt_orders[0].order_id,
+                )
+            if matching_attempt_orders:
+                order = matching_attempt_orders[0]
+                if order.ft_is_open:
+                    try:
+                        expected_amount = cls.get_expected_trade_amount(
+                            state,
+                            amount_quantizer=amount_quantizer,
+                        )
+                        observed_amount = cls._canonical_amount(
+                            trade.amount,
+                            amount_quantizer,
+                        )
+                    except ValueError:
+                        return cls._block(state, "trade_amount_mismatch")
+                    if partial_wallet_mutation is not None or (
+                        cls._is_partial_wallet_mutation(
+                            active_attempt,
+                            expected_amount,
+                            observed_amount,
+                        )
+                    ):
+                        if partial_wallet_mutation is not None and (
+                            partial_wallet_mutation.order_id != order.order_id
+                        ):
+                            return cls._block(
+                                state,
+                                "partial_wallet_order_changed",
+                                order_id=order.order_id,
+                            )
+                        if partial_wallet_mutation is not None:
+                            if cls._amounts_close(
+                                observed_amount,
+                                expected_amount,
+                            ):
+                                partial_wallet_mutation = None
+                                pending_partial_wallet_order_id = None
+                            elif not cls._amounts_close(
+                                observed_amount,
+                                partial_wallet_mutation.observed_trade_amount,
+                            ):
+                                return cls._block(state, "trade_amount_mismatch")
+                        else:
+                            partial_wallet_mutation = TakeProfitPartialWalletMutation(
+                                attempt_id=active_attempt.attempt_id,
+                                order_id=order.order_id,
+                                expected_trade_amount=expected_amount,
+                                requested_exit_amount=active_attempt.amount,
+                                observed_trade_amount=observed_amount,
+                                wallet_shortfall_amount=(
+                                    active_attempt.amount - observed_amount
+                                ),
+                                attempt_submitted_at=(
+                                    active_attempt.submitted_at
+                                    or active_attempt.created_at
+                                ),
+                            )
+                        if partial_wallet_mutation is not None:
+                            active_attempt = replace(active_attempt, status="open")
+                            pending_partial_wallet_order_id = order.order_id
+                if order.order_id not in order_attributions:
+                    if order.ft_order_tag is None:
+                        source: TakeProfitAttributionSource = "recovered_untagged"
+                    else:
+                        source = "attempt"
+                    order_amount = cls._safe_amount(order.safe_amount)
+                    order_attributions[order.order_id] = TakeProfitOrderAttribution(
+                        order_id=order.order_id,
+                        tag=order.ft_order_tag,
+                        side=order.ft_order_side,
+                        stage=active_attempt.stage,
+                        attempt_id=active_attempt.attempt_id,
+                        order_date=order.order_date_utc.isoformat(),
+                        maximum_amount=active_attempt.amount,
+                        order_amount=order_amount,
+                        source=source,
+                    )
+
+        attributed_order_ids = set(order_attributions)
+        matching_attempt_order_ids = {
+            order.order_id for order in matching_attempt_orders
+        }
+        for order in strategy_exit_orders:
+            if order.order_id in attributed_order_ids or (
+                order.order_id in matching_attempt_order_ids
+            ):
+                continue
+            if cls.has_order_tag_prefix(order.ft_order_tag):
+                return cls._block(
+                    state,
+                    "unknown_attempt_order",
+                    order_id=order.order_id,
+                )
+
+        for order_id in attributed_order_ids:
+            order = orders_by_id[order_id]
             previous_amount = credited_order_amounts.get(order_id)
             if order.ft_is_open:
                 if previous_amount is not None:
-                    return cls._block(state, "attributed_order_reopened")
+                    return cls._block(
+                        state,
+                        "attributed_order_reopened",
+                        order_id=order_id,
+                    )
                 continue
             current_amount = terminal_credits[order_id]
             if (
@@ -1207,23 +1835,43 @@ class TakeProfitStageManager:
                 and current_amount < previous_amount
                 and not (cls._amounts_close(current_amount, previous_amount))
             ):
-                return cls._block(state, "attributed_fill_regressed")
+                return cls._block(
+                    state,
+                    "attributed_fill_regressed",
+                    order_id=order_id,
+                )
             credited_order_amounts[order_id] = current_amount
 
         for order_id, previous_amount in non_take_profit_exit_order_amounts.items():
             order = orders_by_id.get(order_id)
             if order is None:
-                return cls._block(state, "attributed_order_missing")
+                return cls._block(
+                    state,
+                    "attributed_order_missing",
+                    order_id=order_id,
+                )
             if order.ft_order_side != trade.exit_side:
-                return cls._block(state, "attributed_order_side_changed")
+                return cls._block(
+                    state,
+                    "attributed_order_side_changed",
+                    order_id=order_id,
+                )
             if order.ft_is_open:
-                return cls._block(state, "attributed_order_reopened")
+                return cls._block(
+                    state,
+                    "attributed_order_reopened",
+                    order_id=order_id,
+                )
             current_amount = terminal_credits[order_id]
             if current_amount < previous_amount and not cls._amounts_close(
                 current_amount,
                 previous_amount,
             ):
-                return cls._block(state, "attributed_fill_regressed")
+                return cls._block(
+                    state,
+                    "attributed_fill_regressed",
+                    order_id=order_id,
+                )
             non_take_profit_exit_order_amounts[order_id] = current_amount
 
         for order in strategy_exit_orders:
@@ -1244,7 +1892,11 @@ class TakeProfitStageManager:
                 and current_amount < previous_amount
                 and not cls._amounts_close(current_amount, previous_amount)
             ):
-                return cls._block(state, "attributed_fill_regressed")
+                return cls._block(
+                    state,
+                    "attributed_fill_regressed",
+                    order_id=order.order_id,
+                )
             non_take_profit_exit_order_amounts[order.order_id] = current_amount
 
         if set(credited_order_amounts) & set(non_take_profit_exit_order_amounts):
@@ -1347,56 +1999,86 @@ class TakeProfitStageManager:
                 observed_amount,
                 expected_with_adjustments,
             ):
+                if partial_wallet_mutation is not None or (
+                    cls._is_partial_wallet_mutation(
+                        active_attempt,
+                        expected_with_adjustments,
+                        observed_amount,
+                    )
+                ):
+                    if active_attempt is None:
+                        raise AssertionError("Validated mutation has no active attempt")
+                    partial_wallet_mutation = (
+                        partial_wallet_mutation
+                        or TakeProfitPartialWalletMutation(
+                            attempt_id=active_attempt.attempt_id,
+                            order_id=None,
+                            expected_trade_amount=expected_with_adjustments,
+                            requested_exit_amount=active_attempt.amount,
+                            observed_trade_amount=observed_amount,
+                            wallet_shortfall_amount=(
+                                active_attempt.amount - observed_amount
+                            ),
+                            attempt_submitted_at=(
+                                active_attempt.submitted_at or active_attempt.created_at
+                            ),
+                        )
+                    )
+                    return cls._block(
+                        replace(
+                            state,
+                            active_attempt=replace(
+                                active_attempt,
+                                status="ambiguous",
+                            ),
+                            partial_wallet_mutation=partial_wallet_mutation,
+                        ),
+                        "partial_wallet_mutation",
+                    )
                 return cls._block(state, "trade_amount_mismatch")
 
-        if matching_attempt_orders:
+        if (
+            partial_wallet_mutation is not None
+            and partial_wallet_mutation.order_id is not None
+            and matching_attempt_orders
+            and not has_open_exit_order
+            and validate_trade_amount
+        ):
+            partial_wallet_mutation = None
+
+        if matching_attempt_orders and (
+            pending_partial_wallet_order_id is None or partial_wallet_mutation is None
+        ):
             active_attempt = None
+
+        (
+            exposure_adjustments,
+            compacted_adjustment_count,
+            compacted_adjustment_amount,
+        ) = cls._compact_exposure_adjustments(
+            exposure_adjustments,
+            state.compacted_exposure_adjustment_count,
+            state.compacted_exposure_adjustment_amount,
+        )
 
         return replace(
             state,
-            attributed_order_ids=tuple(sorted(attributed_order_ids)),
+            order_attributions=tuple(
+                sorted(
+                    order_attributions.values(),
+                    key=lambda attribution: attribution.order_id,
+                )
+            ),
             credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
             non_take_profit_exit_order_amounts=tuple(
                 sorted(non_take_profit_exit_order_amounts.items())
             ),
             exposure_adjustments=exposure_adjustments,
+            compacted_exposure_adjustment_count=compacted_adjustment_count,
+            compacted_exposure_adjustment_amount=compacted_adjustment_amount,
+            partial_wallet_mutation=partial_wallet_mutation,
             active_attempt=active_attempt,
         )
-
-    @classmethod
-    def reconcile_migrated_state(
-        cls,
-        trade: _Trade,
-        state: TakeProfitStageState,
-        source_version: int,
-        *,
-        amount_quantizer: Callable[[float], float] | None = None,
-    ) -> TakeProfitStageState:
-        """Re-evaluate only v4 blocks made obsolete by the split exit ledger."""
-        state = cls.prepare_migrated_state(state, source_version)
-        return cls.reconcile(
-            trade,
-            state,
-            amount_quantizer=amount_quantizer,
-        )
-
-    @staticmethod
-    def prepare_migrated_state(
-        state: TakeProfitStageState,
-        source_version: int,
-    ) -> TakeProfitStageState:
-        if source_version != 4:
-            return state
-        if state.blocked_reason in {
-            "unattributed_exit_fill",
-            "trade_amount_mismatch",
-        }:
-            return replace(
-                state,
-                blocked_reason=None,
-                blocked_order_id=None,
-            )
-        return state
 
     @classmethod
     def reconcile_for_exit_confirmation(
@@ -1495,6 +2177,22 @@ class TakeProfitStageManager:
             for adjustment in candidate.exposure_adjustments
         ):
             return cls._block(candidate, "duplicate_exposure_adjustment")
+        (
+            compacted_adjustments,
+            compacted_adjustment_count,
+            compacted_adjustment_amount,
+        ) = cls._compact_exposure_adjustments(
+            candidate.exposure_adjustments,
+            candidate.compacted_exposure_adjustment_count,
+            candidate.compacted_exposure_adjustment_amount,
+            required_slots=1,
+        )
+        candidate = replace(
+            candidate,
+            exposure_adjustments=compacted_adjustments,
+            compacted_exposure_adjustment_count=compacted_adjustment_count,
+            compacted_exposure_adjustment_amount=compacted_adjustment_amount,
+        )
         if (
             len(candidate.exposure_adjustments)
             >= TakeProfitStageState.MAX_EXPOSURE_ADJUSTMENTS
@@ -1526,7 +2224,6 @@ class TakeProfitStageManager:
     @classmethod
     def get_stage_progress(
         cls,
-        trade: _Trade,
         state: TakeProfitStageState,
         stage: int,
     ) -> TakeProfitStageProgress:
@@ -1569,16 +2266,33 @@ class TakeProfitStageManager:
         )
 
     @classmethod
-    def get_exit_stage(
+    def get_execution_stage(
         cls,
-        trade: _Trade,
         state: TakeProfitStageState,
+    ) -> int:
+        """Return the next scheduled stage, skipping explicitly deferred work."""
+        return cls._get_stage(state, skip_deferred=True)
+
+    @classmethod
+    def get_credited_stage(
+        cls,
+        state: TakeProfitStageState,
+    ) -> int:
+        """Return the stage reached exclusively through attributed CEX fills."""
+        return cls._get_stage(state, skip_deferred=False)
+
+    @classmethod
+    def _get_stage(
+        cls,
+        state: TakeProfitStageState,
+        *,
+        skip_deferred: bool,
     ) -> int:
         cumulative_filled = math.fsum(
             amount for _, amount in state.credited_order_amounts
         )
         cumulative_target = 0.0
-        deferred_stages = set(state.deferred_stages)
+        deferred_stages = set(state.deferred_stages) if skip_deferred else set()
         for stage, target in state.stage_targets:
             cumulative_target += target
             is_filled = cumulative_filled >= cumulative_target or cls._amounts_close(
@@ -1652,6 +2366,21 @@ class TakeProfitStageManager:
         current_time: datetime.datetime,
         recovery_deadline: datetime.datetime,
     ) -> TakeProfitStageState:
+        attempt_id = _non_empty_string(attempt_id)
+        historical_attempt_ids = {
+            *(
+                attribution.attempt_id
+                for attribution in state.order_attributions
+                if attribution.attempt_id is not None
+            ),
+            *(
+                resolution.attempt_id
+                for resolution in state.operator_resolutions
+                if resolution.attempt_id is not None
+            ),
+        }
+        if attempt_id in historical_attempt_ids:
+            raise ValueError("Take-profit attempt ID was already used")
         if state.blocked_reason is not None:
             raise ValueError(
                 "Cannot start a take-profit attempt while state is blocked"
@@ -1673,7 +2402,7 @@ class TakeProfitStageManager:
         stake_amount = cls._safe_amount(stake_amount)
         if amount == 0.0 or stake_amount == 0.0:
             raise ValueError("Take-profit attempt amounts must be positive")
-        tag = cls.order_tag(trade.trade_direction, stage, attempt_id)
+        tag = cls.order_tag(trade.trade_direction, stage)
         submitted_at = current_time.isoformat() if status == "submitting" else None
         return replace(
             state,
@@ -1689,7 +2418,6 @@ class TakeProfitStageManager:
                 submitted_at=submitted_at,
                 recovery_deadline=recovery_deadline.isoformat(),
                 known_order_ids=tuple(sorted(order.order_id for order in trade.orders)),
-                recovery_policy="tagged_or_unique_untagged",
             ),
         )
 
@@ -1731,6 +2459,8 @@ class TakeProfitStageManager:
         attempt = state.active_attempt
         if attempt is None or attempt.attempt_id != attempt_id:
             return state
+        if attempt.status != "proposed":
+            raise ValueError("Submitted take-profit attempt amounts cannot be changed")
         amount = cls._safe_amount(amount)
         stake_amount = cls._safe_amount(stake_amount)
         if amount == 0.0 or stake_amount == 0.0:
@@ -1813,11 +2543,11 @@ class TakeProfitStageManager:
     ) -> TakeProfitStageState:
         """Reconcile one repaired canonical order and record the operator action."""
         order_id = _non_empty_string(order_id)
-        if (
-            state.blocked_reason
-            not in {"unknown_terminal_fill", "unattributed_exit_fill"}
-            or state.blocked_order_id != order_id
-        ):
+        has_matching_block = (
+            state.blocked_reason in _REVALIDATABLE_TERMINAL_BLOCK_REASONS
+            and state.blocked_order_id == order_id
+        )
+        if not has_matching_block:
             raise ValueError("No matching terminal fill to revalidate")
         if resolved_at.tzinfo is None:
             raise ValueError("Take-profit resolution timestamp must be timezone-aware")
@@ -1830,10 +2560,141 @@ class TakeProfitStageManager:
         order = matching_orders[0]
         if order.ft_order_side != trade.exit_side or order.ft_is_open:
             raise ValueError("Revalidated order is not a terminal strategy exit")
-        credited_amount = cls._terminal_credited_amount(order)
+        cls._validate_resolution_timeline(order, resolved_at)
+        existing_attribution = next(
+            (
+                attribution
+                for attribution in state.order_attributions
+                if attribution.order_id == order_id
+            ),
+            None,
+        )
+        zero_fill_proof = next(
+            (
+                proof
+                for proof in state.confirmed_zero_fill_orders
+                if proof.order_id == order_id
+            ),
+            None,
+        )
+        matching_zero_fill_proof = (
+            zero_fill_proof
+            if zero_fill_proof is not None
+            and cls._zero_fill_proof_matches(trade, order, zero_fill_proof)
+            else None
+        )
+        status = (order.status or "").lower()
+        filled = _non_negative_float(order.filled) if order.filled is not None else None
+        if status in _OPERATOR_ZERO_FILL_STATUSES and filled is not None and filled > 0:
+            raise ValueError(
+                "Canceled positive fill requires confirm_terminal_canceled_fill"
+            )
+        credited_amount = cls._terminal_credited_amount(
+            order,
+            matching_zero_fill_proof,
+        )
 
+        configured_stages = {
+            *(stage for stage, _ in state.stage_targets),
+            state.plan_signature.final_stage.stage,
+        }
+        parsed_tag = cls.parse_order_tag(order.ft_order_tag)
+        order_amount = cls._safe_amount(order.safe_amount)
+        operator_attribution: TakeProfitOrderAttribution | None = None
+        causal_attempt: TakeProfitAttempt | None = None
+        if existing_attribution is not None:
+            if order.ft_order_tag != existing_attribution.tag:
+                raise ValueError(
+                    "Canonical order tag must be repaired before revalidation"
+                )
+            if (
+                order_amount > existing_attribution.maximum_amount
+                and not cls._amounts_close(
+                    order_amount,
+                    existing_attribution.maximum_amount,
+                )
+            ):
+                raise ValueError(
+                    "Canonical order amount exceeds the attributed maximum"
+                )
+            operator_attribution = replace(
+                existing_attribution,
+                order_amount=order_amount,
+            )
+        elif (
+            parsed_tag is not None
+            and parsed_tag[0] == trade.trade_direction
+            and parsed_tag[1] in configured_stages
+        ):
+            stage = parsed_tag[1]
+            active_attempt = state.active_attempt
+            if active_attempt is not None:
+                if (
+                    active_attempt.stage != stage
+                    or active_attempt.tag != order.ft_order_tag
+                    or not cls._is_recovered_attempt_candidate(
+                        order,
+                        active_attempt,
+                    )
+                ):
+                    raise ValueError(
+                        "Canonical order does not match the submitted attempt"
+                    )
+                causal_attempt = active_attempt
+            operator_attribution = TakeProfitOrderAttribution(
+                order_id=order_id,
+                tag=order.ft_order_tag,
+                side=order.ft_order_side,
+                stage=stage,
+                attempt_id=(
+                    causal_attempt.attempt_id if causal_attempt is not None else None
+                ),
+                order_date=order.order_date_utc.isoformat(),
+                maximum_amount=(
+                    causal_attempt.amount
+                    if causal_attempt is not None
+                    else order_amount
+                ),
+                order_amount=order_amount,
+                source="operator",
+            )
+        order_attributions = tuple(
+            attribution
+            for attribution in state.order_attributions
+            if attribution.order_id != order_id
+        )
+        if operator_attribution is not None:
+            order_attributions = tuple(
+                sorted(
+                    (*order_attributions, operator_attribution),
+                    key=lambda attribution: attribution.order_id,
+                )
+            )
+        active_attempt = None if causal_attempt is not None else state.active_attempt
         candidate = replace(
             state,
+            order_attributions=order_attributions,
+            confirmed_zero_fill_orders=tuple(
+                proof
+                for proof in state.confirmed_zero_fill_orders
+                if proof.order_id != order_id
+            ),
+            credited_order_amounts=tuple(
+                record
+                for record in state.credited_order_amounts
+                if record[0] != order_id
+            ),
+            non_take_profit_exit_order_amounts=tuple(
+                record
+                for record in state.non_take_profit_exit_order_amounts
+                if record[0] != order_id
+            ),
+            confirmed_canceled_fill_orders=tuple(
+                proof
+                for proof in state.confirmed_canceled_fill_orders
+                if proof.order_id != order_id
+            ),
+            active_attempt=active_attempt,
             blocked_reason=None,
             blocked_order_id=None,
         )
@@ -1848,7 +2709,10 @@ class TakeProfitStageManager:
                 f"{reconciled.blocked_reason}"
             )
 
-        attributed = order_id in reconciled.attributed_order_ids
+        attributed = any(
+            attribution.order_id == order_id
+            for attribution in reconciled.order_attributions
+        )
         persisted_credit = (
             dict(reconciled.credited_order_amounts).get(order_id)
             if attributed
@@ -1888,23 +2752,77 @@ class TakeProfitStageManager:
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> TakeProfitStageState:
         """Persist an exact operator-verified canceled zero-fill snapshot."""
+        reconciled = cls._prepare_terminal_zero_fill_confirmation(
+            trade,
+            state,
+            order_id,
+            terminal_status,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=True,
+        )
+        order_id = _non_empty_string(order_id)
+        terminal_status = _non_empty_string(terminal_status).lower()
+        resolution = TakeProfitOperatorResolution(
+            action="confirmed_terminal_zero_fill",
+            order_id=order_id,
+            credited_amount=0.0,
+            terminal_status=terminal_status,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            reconciled,
+            operator_resolutions=cls._append_operator_resolution(
+                reconciled,
+                resolution,
+            ),
+        )
+
+    @classmethod
+    def validate_terminal_zero_fill_confirmation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> None:
+        """Validate a zero-fill proof without requiring wallet restoration."""
+        cls._prepare_terminal_zero_fill_confirmation(
+            trade,
+            state,
+            order_id,
+            terminal_status,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=False,
+        )
+
+    @classmethod
+    def _prepare_terminal_zero_fill_confirmation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None,
+        validate_trade_amount: bool,
+    ) -> TakeProfitStageState:
         order_id = _non_empty_string(order_id)
         terminal_status = _non_empty_string(terminal_status).lower()
         if terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
             raise ValueError("Terminal zero-fill status is not operator-recoverable")
         if (
-            state.blocked_reason
-            not in {"unknown_terminal_fill", "unknown_external_exit_fill"}
+            state.blocked_reason not in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
             or state.blocked_order_id != order_id
         ):
             raise ValueError("No matching unknown terminal fill to confirm")
         if resolved_at.tzinfo is None:
             raise ValueError("Take-profit resolution timestamp must be timezone-aware")
-        if any(
-            proof.order_id == order_id for proof in state.confirmed_zero_fill_orders
-        ):
-            raise ValueError("Terminal zero-fill order is already confirmed")
-
         matching_orders = [
             order for order in trade.orders if order.order_id == order_id
         ]
@@ -1920,28 +2838,75 @@ class TakeProfitStageManager:
             state,
             confirmed_zero_fill_orders=tuple(
                 sorted(
-                    (*state.confirmed_zero_fill_orders, proof),
+                    (
+                        *(
+                            existing_proof
+                            for existing_proof in state.confirmed_zero_fill_orders
+                            if existing_proof.order_id != order_id
+                        ),
+                        proof,
+                    ),
                     key=lambda item: item.order_id,
                 )
+            ),
+            confirmed_canceled_fill_orders=tuple(
+                existing_proof
+                for existing_proof in state.confirmed_canceled_fill_orders
+                if existing_proof.order_id != order_id
+            ),
+            credited_order_amounts=tuple(
+                record
+                for record in state.credited_order_amounts
+                if record[0] != order_id
+            ),
+            non_take_profit_exit_order_amounts=tuple(
+                record
+                for record in state.non_take_profit_exit_order_amounts
+                if record[0] != order_id
             ),
             blocked_reason=None,
             blocked_order_id=None,
         )
-        reconciled = cls.reconcile(
+        reconciled = cls._reconcile(
             trade,
             candidate,
             amount_quantizer=amount_quantizer,
+            validate_trade_amount=validate_trade_amount,
         )
-        if reconciled.blocked_reason in {
-            "confirmed_terminal_zero_fill_changed",
-            "confirmed_terminal_zero_fill_order_missing",
-        }:
-            raise ValueError("Terminal zero-fill proof failed its postcondition")
+        if reconciled.blocked_reason is not None:
+            raise ValueError(
+                "Terminal zero-fill proof does not produce a valid state: "
+                f"{reconciled.blocked_reason}"
+            )
+        return reconciled
 
+    @classmethod
+    def confirm_terminal_canceled_fill(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Persist exact operator proof for a canceled positive-fill order."""
+        reconciled, proof = cls._prepare_terminal_canceled_fill_confirmation(
+            trade,
+            state,
+            order_id,
+            terminal_status,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=True,
+        )
+        order_id = _non_empty_string(order_id)
+        terminal_status = _non_empty_string(terminal_status).lower()
         resolution = TakeProfitOperatorResolution(
-            action="confirmed_terminal_zero_fill",
+            action="confirmed_terminal_canceled_fill",
             order_id=order_id,
-            credited_amount=0.0,
+            credited_amount=proof.credited_amount,
             terminal_status=terminal_status,
             resolved_at=resolved_at.isoformat(),
         )
@@ -1952,6 +2917,345 @@ class TakeProfitStageManager:
                 resolution,
             ),
         )
+
+    @classmethod
+    def validate_terminal_canceled_fill_confirmation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> None:
+        """Validate a canceled-fill proof without requiring wallet restoration."""
+        cls._prepare_terminal_canceled_fill_confirmation(
+            trade,
+            state,
+            order_id,
+            terminal_status,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=False,
+        )
+
+    @classmethod
+    def _prepare_terminal_canceled_fill_confirmation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None,
+        validate_trade_amount: bool,
+    ) -> tuple[TakeProfitStageState, TakeProfitCanceledFillProof]:
+        order_id = _non_empty_string(order_id)
+        terminal_status = _non_empty_string(terminal_status).lower()
+        if terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+            raise ValueError("Terminal canceled-fill status is not recoverable")
+        if (
+            state.blocked_reason not in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
+            or state.blocked_order_id != order_id
+        ):
+            raise ValueError("No matching canceled terminal fill to confirm")
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        matching_orders = [
+            order for order in trade.orders if order.order_id == order_id
+        ]
+        if len(matching_orders) != 1:
+            raise ValueError("Expected exactly one matching canonical order")
+        proof = cls._build_canceled_fill_proof(
+            trade,
+            matching_orders[0],
+            terminal_status,
+            resolved_at,
+        )
+        candidate = replace(
+            state,
+            confirmed_zero_fill_orders=tuple(
+                existing_proof
+                for existing_proof in state.confirmed_zero_fill_orders
+                if existing_proof.order_id != order_id
+            ),
+            confirmed_canceled_fill_orders=tuple(
+                sorted(
+                    (
+                        *(
+                            existing_proof
+                            for existing_proof in state.confirmed_canceled_fill_orders
+                            if existing_proof.order_id != order_id
+                        ),
+                        proof,
+                    ),
+                    key=lambda item: item.order_id,
+                )
+            ),
+            credited_order_amounts=tuple(
+                record
+                for record in state.credited_order_amounts
+                if record[0] != order_id
+            ),
+            non_take_profit_exit_order_amounts=tuple(
+                record
+                for record in state.non_take_profit_exit_order_amounts
+                if record[0] != order_id
+            ),
+            blocked_reason=None,
+            blocked_order_id=None,
+        )
+        reconciled = cls._reconcile(
+            trade,
+            candidate,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=validate_trade_amount,
+        )
+        if reconciled.blocked_reason is not None:
+            raise ValueError(
+                "Terminal canceled-fill proof does not produce a valid state: "
+                f"{reconciled.blocked_reason}"
+            )
+        return reconciled, proof
+
+    @classmethod
+    def validate_partial_wallet_mutation_restoration(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> None:
+        """Validate deterministic terminal evidence without mutating accounting."""
+        cls._prepare_partial_wallet_mutation_restoration(
+            trade,
+            state,
+            order_id,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=False,
+        )
+
+    @classmethod
+    def restore_partial_wallet_mutation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Accept native order accounting after an audited wallet restoration."""
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        reconciled, mutation, terminal_status = (
+            cls._prepare_partial_wallet_mutation_restoration(
+                trade,
+                state,
+                order_id,
+                amount_quantizer=amount_quantizer,
+                validate_trade_amount=True,
+            )
+        )
+        order = next(order for order in trade.orders if order.order_id == order_id)
+        cls._validate_resolution_timeline(order, resolved_at)
+        resolution = TakeProfitOperatorResolution(
+            action="restored_partial_wallet_mutation",
+            attempt_id=mutation.attempt_id,
+            order_id=mutation.order_id,
+            terminal_status=terminal_status,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            reconciled,
+            operator_resolutions=cls._append_operator_resolution(
+                reconciled,
+                resolution,
+            ),
+        )
+
+    @classmethod
+    def _prepare_partial_wallet_mutation_restoration(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        *,
+        amount_quantizer: Callable[[float], float] | None,
+        validate_trade_amount: bool,
+    ) -> tuple[TakeProfitStageState, TakeProfitPartialWalletMutation, str]:
+        order_id = _non_empty_string(order_id)
+        mutation = state.partial_wallet_mutation
+        if (
+            state.blocked_reason != "partial_wallet_mutation"
+            or mutation is None
+            or mutation.order_id != order_id
+        ):
+            raise ValueError("No matching bound partial-wallet mutation to restore")
+        matching_orders = [
+            order for order in trade.orders if order.order_id == order_id
+        ]
+        if len(matching_orders) != 1:
+            raise ValueError("Expected exactly one matching canonical order")
+        order = matching_orders[0]
+        if order.ft_order_side != trade.exit_side or order.ft_is_open:
+            raise ValueError("Wallet restoration order is not a terminal strategy exit")
+        terminal_status = _non_empty_string(order.status).lower()
+        if terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
+            raise ValueError("Wallet restoration order has no native terminal outcome")
+        candidate = replace(
+            state,
+            blocked_reason=None,
+            blocked_order_id=None,
+        )
+        reconciled = cls._reconcile(
+            trade,
+            candidate,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=validate_trade_amount,
+        )
+        if reconciled.blocked_reason is not None:
+            raise ValueError(
+                "Canonical order accounting does not restore the wallet mutation: "
+                f"{reconciled.blocked_reason}"
+            )
+        if validate_trade_amount:
+            if (
+                reconciled.partial_wallet_mutation is not None
+                or reconciled.active_attempt is not None
+            ):
+                raise ValueError("Partial-wallet mutation remains active after restore")
+        elif reconciled.partial_wallet_mutation != mutation:
+            raise ValueError(
+                "Partial-wallet mutation evidence changed during validation"
+            )
+        return reconciled, mutation, terminal_status
+
+    @classmethod
+    def get_recovery_instruction(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitRecoveryInstruction | None:
+        """Return the single recovery action supported by canonical evidence."""
+        mutation = state.partial_wallet_mutation
+        if (
+            state.blocked_reason == "partial_wallet_mutation"
+            and mutation is not None
+            and mutation.order_id is not None
+        ):
+            try:
+                cls.validate_partial_wallet_mutation_restoration(
+                    trade,
+                    state,
+                    mutation.order_id,
+                    amount_quantizer=amount_quantizer,
+                )
+            except ValueError:
+                return None
+            order = next(
+                order for order in trade.orders if order.order_id == mutation.order_id
+            )
+            return TakeProfitRecoveryInstruction(
+                action="restore_partial_wallet_mutation",
+                attempt_id=mutation.attempt_id,
+                order_id=mutation.order_id,
+                terminal_status=_non_empty_string(order.status).lower(),
+            )
+
+        order_id = state.blocked_order_id
+        if order_id is None:
+            return None
+        matching_orders = [
+            order for order in trade.orders if order.order_id == order_id
+        ]
+        if len(matching_orders) != 1:
+            return None
+        order = matching_orders[0]
+        if order.ft_order_side != trade.exit_side or order.ft_is_open:
+            return None
+        terminal_status = (order.status or "").lower()
+        if (
+            state.blocked_reason in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
+            and terminal_status in _OPERATOR_ZERO_FILL_STATUSES
+            and order.filled is not None
+        ):
+            try:
+                filled = _non_negative_float(order.filled)
+                resolved_at = datetime.datetime.now(datetime.timezone.utc)
+                has_bound_mutation = (
+                    mutation is not None and mutation.order_id == order_id
+                )
+                if filled == 0.0:
+                    if has_bound_mutation:
+                        cls.validate_terminal_zero_fill_confirmation(
+                            trade,
+                            state,
+                            order_id,
+                            terminal_status,
+                            resolved_at,
+                            amount_quantizer=amount_quantizer,
+                        )
+                    else:
+                        cls.confirm_terminal_zero_fill(
+                            trade,
+                            state,
+                            order_id,
+                            terminal_status,
+                            resolved_at,
+                            amount_quantizer=amount_quantizer,
+                        )
+                    action: TakeProfitRecoveryAction = "confirm_terminal_zero"
+                else:
+                    if has_bound_mutation:
+                        cls.validate_terminal_canceled_fill_confirmation(
+                            trade,
+                            state,
+                            order_id,
+                            terminal_status,
+                            resolved_at,
+                            amount_quantizer=amount_quantizer,
+                        )
+                    else:
+                        cls.confirm_terminal_canceled_fill(
+                            trade,
+                            state,
+                            order_id,
+                            terminal_status,
+                            resolved_at,
+                            amount_quantizer=amount_quantizer,
+                        )
+                    action = "confirm_terminal_canceled"
+            except ValueError:
+                return None
+            return TakeProfitRecoveryInstruction(
+                action=action,
+                order_id=order_id,
+                terminal_status=terminal_status,
+            )
+        if terminal_status in _OPERATOR_ZERO_FILL_STATUSES:
+            return None
+        if state.blocked_reason in _REVALIDATABLE_TERMINAL_BLOCK_REASONS:
+            try:
+                cls.revalidate_unknown_terminal_fill(
+                    trade,
+                    state,
+                    order_id,
+                    datetime.datetime.now(datetime.timezone.utc),
+                    amount_quantizer=amount_quantizer,
+                )
+            except ValueError:
+                return None
+            return TakeProfitRecoveryInstruction(
+                action="revalidate_terminal",
+                order_id=order_id,
+            )
+        return None
 
     @staticmethod
     def _append_operator_resolution(
@@ -1977,6 +3281,7 @@ class TakeProfitStageManager:
         cls,
         order: _Order,
         zero_fill_proof: TakeProfitZeroFillProof | None = None,
+        canceled_fill_proof: TakeProfitCanceledFillProof | None = None,
     ) -> float:
         if order.ft_is_open:
             return 0.0
@@ -2023,6 +3328,13 @@ class TakeProfitStageManager:
             cls._validate_terminal_zero_fill(order, allowed_statuses)
             return 0.0
 
+        if status in _OPERATOR_ZERO_FILL_STATUSES:
+            if canceled_fill_proof is None or not cls._canceled_fill_proof_fields_match(
+                order,
+                canceled_fill_proof,
+            ):
+                raise ValueError("Canceled positive fill requires exact operator proof")
+            return canceled_fill_proof.credited_amount
         if status == "rejected" or order.order_filled_utc is None:
             raise ValueError("Terminal positive fill is not explicitly observed")
         if filled < amount and remaining is None:
@@ -2036,7 +3348,6 @@ class TakeProfitStageManager:
     def _external_exit_block(
         cls,
         order: _Order,
-        zero_fill_proof: TakeProfitZeroFillProof | None = None,
     ) -> str | None:
         try:
             amount = _required_positive_value(
@@ -2054,6 +3365,10 @@ class TakeProfitStageManager:
         except ValueError:
             return "unknown_external_exit_fill"
         if filled is not None and filled > 0.0:
+            try:
+                cls._terminal_credited_amount(order)
+            except ValueError:
+                return "unknown_external_exit_fill"
             return "external_exit_fill"
         if order.ft_is_open:
             if fee_base != 0.0:
@@ -2067,7 +3382,7 @@ class TakeProfitStageManager:
                     return "unknown_external_exit_fill"
             return None
         try:
-            credited_amount = cls._terminal_credited_amount(order, zero_fill_proof)
+            credited_amount = cls._terminal_credited_amount(order)
         except ValueError:
             return "unknown_external_exit_fill"
         return "external_exit_fill" if credited_amount > 0.0 else None
@@ -2080,12 +3395,9 @@ class TakeProfitStageManager:
         terminal_status: str,
         confirmed_at: datetime.datetime,
     ) -> TakeProfitZeroFillProof:
-        if order.ft_order_side == trade.exit_side:
-            order_role: TakeProfitOrderRole = "strategy_exit"
-        elif order.ft_order_side != trade.entry_side:
-            order_role = "external_exit"
-        else:
-            raise ValueError("Entry orders cannot be confirmed as terminal exits")
+        if order.ft_order_side != trade.exit_side:
+            raise ValueError("Terminal zero-fill proof is not a strategy exit")
+        cls._validate_resolution_timeline(order, confirmed_at)
         if (order.status or "").lower() != terminal_status:
             raise ValueError("Canonical order status does not match terminal-status")
         amount, remaining, fee_base = cls._validate_terminal_zero_fill(
@@ -2094,8 +3406,9 @@ class TakeProfitStageManager:
         )
         return TakeProfitZeroFillProof(
             order_id=order.order_id,
-            order_role=order_role,
+            order_date=order.order_date_utc.isoformat(),
             order_side=order.ft_order_side,
+            order_tag=order.ft_order_tag,
             terminal_status=terminal_status,
             amount=amount,
             remaining=remaining,
@@ -2110,13 +3423,7 @@ class TakeProfitStageManager:
         order: _Order,
         proof: TakeProfitZeroFillProof,
     ) -> bool:
-        if proof.order_role == "strategy_exit":
-            expected_side = trade.exit_side
-        else:
-            if order.ft_order_side in {trade.entry_side, trade.exit_side}:
-                return False
-            expected_side = proof.order_side
-        if order.ft_order_side != expected_side:
+        if order.ft_order_side != trade.exit_side:
             return False
         return cls._zero_fill_proof_fields_match(order, proof)
 
@@ -2135,12 +3442,146 @@ class TakeProfitStageManager:
             return False
         return (
             order.order_id == proof.order_id
+            and order.order_date_utc == _parse_iso_datetime(proof.order_date)
             and order.ft_order_side == proof.order_side
+            and order.ft_order_tag == proof.order_tag
             and (order.status or "").lower() == proof.terminal_status
             and amount == proof.amount
             and remaining == proof.remaining
             and fee_base == proof.fee_base
         )
+
+    @classmethod
+    def _build_canceled_fill_proof(
+        cls,
+        trade: _Trade,
+        order: _Order,
+        terminal_status: str,
+        confirmed_at: datetime.datetime,
+    ) -> TakeProfitCanceledFillProof:
+        if order.ft_order_side != trade.exit_side:
+            raise ValueError("Terminal canceled-fill proof is not a strategy exit")
+        cls._validate_resolution_timeline(order, confirmed_at)
+        if (order.status or "").lower() != terminal_status:
+            raise ValueError("Canonical order status does not match terminal-status")
+        amount, filled, remaining, fee_base, filled_at = (
+            cls._validate_terminal_canceled_fill(
+                order,
+                _OPERATOR_ZERO_FILL_STATUSES,
+            )
+        )
+        return TakeProfitCanceledFillProof(
+            order_id=order.order_id,
+            order_date=order.order_date_utc.isoformat(),
+            order_side=order.ft_order_side,
+            order_tag=order.ft_order_tag,
+            terminal_status=terminal_status,
+            amount=amount,
+            filled=filled,
+            remaining=remaining,
+            fee_base=fee_base,
+            filled_at=filled_at.isoformat(),
+            confirmed_at=confirmed_at.isoformat(),
+        )
+
+    @classmethod
+    def _canceled_fill_proof_matches(
+        cls,
+        trade: _Trade,
+        order: _Order,
+        proof: TakeProfitCanceledFillProof,
+    ) -> bool:
+        return (
+            order.ft_order_side == trade.exit_side
+            and cls._canceled_fill_proof_fields_match(order, proof)
+        )
+
+    @classmethod
+    def _canceled_fill_proof_fields_match(
+        cls,
+        order: _Order,
+        proof: TakeProfitCanceledFillProof,
+    ) -> bool:
+        try:
+            amount, filled, remaining, fee_base, filled_at = (
+                cls._validate_terminal_canceled_fill(
+                    order,
+                    {proof.terminal_status},
+                )
+            )
+        except ValueError:
+            return False
+        return (
+            order.order_id == proof.order_id
+            and order.order_date_utc == _parse_iso_datetime(proof.order_date)
+            and order.ft_order_side == proof.order_side
+            and order.ft_order_tag == proof.order_tag
+            and (order.status or "").lower() == proof.terminal_status
+            and amount == proof.amount
+            and filled == proof.filled
+            and remaining == proof.remaining
+            and fee_base == proof.fee_base
+            and filled_at == _parse_iso_datetime(proof.filled_at)
+        )
+
+    @staticmethod
+    def _validate_resolution_timeline(
+        order: _Order,
+        resolved_at: datetime.datetime,
+    ) -> None:
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        order_date = order.order_date_utc
+        if order_date.tzinfo is None:
+            raise ValueError(
+                "Canonical order creation timestamp must be timezone-aware"
+            )
+        if resolved_at < order_date:
+            raise ValueError("Take-profit resolution precedes order creation")
+        filled_at = order.order_filled_utc
+        if filled_at is None:
+            return
+        if filled_at.tzinfo is None:
+            raise ValueError("Canonical order fill timestamp must be timezone-aware")
+        if filled_at < order_date or resolved_at < filled_at:
+            raise ValueError("Canonical order has an invalid resolution timeline")
+
+    @classmethod
+    def _validate_terminal_canceled_fill(
+        cls,
+        order: _Order,
+        allowed_statuses: set[str] | frozenset[str],
+    ) -> tuple[float, float, float, float, datetime.datetime]:
+        if order.ft_is_open:
+            raise ValueError("Terminal canceled-fill order is open")
+        status = (order.status or "").lower()
+        if status not in allowed_statuses:
+            raise ValueError(
+                "Terminal canceled-fill status is not operator-recoverable"
+            )
+        amount = _required_positive_value(order.safe_amount, "terminal order amount")
+        if order.filled is None:
+            raise ValueError("Terminal canceled-fill order has no explicit fill")
+        filled = _required_positive_value(order.filled, "terminal order fill")
+        if filled > amount and not cls._amounts_close(filled, amount):
+            raise ValueError("Terminal canceled fill exceeds its amount")
+        filled = min(filled, amount)
+        if order.remaining is None:
+            raise ValueError("Terminal canceled-fill order has no explicit remainder")
+        remaining = _non_negative_float(order.remaining)
+        if not cls._amounts_close(filled + remaining, amount):
+            raise ValueError("Terminal canceled-fill remainder is inconsistent")
+        fee_base = (
+            _non_negative_float(order.ft_fee_base)
+            if order.ft_fee_base is not None
+            else 0.0
+        )
+        if fee_base >= filled or cls._amounts_close(fee_base, filled):
+            raise ValueError("Terminal canceled-fill base fee consumes its fill")
+        filled_at = order.order_filled_utc
+        if filled_at is None or filled_at.tzinfo is None:
+            raise ValueError("Terminal canceled-fill order has no fill timestamp")
+        return amount, filled, remaining, fee_base, filled_at
 
     @classmethod
     def _validate_terminal_zero_fill(
@@ -2273,30 +3714,87 @@ class TakeProfitStageManager:
             for adjustment in adjustments
         )
 
+    @staticmethod
+    def _compact_exposure_adjustments(
+        adjustments: tuple[TakeProfitExposureAdjustment, ...],
+        compacted_count: int,
+        compacted_amount: float,
+        *,
+        required_slots: int = 0,
+    ) -> tuple[tuple[TakeProfitExposureAdjustment, ...], int, float]:
+        """Compact oldest retired records only, preserving aggregate audit data."""
+        maximum_records = max(
+            0,
+            TakeProfitStageState.MAX_EXPOSURE_ADJUSTMENTS - required_slots,
+        )
+        remove_count = max(0, len(adjustments) - maximum_records)
+        if remove_count == 0:
+            return adjustments, compacted_count, compacted_amount
+        retired_indexes = [
+            index
+            for index, adjustment in enumerate(adjustments)
+            if not adjustment.is_active
+        ][:remove_count]
+        if len(retired_indexes) != remove_count:
+            return adjustments, compacted_count, compacted_amount
+        retired_index_set = set(retired_indexes)
+        compacted_adjustments = tuple(
+            adjustment
+            for index, adjustment in enumerate(adjustments)
+            if index not in retired_index_set
+        )
+        compacted_sum = math.fsum(
+            adjustments[index].amount for index in retired_indexes
+        )
+        return (
+            compacted_adjustments,
+            compacted_count + remove_count,
+            math.fsum((compacted_amount, compacted_sum)),
+        )
+
     @classmethod
-    def _is_legacy_emergency_successor(
+    def _attribution_provenance_matches(
         cls,
         trade: _Trade,
-        predecessor: _Order,
-        emergency_order: _Order,
+        attribution: TakeProfitOrderAttribution,
+        order: _Order,
         configured_stages: set[int],
     ) -> bool:
-        parsed_tag = cls.parse_order_tag(predecessor.ft_order_tag)
-        if parsed_tag is None:
+        if attribution.stage not in configured_stages:
             return False
-        direction, stage, _ = parsed_tag
-        remaining_amount = cls._safe_amount(predecessor.safe_remaining)
-        return (
-            direction == trade.trade_direction
-            and stage in configured_stages
-            and not predecessor.ft_is_open
-            and predecessor.ft_order_side == trade.exit_side
-            and emergency_order.ft_order_side == trade.exit_side
-            and remaining_amount > 0.0
-            and cls._amounts_close(
-                cls._safe_amount(emergency_order.safe_amount),
-                remaining_amount,
+        if attribution.source == "recovered_untagged":
+            has_valid_tag = attribution.tag is None
+        else:
+            parsed_tag = cls.parse_order_tag(attribution.tag)
+            has_valid_tag = (
+                parsed_tag is not None
+                and parsed_tag[0] == trade.trade_direction
+                and parsed_tag[1] == attribution.stage
             )
+        return (
+            has_valid_tag
+            and order.order_date_utc.tzinfo is not None
+            and order.order_date_utc == _parse_iso_datetime(attribution.order_date)
+        )
+
+    @staticmethod
+    def _is_partial_wallet_mutation(
+        attempt: TakeProfitAttempt | None,
+        expected_amount: float,
+        observed_amount: float,
+    ) -> bool:
+        return (
+            attempt is not None
+            and attempt.status in {"submitting", "open", "ambiguous"}
+            and (
+                expected_amount > attempt.amount
+                or TakeProfitStageManager._amounts_close(
+                    expected_amount,
+                    attempt.amount,
+                )
+            )
+            and observed_amount < attempt.amount
+            and observed_amount >= attempt.amount * 0.98
         )
 
     @classmethod
@@ -2305,21 +3803,27 @@ class TakeProfitStageManager:
         order: _Order,
         attempt: TakeProfitAttempt,
     ) -> bool:
+        order_amount = cls._safe_amount(order.safe_amount)
+        amount_matches = cls._amounts_close(order_amount, attempt.amount) or (
+            attempt.amount * 0.98 <= order_amount < attempt.amount
+        )
         if (
-            attempt.recovery_policy != "tagged_or_unique_untagged"
-            or order.order_id in attempt.known_order_ids
-            or order.ft_order_tag is not None
+            order.order_id in attempt.known_order_ids
             or order.ft_order_side != attempt.exit_side
-            or not cls._amounts_close(
-                cls._safe_amount(order.safe_amount),
-                attempt.amount,
-            )
+            or not amount_matches
             or attempt.submitted_at is None
         ):
             return False
-        submitted_at = datetime.datetime.fromisoformat(attempt.submitted_at)
-        recovery_deadline = datetime.datetime.fromisoformat(attempt.recovery_deadline)
-        return submitted_at <= order.order_date_utc <= recovery_deadline
+        has_exact_tag = order.ft_order_tag == attempt.tag
+        if not (has_exact_tag or order.ft_order_tag is None):
+            return False
+        submitted_at = _parse_iso_datetime(attempt.submitted_at)
+        recovery_deadline = _parse_iso_datetime(attempt.recovery_deadline)
+        order_date = order.order_date_utc
+        return (
+            order_date.tzinfo is not None
+            and submitted_at <= order_date <= recovery_deadline
+        )
 
     @staticmethod
     def _block(

--- a/quickadapter/user_data/strategies/TakeProfitStageManager.py
+++ b/quickadapter/user_data/strategies/TakeProfitStageManager.py
@@ -1,24 +1,29 @@
 import datetime
 import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
-from dataclasses import dataclass, replace
+from dataclasses import dataclass, fields, replace
 from decimal import Decimal
 from typing import Literal, Protocol, Self, final
 
 
-TakeProfitAttemptStatus = Literal["proposed", "submitting", "open", "ambiguous"]
+TakeProfitAttemptStatus = Literal["proposed", "submitting", "ambiguous"]
 TakeProfitOperatorAction = Literal[
     "confirmed_no_remote_order",
     "confirmed_terminal_canceled_fill",
     "confirmed_terminal_zero_fill",
-    "revalidated_terminal_fill",
-    "restored_partial_wallet_mutation",
+    "revalidated_state",
+    "revalidated_terminal_order",
 ]
 TakeProfitRecoveryAction = Literal[
-    "confirm_terminal_canceled",
-    "confirm_terminal_zero",
-    "restore_partial_wallet_mutation",
-    "revalidate_terminal",
+    "confirm_terminal_canceled_fill",
+    "confirm_terminal_zero_fill",
+    "revalidate_state",
+    "revalidate_terminal_order",
+]
+TakeProfitTradeAccountingAction = Literal[
+    "native_freqtrade_lifecycle",
+    "none",
+    "recalculate_from_orders",
 ]
 TakeProfitAttributionSource = Literal[
     "attempt",
@@ -27,26 +32,89 @@ TakeProfitAttributionSource = Literal[
 ]
 
 
-_OPERATOR_ZERO_FILL_STATUSES = frozenset({"canceled", "cancelled"})
-_NATIVE_WALLET_RESTORATION_STATUSES = frozenset({"closed", "expired", "rejected"})
-_CONFIRMABLE_TERMINAL_BLOCK_REASONS = frozenset(
-    {
-        "confirmed_terminal_canceled_fill_changed",
-        "confirmed_terminal_zero_fill_changed",
-        "unknown_terminal_fill",
-    }
-)
-_REVALIDATABLE_TERMINAL_BLOCK_REASONS = frozenset(
+_OPERATOR_CONFIRMABLE_CANCELED_STATUSES = frozenset({"canceled", "cancelled"})
+_RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS = frozenset(
     {
         "attributed_fill_regressed",
         "attributed_order_amount_changed",
+        "attributed_order_missing",
+        "attributed_order_provenance_changed",
+        "attributed_order_reopened",
+        "attributed_order_side_changed",
         "attributed_order_tag_changed",
-        *_CONFIRMABLE_TERMINAL_BLOCK_REASONS,
+        "confirmed_terminal_canceled_fill_changed",
+        "confirmed_terminal_canceled_fill_order_missing",
+        "confirmed_terminal_zero_fill_changed",
+        "confirmed_terminal_zero_fill_order_missing",
+        "terminal_trade_amount_mismatch",
         "unattributed_exit_fill",
+        "unknown_attempt_order",
+        "unknown_terminal_fill",
+    }
+)
+_REVALIDATABLE_STATE_BLOCK_REASONS = frozenset(
+    {
+        "attributed_fill_regressed",
+        "attributed_order_amount_changed",
+        "attributed_order_missing",
+        "attributed_order_provenance_changed",
+        "attributed_order_reopened",
+        "attributed_order_side_changed",
+        "attributed_order_tag_changed",
+        "confirmed_terminal_canceled_fill_changed",
+        "confirmed_terminal_canceled_fill_order_missing",
+        "confirmed_terminal_zero_fill_changed",
+        "confirmed_terminal_zero_fill_order_missing",
+        "closed_trade_exposure_mismatch",
+        "closed_trade_has_open_exit_order",
+        "duplicate_order_id",
+        "entry_exposure_changed",
+        "initial_exposure_mismatch",
+        "trade_amount_mismatch",
+        "unknown_attempt_order",
+    }
+)
+_BLOCKED_REASONS = frozenset(
+    {
+        "ambiguous_recovered_exit",
+        "attributed_fill_regressed",
+        "attributed_order_amount_changed",
+        "attributed_order_missing",
+        "attributed_order_provenance_changed",
+        "attributed_order_reopened",
+        "attributed_order_side_changed",
+        "attributed_order_tag_changed",
+        "closed_trade_exposure_mismatch",
+        "closed_trade_has_open_exit_order",
+        "confirmed_terminal_canceled_fill_changed",
+        "confirmed_terminal_canceled_fill_order_missing",
+        "confirmed_terminal_zero_fill_changed",
+        "confirmed_terminal_zero_fill_order_missing",
+        "credited_fill_exceeds_initial_amount",
+        "duplicate_exposure_adjustment",
+        "duplicate_order_id",
+        "entry_exposure_changed",
+        "exit_order_role_changed",
+        "exposure_adjustment_limit",
+        "external_exit_fill",
+        "initial_exposure_mismatch",
+        "missing_entry_exposure",
+        "multiple_attempt_orders",
+        "open_entry_order",
+        "partial_wallet_mutation",
+        "partial_wallet_order_changed",
+        "terminal_trade_amount_mismatch",
+        "trade_amount_mismatch",
+        "unattributed_exit_fill",
+        "unknown_attempt_order",
+        "unknown_external_exit_fill",
+        "unknown_terminal_fill",
+        "zero_fill_retry_limit_reached",
     }
 )
 _BLOCKED_ORDER_ID_REASONS = frozenset(
     {
+        "ambiguous_recovered_exit",
         "confirmed_terminal_zero_fill_changed",
         "confirmed_terminal_zero_fill_order_missing",
         "confirmed_terminal_canceled_fill_changed",
@@ -58,12 +126,16 @@ _BLOCKED_ORDER_ID_REASONS = frozenset(
         "attributed_order_reopened",
         "attributed_order_side_changed",
         "attributed_order_tag_changed",
+        "closed_trade_has_open_exit_order",
+        "external_exit_fill",
         "multiple_attempt_orders",
         "partial_wallet_order_changed",
+        "terminal_trade_amount_mismatch",
         "unknown_attempt_order",
         "unknown_external_exit_fill",
         "unknown_terminal_fill",
         "unattributed_exit_fill",
+        "zero_fill_retry_limit_reached",
     }
 )
 
@@ -74,6 +146,9 @@ class _Order(Protocol):
 
     @property
     def ft_fee_base(self) -> float | None: ...
+
+    @property
+    def funding_fee(self) -> float | None: ...
 
     @property
     def order_id(self) -> str: ...
@@ -103,10 +178,16 @@ class _Order(Protocol):
     def safe_amount_after_fee(self) -> float: ...
 
     @property
+    def safe_price(self) -> float | None: ...
+
+    @property
     def status(self) -> str | None: ...
 
 
 class _Trade(Protocol):
+    @property
+    def is_open(self) -> bool: ...
+
     @property
     def amount(self) -> float: ...
 
@@ -117,6 +198,9 @@ class _Trade(Protocol):
     def exit_side(self) -> str: ...
 
     @property
+    def funding_fee_running(self) -> float | None: ...
+
+    @property
     def orders(self) -> Sequence[_Order]: ...
 
     @property
@@ -125,32 +209,57 @@ class _Trade(Protocol):
 
 @dataclass(frozen=True, slots=True)
 class TakeProfitRecoveryInstruction:
-    """Single supported operator recovery path for the current blocked state."""
+    """Canonical recovery disposition for the current blocked state."""
 
     action: TakeProfitRecoveryAction
-    order_id: str
+    expected_trade_amount: float
+    order_id: str | None = None
     terminal_status: str | None = None
-    attempt_id: str | None = None
+    trade_accounting_action: TakeProfitTradeAccountingAction = "none"
 
     def __post_init__(self) -> None:
-        _non_empty_string(self.order_id)
-        if self.action == "restore_partial_wallet_mutation":
-            _non_empty_string(self.attempt_id)
-            if self.terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
-                raise ValueError("Wallet restoration has an invalid terminal status")
-        elif self.action in {
-            "confirm_terminal_canceled",
-            "confirm_terminal_zero",
+        _non_negative_float(self.expected_trade_amount)
+        if self.trade_accounting_action not in {
+            "native_freqtrade_lifecycle",
+            "none",
+            "recalculate_from_orders",
         }:
-            if self.attempt_id is not None:
-                raise ValueError("Terminal proof instruction has an attempt ID")
-            if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+            raise ValueError("Recovery has an invalid trade-accounting action")
+        if self.trade_accounting_action != "none" and self.order_id is None:
+            raise ValueError("Trade-accounting recovery has no order ID")
+        if (self.trade_accounting_action == "native_freqtrade_lifecycle") != (
+            not self.expected_trade_is_open
+        ):
+            raise ValueError("Recovery has an inconsistent trade lifecycle")
+        if self.action in {
+            "confirm_terminal_canceled_fill",
+            "confirm_terminal_zero_fill",
+        }:
+            _non_empty_string(self.order_id)
+            if self.terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
                 raise ValueError("Terminal proof instruction has an invalid status")
-        elif self.action == "revalidate_terminal":
-            if self.attempt_id is not None or self.terminal_status is not None:
-                raise ValueError("Revalidation instruction has terminal fields")
+        elif self.action == "revalidate_terminal_order":
+            _non_empty_string(self.order_id)
+            if self.terminal_status is not None:
+                raise ValueError("Recovery instruction has unexpected terminal fields")
+        elif self.action == "revalidate_state":
+            if any(
+                value is not None for value in (self.order_id, self.terminal_status)
+            ):
+                raise ValueError("State revalidation instruction has evidence fields")
+            if self.trade_accounting_action != "none":
+                raise ValueError("State revalidation cannot repair trade accounting")
         else:
             raise ValueError(f"Invalid take-profit recovery action {self.action!r}")
+
+    @property
+    def expected_trade_is_open(self) -> bool:
+        return not math.isclose(
+            self.expected_trade_amount,
+            0.0,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -184,8 +293,9 @@ class TakeProfitAttempt:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit attempt")
         status = value.get("status")
-        if status not in {"proposed", "submitting", "open", "ambiguous"}:
+        if status not in {"proposed", "submitting", "ambiguous"}:
             raise ValueError(f"Invalid take-profit attempt status {status!r}")
         submitted_at = value.get("submitted_at")
         if submitted_at is not None and not isinstance(submitted_at, str):
@@ -211,7 +321,7 @@ class TakeProfitAttempt:
         )
         if amount == 0.0 or stake_amount == 0.0:
             raise ValueError("Take-profit attempt amounts must be positive")
-        if status in {"submitting", "open", "ambiguous"} and submitted_time is None:
+        if status in {"submitting", "ambiguous"} and submitted_time is None:
             raise ValueError("Submitted take-profit attempt has no timestamp")
         if submitted_time is not None and submitted_time < created_time:
             raise ValueError("Take-profit attempt was submitted before creation")
@@ -233,6 +343,44 @@ class TakeProfitAttempt:
             submitted_at=submitted_at,
             recovery_deadline=recovery_deadline,
             known_order_ids=tuple(known_order_ids),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitRetryGate:
+    """Persisted backoff after causally attributed terminal zero fills."""
+
+    stage: int
+    consecutive_zero_fill_count: int
+    last_order_id: str
+    retry_not_before: str
+
+    def __post_init__(self) -> None:
+        _non_negative_int(self.stage)
+        if self.consecutive_zero_fill_count <= 0:
+            raise ValueError("Take-profit zero-fill retry count must be positive")
+        _non_empty_string(self.last_order_id)
+        _parse_iso_datetime(self.retry_not_before)
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "consecutive_zero_fill_count": self.consecutive_zero_fill_count,
+            "last_order_id": self.last_order_id,
+            "retry_not_before": self.retry_not_before,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit retry gate")
+        return cls(
+            stage=_required_non_negative_int(value, "stage"),
+            consecutive_zero_fill_count=_required_non_negative_int(
+                value,
+                "consecutive_zero_fill_count",
+            ),
+            last_order_id=_required_string(value, "last_order_id"),
+            retry_not_before=_required_string(value, "retry_not_before"),
         )
 
 
@@ -302,6 +450,7 @@ class TakeProfitExposureAdjustment:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit exposure adjustment")
         retired_at = value.get("retired_at")
         if retired_at is not None and not isinstance(retired_at, str):
             raise ValueError("Invalid exposure adjustment retirement timestamp")
@@ -348,6 +497,7 @@ class TakeProfitStageDefinition:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit stage definition")
         return cls(
             stage=_required_non_negative_int(value, "stage"),
             trigger_natr_fraction=_required_positive_float(
@@ -382,6 +532,7 @@ class TakeProfitFinalStageDefinition:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "final take-profit stage definition")
         return cls(
             stage=_required_non_negative_int(value, "stage"),
             trigger_natr_fraction=_required_positive_float(
@@ -427,6 +578,7 @@ class TakeProfitPlanSignature:
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit plan signature")
         partial_raw = value.get("partial_stages")
         final_raw = value.get("final_stage")
         if not isinstance(partial_raw, list) or not all(
@@ -453,6 +605,8 @@ class TakeProfitOperatorResolution:
     order_id: str | None = None
     credited_amount: float | None = None
     terminal_status: str | None = None
+    cleared_block_reason: str | None = None
+    cleared_block_order_id: str | None = None
 
     def __post_init__(self) -> None:
         _parse_iso_datetime(self.resolved_at)
@@ -469,7 +623,7 @@ class TakeProfitOperatorResolution:
             if (
                 self.attempt_id is not None
                 or self.credited_amount != 0.0
-                or self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES
+                or self.terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES
             ):
                 raise ValueError("Terminal zero-fill resolution has invalid fields")
         elif self.action == "confirmed_terminal_canceled_fill":
@@ -477,14 +631,14 @@ class TakeProfitOperatorResolution:
             if (
                 self.attempt_id is not None
                 or self.credited_amount is None
-                or self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES
+                or self.terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES
             ):
                 raise ValueError("Terminal canceled-fill resolution has invalid fields")
             _required_positive_value(
                 self.credited_amount,
                 "terminal canceled-fill resolution credit",
             )
-        elif self.action == "revalidated_terminal_fill":
+        elif self.action == "revalidated_terminal_order":
             _non_empty_string(self.order_id)
             if (
                 self.attempt_id is not None
@@ -493,19 +647,30 @@ class TakeProfitOperatorResolution:
             ):
                 raise ValueError("Terminal-fill resolution has invalid fields")
             _non_negative_float(self.credited_amount)
-        elif self.action == "restored_partial_wallet_mutation":
-            _non_empty_string(self.attempt_id)
-            _non_empty_string(self.order_id)
-            if self.credited_amount is not None or self.terminal_status is None:
-                raise ValueError(
-                    "Partial-wallet restoration has invalid terminal fields"
+        elif self.action == "revalidated_state":
+            if self.cleared_block_reason not in _REVALIDATABLE_STATE_BLOCK_REASONS:
+                raise ValueError("State revalidation has an invalid block reason")
+            if any(
+                value is not None
+                for value in (
+                    self.attempt_id,
+                    self.order_id,
+                    self.credited_amount,
+                    self.terminal_status,
                 )
-            if self.terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
-                raise ValueError(
-                    "Partial-wallet restoration has an invalid terminal status"
-                )
+            ):
+                raise ValueError("State revalidation has evidence fields")
+            if self.cleared_block_reason in _BLOCKED_ORDER_ID_REASONS:
+                _non_empty_string(self.cleared_block_order_id)
+            elif self.cleared_block_order_id is not None:
+                raise ValueError("State revalidation has an unexpected order ID")
         else:
             raise ValueError(f"Invalid take-profit operator action {self.action!r}")
+        if self.action != "revalidated_state" and (
+            self.cleared_block_reason is not None
+            or self.cleared_block_order_id is not None
+        ):
+            raise ValueError("Operator resolution has unexpected block evidence")
 
     def to_mapping(self) -> dict[str, object]:
         return {
@@ -514,24 +679,29 @@ class TakeProfitOperatorResolution:
             "order_id": self.order_id,
             "credited_amount": self.credited_amount,
             "terminal_status": self.terminal_status,
+            "cleared_block_reason": self.cleared_block_reason,
+            "cleared_block_order_id": self.cleared_block_order_id,
             "resolved_at": self.resolved_at,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit operator resolution")
         action = value.get("action")
         if action not in {
             "confirmed_no_remote_order",
             "confirmed_terminal_canceled_fill",
             "confirmed_terminal_zero_fill",
-            "revalidated_terminal_fill",
-            "restored_partial_wallet_mutation",
+            "revalidated_state",
+            "revalidated_terminal_order",
         }:
             raise ValueError(f"Invalid take-profit operator action {action!r}")
         attempt_id = value.get("attempt_id")
         order_id = value.get("order_id")
         credited_amount = value.get("credited_amount")
         terminal_status = value.get("terminal_status")
+        cleared_block_reason = value.get("cleared_block_reason")
+        cleared_block_order_id = value.get("cleared_block_order_id")
         return cls(
             action=action,
             resolved_at=_required_string(value, "resolved_at"),
@@ -549,6 +719,16 @@ class TakeProfitOperatorResolution:
                 if terminal_status is not None
                 else None
             ),
+            cleared_block_reason=(
+                _non_empty_string(cleared_block_reason)
+                if cleared_block_reason is not None
+                else None
+            ),
+            cleared_block_order_id=(
+                _non_empty_string(cleared_block_order_id)
+                if cleared_block_order_id is not None
+                else None
+            ),
         )
 
 
@@ -564,6 +744,7 @@ class TakeProfitZeroFillProof:
     amount: float
     remaining: float
     fee_base: float
+    funding_fee: float
     confirmed_at: str
 
     def __post_init__(self) -> None:
@@ -572,7 +753,7 @@ class TakeProfitZeroFillProof:
         _non_empty_string(self.order_side)
         if self.order_tag is not None:
             _non_empty_string(self.order_tag)
-        if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+        if self.terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             raise ValueError("Invalid operator-confirmed zero-fill status")
         amount = _required_positive_value(self.amount, "zero-fill proof amount")
         remaining = _non_negative_float(self.remaining)
@@ -580,6 +761,8 @@ class TakeProfitZeroFillProof:
             raise ValueError("Terminal zero-fill proof has an inconsistent remainder")
         if _non_negative_float(self.fee_base) != 0.0:
             raise ValueError("Terminal zero-fill proof has a base fee")
+        if _finite_float(self.funding_fee) != 0.0:
+            raise ValueError("Terminal zero-fill proof has a funding fee")
         confirmed_at = _parse_iso_datetime(self.confirmed_at)
         if confirmed_at < order_date:
             raise ValueError("Terminal zero fill was confirmed before order creation")
@@ -594,11 +777,13 @@ class TakeProfitZeroFillProof:
             "amount": self.amount,
             "remaining": self.remaining,
             "fee_base": self.fee_base,
+            "funding_fee": self.funding_fee,
             "confirmed_at": self.confirmed_at,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "terminal zero-fill proof")
         order_tag = value.get("order_tag")
         if order_tag is not None and not isinstance(order_tag, str):
             raise ValueError("Invalid terminal zero-fill order tag")
@@ -611,6 +796,7 @@ class TakeProfitZeroFillProof:
             amount=_required_positive_float(value, "amount"),
             remaining=_required_non_negative_float(value, "remaining"),
             fee_base=_required_non_negative_float(value, "fee_base"),
+            funding_fee=_required_finite_float(value, "funding_fee"),
             confirmed_at=_required_string(value, "confirmed_at"),
         )
 
@@ -628,6 +814,8 @@ class TakeProfitCanceledFillProof:
     filled: float
     remaining: float
     fee_base: float
+    execution_price: float
+    funding_fee: float
     filled_at: str
     confirmed_at: str
 
@@ -637,12 +825,17 @@ class TakeProfitCanceledFillProof:
         _non_empty_string(self.order_side)
         if self.order_tag is not None:
             _non_empty_string(self.order_tag)
-        if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+        if self.terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             raise ValueError("Invalid operator-confirmed canceled-fill status")
         amount = _required_positive_value(self.amount, "canceled-fill proof amount")
         filled = _required_positive_value(self.filled, "canceled-fill proof fill")
         remaining = _non_negative_float(self.remaining)
         fee_base = _non_negative_float(self.fee_base)
+        _required_positive_value(
+            self.execution_price,
+            "canceled-fill proof execution price",
+        )
+        _finite_float(self.funding_fee)
         if filled > amount and not math.isclose(
             filled,
             amount,
@@ -686,12 +879,15 @@ class TakeProfitCanceledFillProof:
             "filled": self.filled,
             "remaining": self.remaining,
             "fee_base": self.fee_base,
+            "execution_price": self.execution_price,
+            "funding_fee": self.funding_fee,
             "filled_at": self.filled_at,
             "confirmed_at": self.confirmed_at,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "terminal canceled-fill proof")
         order_tag = value.get("order_tag")
         if order_tag is not None and not isinstance(order_tag, str):
             raise ValueError("Invalid terminal canceled-fill order tag")
@@ -705,6 +901,8 @@ class TakeProfitCanceledFillProof:
             filled=_required_positive_float(value, "filled"),
             remaining=_required_non_negative_float(value, "remaining"),
             fee_base=_required_non_negative_float(value, "fee_base"),
+            execution_price=_required_positive_float(value, "execution_price"),
+            funding_fee=_required_finite_float(value, "funding_fee"),
             filled_at=_required_string(value, "filled_at"),
             confirmed_at=_required_string(value, "confirmed_at"),
         )
@@ -712,9 +910,10 @@ class TakeProfitCanceledFillProof:
 
 @dataclass(frozen=True, slots=True)
 class TakeProfitOrderAttribution:
-    """Immutable evidence binding one canonical order to take-profit execution."""
+    """Audit evidence binding one canonical order to take-profit execution."""
 
     order_id: str
+    attribution_sequence: int
     tag: str | None
     side: str
     stage: int
@@ -723,16 +922,19 @@ class TakeProfitOrderAttribution:
     maximum_amount: float
     order_amount: float
     source: TakeProfitAttributionSource
+    attempt_submitted_at: str | None = None
+    retry_delay_seconds: float | None = None
 
     def __post_init__(self) -> None:
         _non_empty_string(self.order_id)
+        _non_negative_int(self.attribution_sequence)
         if self.tag is not None:
             _non_empty_string(self.tag)
         _non_empty_string(self.side)
         _non_negative_int(self.stage)
         if self.attempt_id is not None:
             _non_empty_string(self.attempt_id)
-        _parse_iso_datetime(self.order_date)
+        order_date = _parse_iso_datetime(self.order_date)
         maximum_amount = _required_positive_value(
             self.maximum_amount,
             "attribution maximum amount",
@@ -767,10 +969,34 @@ class TakeProfitOrderAttribution:
             parsed_tag = TakeProfitStageManager.parse_order_tag(self.tag)
             if parsed_tag is None or parsed_tag[1] != self.stage:
                 raise ValueError("Operator attribution has an invalid tag")
+        if self.attempt_id is None:
+            if (
+                self.attempt_submitted_at is not None
+                or self.retry_delay_seconds is not None
+            ):
+                raise ValueError("Non-attempt attribution has retry evidence")
+        else:
+            if self.attempt_submitted_at is None:
+                raise ValueError("Attempt attribution has no submission timestamp")
+            attempt_submitted_at = _parse_iso_datetime(self.attempt_submitted_at)
+            if self.retry_delay_seconds is None:
+                raise ValueError("Attempt attribution has no retry delay")
+            retry_delay_seconds = _required_positive_value(
+                self.retry_delay_seconds,
+                "attribution retry delay",
+            )
+            if not (
+                attempt_submitted_at
+                <= order_date
+                <= attempt_submitted_at
+                + datetime.timedelta(seconds=retry_delay_seconds)
+            ):
+                raise ValueError("Attributed order is outside its submission window")
 
     def to_mapping(self) -> dict[str, object]:
         return {
             "order_id": self.order_id,
+            "attribution_sequence": self.attribution_sequence,
             "tag": self.tag,
             "side": self.side,
             "stage": self.stage,
@@ -779,10 +1005,13 @@ class TakeProfitOrderAttribution:
             "maximum_amount": self.maximum_amount,
             "order_amount": self.order_amount,
             "source": self.source,
+            "attempt_submitted_at": self.attempt_submitted_at,
+            "retry_delay_seconds": self.retry_delay_seconds,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "take-profit order attribution")
         source = value.get("source")
         if source not in {
             "attempt",
@@ -791,8 +1020,14 @@ class TakeProfitOrderAttribution:
         }:
             raise ValueError("Invalid take-profit attribution source")
         attempt_id = value.get("attempt_id")
+        attempt_submitted_at = value.get("attempt_submitted_at")
+        retry_delay_seconds = value.get("retry_delay_seconds")
         return cls(
             order_id=_required_string(value, "order_id"),
+            attribution_sequence=_required_non_negative_int(
+                value,
+                "attribution_sequence",
+            ),
             tag=(
                 _non_empty_string(value.get("tag"))
                 if value.get("tag") is not None
@@ -807,6 +1042,19 @@ class TakeProfitOrderAttribution:
             maximum_amount=_required_positive_float(value, "maximum_amount"),
             order_amount=_required_positive_float(value, "order_amount"),
             source=source,
+            attempt_submitted_at=(
+                _non_empty_string(attempt_submitted_at)
+                if attempt_submitted_at is not None
+                else None
+            ),
+            retry_delay_seconds=(
+                _required_positive_value(
+                    retry_delay_seconds,
+                    "attribution retry delay",
+                )
+                if retry_delay_seconds is not None
+                else None
+            ),
         )
 
 
@@ -819,7 +1067,7 @@ class TakeProfitPartialWalletMutation:
     expected_trade_amount: float
     requested_exit_amount: float
     observed_trade_amount: float
-    wallet_shortfall_amount: float
+    requested_exit_shortfall_amount: float
     attempt_submitted_at: str
 
     def __post_init__(self) -> None:
@@ -839,8 +1087,8 @@ class TakeProfitPartialWalletMutation:
             "partial wallet mutation observed amount",
         )
         shortfall = _required_positive_value(
-            self.wallet_shortfall_amount,
-            "partial wallet mutation wallet shortfall",
+            self.requested_exit_shortfall_amount,
+            "partial wallet mutation requested-exit shortfall",
         )
         if (
             expected < requested
@@ -852,7 +1100,7 @@ class TakeProfitPartialWalletMutation:
             )
         ) or observed >= expected:
             raise ValueError("Partial wallet mutation is not a partial-exit mutation")
-        if observed >= requested or observed < requested * 0.98:
+        if observed >= requested or observed <= requested * 0.98:
             raise ValueError("Partial wallet mutation is outside the fallback window")
         if not math.isclose(
             requested - observed,
@@ -870,12 +1118,13 @@ class TakeProfitPartialWalletMutation:
             "expected_trade_amount": self.expected_trade_amount,
             "requested_exit_amount": self.requested_exit_amount,
             "observed_trade_amount": self.observed_trade_amount,
-            "wallet_shortfall_amount": self.wallet_shortfall_amount,
+            "requested_exit_shortfall_amount": (self.requested_exit_shortfall_amount),
             "attempt_submitted_at": self.attempt_submitted_at,
         }
 
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        _require_exact_mapping_keys(value, cls, "partial wallet mutation")
         order_id = value.get("order_id")
         return cls(
             attempt_id=_required_string(value, "attempt_id"),
@@ -892,9 +1141,9 @@ class TakeProfitPartialWalletMutation:
                 value,
                 "observed_trade_amount",
             ),
-            wallet_shortfall_amount=_required_positive_float(
+            requested_exit_shortfall_amount=_required_positive_float(
                 value,
-                "wallet_shortfall_amount",
+                "requested_exit_shortfall_amount",
             ),
             attempt_submitted_at=_required_string(value, "attempt_submitted_at"),
         )
@@ -917,6 +1166,7 @@ class TakeProfitStageState:
     confirmed_zero_fill_orders: tuple[TakeProfitZeroFillProof, ...]
     confirmed_canceled_fill_orders: tuple[TakeProfitCanceledFillProof, ...]
     operator_resolutions: tuple[TakeProfitOperatorResolution, ...]
+    retry_gate: TakeProfitRetryGate | None = None
     partial_wallet_mutation: TakeProfitPartialWalletMutation | None = None
     active_attempt: TakeProfitAttempt | None = None
     blocked_reason: str | None = None
@@ -925,6 +1175,7 @@ class TakeProfitStageState:
     SCHEMA_VERSION = 1
     MAX_OPERATOR_RESOLUTIONS = 32
     MAX_EXPOSURE_ADJUSTMENTS = 32
+    MAX_CONSECUTIVE_ZERO_FILL_OUTCOMES = 5
 
     def to_mapping(self) -> dict[str, object]:
         return {
@@ -969,6 +1220,9 @@ class TakeProfitStageState:
             "operator_resolutions": [
                 resolution.to_mapping() for resolution in self.operator_resolutions
             ],
+            "retry_gate": (
+                self.retry_gate.to_mapping() if self.retry_gate is not None else None
+            ),
             "partial_wallet_mutation": (
                 self.partial_wallet_mutation.to_mapping()
                 if self.partial_wallet_mutation is not None
@@ -991,6 +1245,7 @@ class TakeProfitStageState:
                 f"Unsupported take-profit state version {version!r}; "
                 f"expected {cls.SCHEMA_VERSION}"
             )
+        _require_exact_mapping_keys(value, cls, "take-profit state")
 
         plan_raw = value.get("plan_signature")
         if not isinstance(plan_raw, Mapping):
@@ -1050,6 +1305,11 @@ class TakeProfitStageState:
         )
         if len(attribution_order_ids) != len(set(attribution_order_ids)):
             raise ValueError("Duplicate attributed take-profit order")
+        attribution_sequences = tuple(
+            attribution.attribution_sequence for attribution in order_attributions
+        )
+        if sorted(attribution_sequences) != list(range(len(order_attributions))):
+            raise ValueError("Invalid take-profit attribution sequence")
         attribution_attempt_ids = tuple(
             attribution.attempt_id
             for attribution in order_attributions
@@ -1159,10 +1419,17 @@ class TakeProfitStageState:
         ):
             raise ValueError("Exposure credits exceed the initial amount")
         if any(
-            adjustment.exit_credit_baseline > total_exit_credited
+            adjustment.is_active
+            and adjustment.exit_credit_baseline > total_exit_credited
+            and not math.isclose(
+                adjustment.exit_credit_baseline,
+                total_exit_credited,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
             for adjustment in exposure_adjustments
         ):
-            raise ValueError("Exposure adjustment has an invalid fill baseline")
+            raise ValueError("Active exposure adjustment has an invalid fill baseline")
 
         proofs_raw = value.get("confirmed_zero_fill_orders")
         if not isinstance(proofs_raw, list) or not all(
@@ -1215,6 +1482,93 @@ class TakeProfitStageState:
         )
         if len(resolved_attempt_ids) != len(set(resolved_attempt_ids)):
             raise ValueError("Duplicate take-profit operator resolution")
+
+        retry_gate_raw = value.get("retry_gate")
+        if retry_gate_raw is not None and not isinstance(retry_gate_raw, Mapping):
+            raise ValueError("Invalid take-profit retry gate")
+        retry_gate = (
+            TakeProfitRetryGate.from_mapping(retry_gate_raw)
+            if isinstance(retry_gate_raw, Mapping)
+            else None
+        )
+        if retry_gate is not None:
+            credited_amounts_by_order_id = dict(credited_order_amounts)
+            retry_attribution = next(
+                (
+                    attribution
+                    for attribution in order_attributions
+                    if attribution.order_id == retry_gate.last_order_id
+                ),
+                None,
+            )
+            retry_credit = credited_amounts_by_order_id.get(retry_gate.last_order_id)
+            if (
+                retry_attribution is None
+                or retry_attribution.stage != retry_gate.stage
+                or retry_attribution.attempt_id is None
+                or (retry_credit is not None and retry_credit != 0.0)
+            ):
+                raise ValueError(
+                    "Take-profit retry gate has no matching zero-fill order"
+                )
+            if (
+                retry_gate.consecutive_zero_fill_count
+                > cls.MAX_CONSECUTIVE_ZERO_FILL_OUTCOMES
+            ):
+                raise ValueError("Take-profit retry gate exceeds its safety budget")
+            suffix_attribution, suffix_count = (
+                TakeProfitStageManager._derive_retry_suffix(
+                    order_attributions,
+                    credited_amounts_by_order_id,
+                )
+            )
+            if retry_credit is None:
+                credited_sequences = (
+                    attribution.attribution_sequence
+                    for attribution in order_attributions
+                    if attribution.order_id in credited_amounts_by_order_id
+                )
+                if max(credited_sequences, default=-1) >= (
+                    retry_attribution.attribution_sequence
+                ):
+                    raise ValueError("Uncredited retry outcome is not causally latest")
+                expected_count = (
+                    suffix_count + 1
+                    if suffix_attribution is not None
+                    and suffix_attribution.stage == retry_attribution.stage
+                    else 1
+                )
+            else:
+                if (
+                    suffix_attribution is None
+                    or suffix_attribution.order_id != retry_gate.last_order_id
+                ):
+                    raise ValueError(
+                        "Take-profit retry gate is not the causal zero-fill suffix"
+                    )
+                expected_count = suffix_count
+            if retry_gate.consecutive_zero_fill_count != expected_count:
+                raise ValueError(
+                    "Take-profit retry count does not match its causal suffix"
+                )
+            if (
+                retry_attribution.attempt_submitted_at is None
+                or retry_attribution.retry_delay_seconds is None
+            ):
+                raise ValueError("Take-profit retry gate has no timing evidence")
+            minimum_retry_time = max(
+                _parse_iso_datetime(retry_attribution.attempt_submitted_at),
+                _parse_iso_datetime(retry_attribution.order_date),
+            ) + datetime.timedelta(
+                seconds=(
+                    retry_attribution.retry_delay_seconds
+                    * TakeProfitStageManager._retry_backoff_multiplier(expected_count)
+                )
+            )
+            if _parse_iso_datetime(retry_gate.retry_not_before) < minimum_retry_time:
+                raise ValueError(
+                    "Take-profit retry deadline precedes its causal backoff"
+                )
         active_raw = value.get("active_attempt")
         if active_raw is not None and not isinstance(active_raw, Mapping):
             raise ValueError("Invalid take-profit active_attempt")
@@ -1238,7 +1592,10 @@ class TakeProfitStageState:
         ):
             raise ValueError("Resolved take-profit attempt cannot remain active")
         blocked_reason = value.get("blocked_reason")
-        if blocked_reason is not None and not isinstance(blocked_reason, str):
+        if blocked_reason is not None and (
+            not isinstance(blocked_reason, str)
+            or blocked_reason not in _BLOCKED_REASONS
+        ):
             raise ValueError("Invalid take-profit blocked_reason")
         blocked_order_id = value.get("blocked_order_id")
         if blocked_reason in _BLOCKED_ORDER_ID_REASONS:
@@ -1246,7 +1603,17 @@ class TakeProfitStageState:
         elif blocked_reason is None and blocked_order_id is not None:
             raise ValueError("Take-profit blocked_order_id requires a blocked state")
         elif blocked_order_id is not None:
-            blocked_order_id = _non_empty_string(blocked_order_id)
+            raise ValueError(
+                "Take-profit blocked_order_id is invalid for its blocked state"
+            )
+        if blocked_reason == "zero_fill_retry_limit_reached":
+            if (
+                retry_gate is None
+                or retry_gate.consecutive_zero_fill_count
+                < cls.MAX_CONSECUTIVE_ZERO_FILL_OUTCOMES
+                or blocked_order_id != retry_gate.last_order_id
+            ):
+                raise ValueError("Zero-fill retry limit has no matching retry gate")
 
         partial_wallet_raw = value.get("partial_wallet_mutation")
         if partial_wallet_raw is not None and not isinstance(
@@ -1260,17 +1627,41 @@ class TakeProfitStageState:
             else None
         )
         if partial_wallet_mutation is not None:
-            if (
-                active_attempt is None
-                or active_attempt.attempt_id != partial_wallet_mutation.attempt_id
-                or active_attempt.status not in {"open", "ambiguous"}
-            ):
-                raise ValueError("Partial wallet mutation has no matching attempt")
             if partial_wallet_mutation.order_id is None:
-                if active_attempt.status != "ambiguous":
+                if (
+                    active_attempt is None
+                    or active_attempt.attempt_id != partial_wallet_mutation.attempt_id
+                    or active_attempt.status != "ambiguous"
+                ):
                     raise ValueError("Unbound partial wallet attempt is not ambiguous")
-                if blocked_reason != "partial_wallet_mutation":
+                if blocked_reason is None:
                     raise ValueError("Unbound partial wallet mutation must be blocked")
+                attempt_amount_matches = math.isclose(
+                    partial_wallet_mutation.requested_exit_amount,
+                    active_attempt.amount,
+                    rel_tol=1e-9,
+                    abs_tol=1e-12,
+                ) or (
+                    math.isclose(
+                        partial_wallet_mutation.observed_trade_amount,
+                        active_attempt.amount,
+                        rel_tol=1e-9,
+                        abs_tol=1e-12,
+                    )
+                    and math.isclose(
+                        partial_wallet_mutation.expected_trade_amount,
+                        partial_wallet_mutation.requested_exit_amount,
+                        rel_tol=1e-9,
+                        abs_tol=1e-12,
+                    )
+                )
+                if not attempt_amount_matches or (
+                    partial_wallet_mutation.attempt_submitted_at
+                    != (active_attempt.submitted_at or active_attempt.created_at)
+                ):
+                    raise ValueError(
+                        "Partial wallet mutation does not match its attempt"
+                    )
             elif (
                 blocked_reason == "partial_wallet_order_changed"
                 and blocked_order_id != partial_wallet_mutation.order_id
@@ -1278,15 +1669,33 @@ class TakeProfitStageState:
                 raise ValueError(
                     "Bound partial wallet mutation has invalid order block"
                 )
-            if not math.isclose(
-                partial_wallet_mutation.requested_exit_amount,
-                active_attempt.amount,
-                rel_tol=1e-9,
-                abs_tol=1e-12,
-            ) or partial_wallet_mutation.attempt_submitted_at != (
-                active_attempt.submitted_at or active_attempt.created_at
-            ):
-                raise ValueError("Partial wallet mutation does not match its attempt")
+            else:
+                if active_attempt is not None:
+                    raise ValueError(
+                        "Bound partial wallet mutation has an active attempt"
+                    )
+                mutation_attribution = next(
+                    (
+                        attribution
+                        for attribution in order_attributions
+                        if attribution.order_id == partial_wallet_mutation.order_id
+                    ),
+                    None,
+                )
+                if (
+                    mutation_attribution is None
+                    or mutation_attribution.attempt_id
+                    != partial_wallet_mutation.attempt_id
+                    or not math.isclose(
+                        mutation_attribution.maximum_amount,
+                        partial_wallet_mutation.requested_exit_amount,
+                        rel_tol=1e-9,
+                        abs_tol=1e-12,
+                    )
+                ):
+                    raise ValueError(
+                        "Bound partial wallet mutation has no matching attribution"
+                    )
         elif blocked_reason == "partial_wallet_mutation":
             raise ValueError("Partial wallet block has no mutation evidence")
 
@@ -1301,40 +1710,9 @@ class TakeProfitStageState:
             else ()
         )
         if active_attributions:
-            if (
-                len(active_attributions) != 1
-                or partial_wallet_mutation is None
-                or partial_wallet_mutation.order_id != active_attributions[0].order_id
-            ):
-                raise ValueError("Active attempt has invalid attributed order evidence")
-            attribution = active_attributions[0]
-            tag_matches = (
-                attribution.tag is None
-                if attribution.source == "recovered_untagged"
-                else attribution.tag == active_attempt.tag
-            )
-            if (
-                attribution.source not in {"attempt", "recovered_untagged"}
-                or attribution.stage != active_attempt.stage
-                or attribution.side != active_attempt.exit_side
-                or not tag_matches
-                or not math.isclose(
-                    attribution.maximum_amount,
-                    active_attempt.amount,
-                    rel_tol=1e-9,
-                    abs_tol=1e-12,
-                )
-            ):
-                raise ValueError("Active attempt attribution does not match its intent")
-        elif (
-            partial_wallet_mutation is not None
-            and partial_wallet_mutation.order_id is not None
-        ):
-            raise ValueError("Bound partial wallet mutation has no attribution")
-        elif active_attempt is not None and active_attempt.status == "open":
-            raise ValueError("Open take-profit attempt has no attributed order")
+            raise ValueError("Attributed take-profit attempt cannot remain active")
 
-        return cls(
+        parsed_state = cls(
             version=cls.SCHEMA_VERSION,
             plan_signature=plan_signature,
             initial_amount=initial_amount,
@@ -1367,11 +1745,18 @@ class TakeProfitStageState:
                 )
             ),
             operator_resolutions=operator_resolutions,
+            retry_gate=retry_gate,
             partial_wallet_mutation=partial_wallet_mutation,
             active_attempt=active_attempt,
             blocked_reason=blocked_reason,
             blocked_order_id=blocked_order_id,
         )
+        if active_attempt is not None:
+            TakeProfitStageManager._validate_attempt_bounds(
+                parsed_state,
+                active_attempt,
+            )
+        return parsed_state
 
 
 @dataclass(frozen=True, slots=True)
@@ -1443,6 +1828,7 @@ class TakeProfitStageManager:
         *,
         amount_quantizer: Callable[[float], float] | None = None,
         validate_trade_amount: bool = True,
+        current_time: datetime.datetime | None = None,
     ) -> TakeProfitStageState:
         entry_order_amounts = cls._entry_order_amounts(trade)
         if entry_order_amounts:
@@ -1481,6 +1867,7 @@ class TakeProfitStageManager:
             confirmed_zero_fill_orders=(),
             confirmed_canceled_fill_orders=(),
             operator_resolutions=(),
+            retry_gate=None,
             blocked_reason=blocked_reason,
         )
         return (
@@ -1491,6 +1878,7 @@ class TakeProfitStageManager:
                 state,
                 amount_quantizer=amount_quantizer,
                 validate_trade_amount=validate_trade_amount,
+                current_time=current_time,
             )
         )
 
@@ -1501,12 +1889,14 @@ class TakeProfitStageManager:
         state: TakeProfitStageState,
         *,
         amount_quantizer: Callable[[float], float] | None = None,
+        current_time: datetime.datetime | None = None,
     ) -> TakeProfitStageState:
         return cls._reconcile(
             trade,
             state,
             amount_quantizer=amount_quantizer,
             validate_trade_amount=True,
+            current_time=current_time,
         )
 
     @classmethod
@@ -1517,9 +1907,26 @@ class TakeProfitStageManager:
         *,
         amount_quantizer: Callable[[float], float] | None,
         validate_trade_amount: bool,
+        current_time: datetime.datetime | None,
+        allow_canonical_adjustment_retirement: bool = False,
     ) -> TakeProfitStageState:
+        if current_time is not None and current_time.tzinfo is None:
+            raise ValueError(
+                "Take-profit reconciliation timestamp must be timezone-aware"
+            )
         if state.blocked_reason is not None:
-            return state
+            mutation = state.partial_wallet_mutation
+            can_refresh_unbound_wallet_mutation = (
+                state.blocked_reason == "partial_wallet_mutation"
+                and mutation is not None
+                and mutation.order_id is None
+            )
+            can_refresh_retry_limit = (
+                state.blocked_reason == "zero_fill_retry_limit_reached"
+            )
+            if not (can_refresh_unbound_wallet_mutation or can_refresh_retry_limit):
+                return state
+            state = replace(state, blocked_reason=None, blocked_order_id=None)
 
         orders_by_id: dict[str, _Order] = {}
         for order in trade.orders:
@@ -1612,23 +2019,6 @@ class TakeProfitStageManager:
                     order_id=order.order_id,
                 )
 
-        terminal_credits: dict[str, float] = {}
-        for order in strategy_exit_orders:
-            if order.ft_is_open:
-                continue
-            try:
-                terminal_credits[order.order_id] = cls._terminal_credited_amount(
-                    order,
-                    confirmed_zero_fill_orders.get(order.order_id),
-                    confirmed_canceled_fill_orders.get(order.order_id),
-                )
-            except ValueError:
-                return cls._block(
-                    state,
-                    "unknown_terminal_fill",
-                    order_id=order.order_id,
-                )
-
         for attribution in order_attributions.values():
             order_id = attribution.order_id
             order = orders_by_id.get(order_id)
@@ -1654,19 +2044,28 @@ class TakeProfitStageManager:
                     order_id=order_id,
                 )
             order_amount = cls._safe_amount(order.safe_amount)
-            if (
-                not cls._amounts_close(order_amount, attribution.order_amount)
-                or order_amount > attribution.maximum_amount
-                and not cls._amounts_close(
-                    order_amount,
-                    attribution.maximum_amount,
-                )
+            if order_amount > attribution.maximum_amount and not cls._amounts_close(
+                order_amount,
+                attribution.maximum_amount,
             ):
                 return cls._block(
                     state,
                     "attributed_order_amount_changed",
                     order_id=order_id,
                 )
+            reconciled_attribution = cls._reconcile_attribution_order_amount(
+                attribution,
+                order_amount,
+                amount_quantizer,
+            )
+            if reconciled_attribution is None:
+                return cls._block(
+                    state,
+                    "attributed_order_amount_changed",
+                    order_id=order_id,
+                )
+            attribution = reconciled_attribution
+            order_attributions[order_id] = attribution
             if not cls._attribution_provenance_matches(
                 trade,
                 attribution,
@@ -1682,36 +2081,21 @@ class TakeProfitStageManager:
         active_attempt = state.active_attempt
         partial_wallet_mutation = state.partial_wallet_mutation
         matching_attempt_orders: list[_Order] = []
-        pending_partial_wallet_order_id: str | None = None
+        retry_gate = state.retry_gate
         if active_attempt is not None and active_attempt.status in {
             "submitting",
-            "open",
             "ambiguous",
         }:
-            bound_attributions = [
-                attribution
-                for attribution in order_attributions.values()
-                if attribution.attempt_id == active_attempt.attempt_id
+            matching_attempt_orders = [
+                order
+                for order in strategy_exit_orders
+                if order.order_id not in order_attributions
+                and cls._is_recovered_attempt_candidate(
+                    order,
+                    active_attempt,
+                    amount_quantizer,
+                )
             ]
-            if bound_attributions:
-                if len(bound_attributions) != 1:
-                    return cls._block(state, "multiple_attempt_orders")
-                bound_order = orders_by_id.get(bound_attributions[0].order_id)
-                if bound_order is None:
-                    return cls._block(
-                        state,
-                        "attributed_order_missing",
-                        order_id=bound_attributions[0].order_id,
-                    )
-                matching_attempt_orders = [bound_order]
-                pending_partial_wallet_order_id = bound_order.order_id
-            else:
-                matching_attempt_orders = [
-                    order
-                    for order in strategy_exit_orders
-                    if order.order_id not in order_attributions
-                    and cls._is_recovered_attempt_candidate(order, active_attempt)
-                ]
             if len(matching_attempt_orders) > 1:
                 block_reason = (
                     "ambiguous_recovered_exit"
@@ -1727,80 +2111,162 @@ class TakeProfitStageManager:
                 )
             if matching_attempt_orders:
                 order = matching_attempt_orders[0]
-                if order.ft_is_open:
-                    try:
-                        expected_amount = cls.get_expected_trade_amount(
+                source: TakeProfitAttributionSource = (
+                    "recovered_untagged" if order.ft_order_tag is None else "attempt"
+                )
+                order_attributions[order.order_id] = TakeProfitOrderAttribution(
+                    order_id=order.order_id,
+                    attribution_sequence=(
+                        max(
+                            (
+                                attribution.attribution_sequence
+                                for attribution in order_attributions.values()
+                            ),
+                            default=-1,
+                        )
+                        + 1
+                    ),
+                    tag=order.ft_order_tag,
+                    side=order.ft_order_side,
+                    stage=active_attempt.stage,
+                    attempt_id=active_attempt.attempt_id,
+                    order_date=order.order_date_utc.isoformat(),
+                    maximum_amount=(
+                        partial_wallet_mutation.requested_exit_amount
+                        if partial_wallet_mutation is not None
+                        and partial_wallet_mutation.attempt_id
+                        == active_attempt.attempt_id
+                        else active_attempt.amount
+                    ),
+                    order_amount=cls._safe_amount(order.safe_amount),
+                    source=source,
+                    attempt_submitted_at=(
+                        active_attempt.submitted_at or active_attempt.created_at
+                    ),
+                    retry_delay_seconds=cls._attempt_retry_delay_seconds(
+                        active_attempt
+                    ),
+                )
+                if partial_wallet_mutation is not None:
+                    if partial_wallet_mutation.order_id not in {
+                        None,
+                        order.order_id,
+                    }:
+                        causal_candidate = replace(
                             state,
-                            amount_quantizer=amount_quantizer,
+                            order_attributions=tuple(
+                                sorted(
+                                    order_attributions.values(),
+                                    key=lambda attribution: attribution.order_id,
+                                )
+                            ),
+                            active_attempt=None,
                         )
-                        observed_amount = cls._canonical_amount(
-                            trade.amount,
-                            amount_quantizer,
+                        return cls._block(
+                            causal_candidate,
+                            "partial_wallet_order_changed",
+                            order_id=order.order_id,
                         )
-                    except ValueError:
-                        return cls._block(state, "trade_amount_mismatch")
-                    if partial_wallet_mutation is not None or (
-                        cls._is_partial_wallet_mutation(
-                            active_attempt,
-                            expected_amount,
-                            observed_amount,
-                        )
-                    ):
-                        if partial_wallet_mutation is not None and (
-                            partial_wallet_mutation.order_id != order.order_id
-                        ):
-                            return cls._block(
-                                state,
-                                "partial_wallet_order_changed",
-                                order_id=order.order_id,
-                            )
-                        if partial_wallet_mutation is not None:
-                            if cls._amounts_close(
-                                observed_amount,
-                                expected_amount,
-                            ):
-                                partial_wallet_mutation = None
-                                pending_partial_wallet_order_id = None
-                            elif not cls._amounts_close(
-                                observed_amount,
-                                partial_wallet_mutation.observed_trade_amount,
-                            ):
-                                return cls._block(state, "trade_amount_mismatch")
-                        else:
-                            partial_wallet_mutation = TakeProfitPartialWalletMutation(
-                                attempt_id=active_attempt.attempt_id,
-                                order_id=order.order_id,
-                                expected_trade_amount=expected_amount,
-                                requested_exit_amount=active_attempt.amount,
-                                observed_trade_amount=observed_amount,
-                                wallet_shortfall_amount=(
-                                    active_attempt.amount - observed_amount
-                                ),
-                                attempt_submitted_at=(
-                                    active_attempt.submitted_at
-                                    or active_attempt.created_at
-                                ),
-                            )
-                        if partial_wallet_mutation is not None:
-                            active_attempt = replace(active_attempt, status="open")
-                            pending_partial_wallet_order_id = order.order_id
-                if order.order_id not in order_attributions:
-                    if order.ft_order_tag is None:
-                        source: TakeProfitAttributionSource = "recovered_untagged"
-                    else:
-                        source = "attempt"
-                    order_amount = cls._safe_amount(order.safe_amount)
-                    order_attributions[order.order_id] = TakeProfitOrderAttribution(
+                    partial_wallet_mutation = replace(
+                        partial_wallet_mutation,
                         order_id=order.order_id,
-                        tag=order.ft_order_tag,
-                        side=order.ft_order_side,
-                        stage=active_attempt.stage,
-                        attempt_id=active_attempt.attempt_id,
-                        order_date=order.order_date_utc.isoformat(),
-                        maximum_amount=active_attempt.amount,
-                        order_amount=order_amount,
-                        source=source,
                     )
+                try:
+                    expected_amount = cls.get_expected_trade_amount(
+                        state,
+                        amount_quantizer=amount_quantizer,
+                    )
+                    observed_amount = cls._canonical_amount(
+                        trade.amount,
+                        amount_quantizer,
+                    )
+                except ValueError:
+                    causal_candidate = replace(
+                        state,
+                        order_attributions=tuple(
+                            sorted(
+                                order_attributions.values(),
+                                key=lambda attribution: attribution.order_id,
+                            )
+                        ),
+                        partial_wallet_mutation=partial_wallet_mutation,
+                        active_attempt=None,
+                    )
+                    return cls._block(causal_candidate, "trade_amount_mismatch")
+                if partial_wallet_mutation is None and cls._is_partial_wallet_mutation(
+                    active_attempt,
+                    expected_amount,
+                    observed_amount,
+                ):
+                    partial_wallet_mutation = TakeProfitPartialWalletMutation(
+                        attempt_id=active_attempt.attempt_id,
+                        order_id=order.order_id,
+                        expected_trade_amount=expected_amount,
+                        requested_exit_amount=active_attempt.amount,
+                        observed_trade_amount=observed_amount,
+                        requested_exit_shortfall_amount=(
+                            active_attempt.amount - observed_amount
+                        ),
+                        attempt_submitted_at=(
+                            active_attempt.submitted_at or active_attempt.created_at
+                        ),
+                    )
+                active_attempt = None
+
+        for attribution in order_attributions.values():
+            order = orders_by_id[attribution.order_id]
+            if (
+                attribution.attempt_id is None
+                or order.ft_is_open
+                or order.order_id in credited_order_amounts
+            ):
+                continue
+            try:
+                cls._validate_terminal_zero_fill(
+                    order,
+                    cls._ZERO_FILL_RETRY_STATUSES
+                    | _OPERATOR_CONFIRMABLE_CANCELED_STATUSES,
+                )
+            except ValueError:
+                continue
+            retry_gate = cls._record_zero_fill_outcome(
+                retry_gate,
+                attribution,
+                order,
+                current_time=current_time,
+            )
+
+        candidate = replace(
+            state,
+            order_attributions=tuple(
+                sorted(
+                    order_attributions.values(),
+                    key=lambda attribution: attribution.order_id,
+                )
+            ),
+            retry_gate=retry_gate,
+            partial_wallet_mutation=partial_wallet_mutation,
+            active_attempt=active_attempt,
+        )
+
+        terminal_credits: dict[str, float] = {}
+        for order in strategy_exit_orders:
+            if order.ft_is_open:
+                continue
+            try:
+                terminal_credits[order.order_id] = cls._terminal_credited_amount(
+                    order,
+                    confirmed_zero_fill_orders.get(order.order_id),
+                    confirmed_canceled_fill_orders.get(order.order_id),
+                )
+            except ValueError:
+                if partial_wallet_mutation is not None:
+                    return cls._block(candidate, "partial_wallet_mutation")
+                return cls._block(
+                    candidate,
+                    "unknown_terminal_fill",
+                    order_id=order.order_id,
+                )
 
         attributed_order_ids = set(order_attributions)
         matching_attempt_order_ids = {
@@ -1813,7 +2279,7 @@ class TakeProfitStageManager:
                 continue
             if cls.has_order_tag_prefix(order.ft_order_tag):
                 return cls._block(
-                    state,
+                    candidate,
                     "unknown_attempt_order",
                     order_id=order.order_id,
                 )
@@ -1824,7 +2290,7 @@ class TakeProfitStageManager:
             if order.ft_is_open:
                 if previous_amount is not None:
                     return cls._block(
-                        state,
+                        candidate,
                         "attributed_order_reopened",
                         order_id=order_id,
                     )
@@ -1836,7 +2302,7 @@ class TakeProfitStageManager:
                 and not (cls._amounts_close(current_amount, previous_amount))
             ):
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_fill_regressed",
                     order_id=order_id,
                 )
@@ -1846,19 +2312,19 @@ class TakeProfitStageManager:
             order = orders_by_id.get(order_id)
             if order is None:
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_order_missing",
                     order_id=order_id,
                 )
             if order.ft_order_side != trade.exit_side:
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_order_side_changed",
                     order_id=order_id,
                 )
             if order.ft_is_open:
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_order_reopened",
                     order_id=order_id,
                 )
@@ -1868,7 +2334,7 @@ class TakeProfitStageManager:
                 previous_amount,
             ):
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_fill_regressed",
                     order_id=order_id,
                 )
@@ -1878,11 +2344,11 @@ class TakeProfitStageManager:
             if order.ft_is_open or order.order_id in attributed_order_ids:
                 continue
             if order.order_id in credited_order_amounts:
-                return cls._block(state, "exit_order_role_changed")
+                return cls._block(candidate, "exit_order_role_changed")
             current_amount = terminal_credits[order.order_id]
             if current_amount > 0.0 and not order.ft_order_tag:
                 return cls._block(
-                    state,
+                    candidate,
                     "unattributed_exit_fill",
                     order_id=order.order_id,
                 )
@@ -1893,14 +2359,40 @@ class TakeProfitStageManager:
                 and not cls._amounts_close(current_amount, previous_amount)
             ):
                 return cls._block(
-                    state,
+                    candidate,
                     "attributed_fill_regressed",
                     order_id=order.order_id,
                 )
             non_take_profit_exit_order_amounts[order.order_id] = current_amount
 
         if set(credited_order_amounts) & set(non_take_profit_exit_order_amounts):
-            return cls._block(state, "exit_order_role_changed")
+            return cls._block(candidate, "exit_order_role_changed")
+
+        previous_credited_order_amounts = dict(state.credited_order_amounts)
+        increased_positive_order_ids = {
+            order_id
+            for order_id, amount in credited_order_amounts.items()
+            if amount > 0.0
+            and amount > previous_credited_order_amounts.get(order_id, 0.0)
+            and not cls._amounts_close(
+                amount,
+                previous_credited_order_amounts.get(order_id, 0.0),
+            )
+        }
+        retry_gate = cls._reconcile_retry_gate(
+            retry_gate,
+            order_attributions.values(),
+            credited_order_amounts,
+            current_time=current_time,
+        )
+        candidate = replace(
+            candidate,
+            credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
+            non_take_profit_exit_order_amounts=tuple(
+                sorted(non_take_profit_exit_order_amounts.items())
+            ),
+            retry_gate=retry_gate,
+        )
 
         total_take_profit_credited = math.fsum(credited_order_amounts.values())
         total_exit_credited = total_take_profit_credited + math.fsum(
@@ -1910,7 +2402,7 @@ class TakeProfitStageManager:
             total_exit_credited,
             state.initial_amount,
         ):
-            return cls._block(state, "credited_fill_exceeds_initial_amount")
+            return cls._block(candidate, "credited_fill_exceeds_initial_amount")
 
         exposure_adjustments = state.exposure_adjustments
         has_open_exit_order = any(
@@ -1918,6 +2410,17 @@ class TakeProfitStageManager:
             for order in trade.orders
             if order.ft_order_side != trade.entry_side
         )
+        if not trade.is_open and has_open_exit_order:
+            open_exit_order_id = min(
+                order.order_id
+                for order in trade.orders
+                if order.ft_order_side != trade.entry_side and order.ft_is_open
+            )
+            return cls._block(
+                candidate,
+                "closed_trade_has_open_exit_order",
+                order_id=open_exit_order_id,
+            )
         if validate_trade_amount and not has_open_exit_order:
             exit_credit_amounts = (
                 *credited_order_amounts.values(),
@@ -1938,27 +2441,58 @@ class TakeProfitStageManager:
                     state.initial_amount,
                 )
             ):
-                return cls._block(state, "credited_fill_exceeds_initial_amount")
+                return cls._block(candidate, "credited_fill_exceeds_initial_amount")
             expected_with_adjustments = cls._canonical_expected_trade_amount(
                 persisted_entry_amounts.values(),
                 exit_credit_amounts,
                 (adjustment.amount for adjustment in active_adjustments),
                 amount_quantizer,
             )
-            try:
-                observed_amount = cls._canonical_amount(
-                    trade.amount,
-                    amount_quantizer,
-                )
-            except ValueError:
-                return cls._block(state, "trade_amount_mismatch")
-            retireable_adjustments = tuple(
-                adjustment
-                for adjustment in active_adjustments
-                if total_exit_credited > adjustment.exit_credit_baseline
+            if trade.is_open:
+                try:
+                    observed_amount = cls._canonical_amount(
+                        trade.amount,
+                        amount_quantizer,
+                    )
+                except ValueError:
+                    return cls._block(candidate, "trade_amount_mismatch")
+            else:
+                observed_amount = 0.0
+                if not cls._amounts_close(expected_with_adjustments, 0.0):
+                    return cls._block(candidate, "closed_trade_exposure_mismatch")
+            if trade.is_open and cls._amounts_close(expected_with_adjustments, 0.0):
+                if len(increased_positive_order_ids) == 1:
+                    return cls._block(
+                        candidate,
+                        "terminal_trade_amount_mismatch",
+                        order_id=next(iter(increased_positive_order_ids)),
+                    )
+                return cls._block(candidate, "trade_amount_mismatch")
+            expected_without_adjustments = cls._canonical_expected_trade_amount(
+                persisted_entry_amounts.values(),
+                exit_credit_amounts,
+                (),
+                amount_quantizer,
             )
-            adjustments_were_retired = False
-            if retireable_adjustments:
+            if (
+                trade.is_open
+                and allow_canonical_adjustment_retirement
+                and active_adjustments
+                and cls._amounts_close(
+                    observed_amount,
+                    expected_without_adjustments,
+                )
+            ):
+                retireable_adjustments = active_adjustments
+                adjustments_were_retired = True
+            else:
+                retireable_adjustments = tuple(
+                    adjustment
+                    for adjustment in active_adjustments
+                    if total_exit_credited > adjustment.exit_credit_baseline
+                )
+                adjustments_were_retired = False
+            if retireable_adjustments and not adjustments_were_retired:
                 expected_after_retirement = cls._canonical_expected_trade_amount(
                     persisted_entry_amounts.values(),
                     exit_credit_amounts,
@@ -1975,17 +2509,20 @@ class TakeProfitStageManager:
                 )
             if adjustments_were_retired:
                 retirement_time = max(
-                    *(
-                        order.order_filled_utc
-                        for order in strategy_exit_orders
-                        if not order.ft_is_open
-                        and terminal_credits.get(order.order_id, 0.0) > 0.0
-                        and order.order_filled_utc is not None
-                    ),
-                    *(
-                        _parse_iso_datetime(adjustment.recorded_at)
-                        for adjustment in retireable_adjustments
-                    ),
+                    (
+                        *((current_time,) if current_time is not None else ()),
+                        *(
+                            order.order_filled_utc
+                            for order in strategy_exit_orders
+                            if not order.ft_is_open
+                            and terminal_credits.get(order.order_id, 0.0) > 0.0
+                            and order.order_filled_utc is not None
+                        ),
+                        *(
+                            _parse_iso_datetime(adjustment.recorded_at)
+                            for adjustment in retireable_adjustments
+                        ),
+                    )
                 ).isoformat()
                 retireable_ids = {
                     adjustment.adjustment_id for adjustment in retireable_adjustments
@@ -1999,6 +2536,11 @@ class TakeProfitStageManager:
                 observed_amount,
                 expected_with_adjustments,
             ):
+                if (
+                    partial_wallet_mutation is not None
+                    and partial_wallet_mutation.order_id is not None
+                ):
+                    return cls._block(candidate, "partial_wallet_mutation")
                 if partial_wallet_mutation is not None or (
                     cls._is_partial_wallet_mutation(
                         active_attempt,
@@ -2016,7 +2558,7 @@ class TakeProfitStageManager:
                             expected_trade_amount=expected_with_adjustments,
                             requested_exit_amount=active_attempt.amount,
                             observed_trade_amount=observed_amount,
-                            wallet_shortfall_amount=(
+                            requested_exit_shortfall_amount=(
                                 active_attempt.amount - observed_amount
                             ),
                             attempt_submitted_at=(
@@ -2026,7 +2568,7 @@ class TakeProfitStageManager:
                     )
                     return cls._block(
                         replace(
-                            state,
+                            candidate,
                             active_attempt=replace(
                                 active_attempt,
                                 status="ambiguous",
@@ -2035,21 +2577,14 @@ class TakeProfitStageManager:
                         ),
                         "partial_wallet_mutation",
                     )
-                return cls._block(state, "trade_amount_mismatch")
-
-        if (
-            partial_wallet_mutation is not None
-            and partial_wallet_mutation.order_id is not None
-            and matching_attempt_orders
-            and not has_open_exit_order
-            and validate_trade_amount
-        ):
-            partial_wallet_mutation = None
-
-        if matching_attempt_orders and (
-            pending_partial_wallet_order_id is None or partial_wallet_mutation is None
-        ):
-            active_attempt = None
+                if len(increased_positive_order_ids) == 1:
+                    order_id = next(iter(increased_positive_order_ids))
+                    return cls._block(
+                        candidate,
+                        "terminal_trade_amount_mismatch",
+                        order_id=order_id,
+                    )
+                return cls._block(candidate, "trade_amount_mismatch")
 
         (
             exposure_adjustments,
@@ -2061,24 +2596,31 @@ class TakeProfitStageManager:
             state.compacted_exposure_adjustment_amount,
         )
 
-        return replace(
-            state,
-            order_attributions=tuple(
-                sorted(
-                    order_attributions.values(),
-                    key=lambda attribution: attribution.order_id,
-                )
-            ),
-            credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
-            non_take_profit_exit_order_amounts=tuple(
-                sorted(non_take_profit_exit_order_amounts.items())
-            ),
+        reconciled = replace(
+            candidate,
             exposure_adjustments=exposure_adjustments,
             compacted_exposure_adjustment_count=compacted_adjustment_count,
             compacted_exposure_adjustment_amount=compacted_adjustment_amount,
             partial_wallet_mutation=partial_wallet_mutation,
             active_attempt=active_attempt,
         )
+        if (
+            reconciled.partial_wallet_mutation is not None
+            and not has_open_exit_order
+            and validate_trade_amount
+        ):
+            return cls._block(reconciled, "partial_wallet_mutation")
+        if (
+            reconciled.retry_gate is not None
+            and reconciled.retry_gate.consecutive_zero_fill_count
+            >= TakeProfitStageState.MAX_CONSECUTIVE_ZERO_FILL_OUTCOMES
+        ):
+            return cls._block(
+                reconciled,
+                "zero_fill_retry_limit_reached",
+                order_id=reconciled.retry_gate.last_order_id,
+            )
+        return reconciled
 
     @classmethod
     def reconcile_for_exit_confirmation(
@@ -2106,7 +2648,11 @@ class TakeProfitStageManager:
             trade.amount,
             "observed trade amount",
         )
-        if not cls._amounts_close(confirmed_amount, observed_amount):
+        if not cls._raw_and_canonical_amounts_match(
+            confirmed_amount,
+            observed_amount,
+            amount_quantizer,
+        ):
             return cls._block(state, "trade_amount_mismatch")
 
         candidate = cls._reconcile(
@@ -2114,6 +2660,7 @@ class TakeProfitStageManager:
             state,
             amount_quantizer=amount_quantizer,
             validate_trade_amount=False,
+            current_time=current_time,
         )
         if candidate.blocked_reason is not None:
             return candidate
@@ -2159,7 +2706,13 @@ class TakeProfitStageManager:
             active_adjustment_amounts,
             amount_quantizer,
         )
-        if cls._amounts_close(observed_amount, expected_amount):
+        if expected_amount < 0.0:
+            return cls._block(candidate, "trade_amount_mismatch")
+        if cls._raw_and_canonical_amounts_match(
+            observed_amount,
+            expected_amount,
+            amount_quantizer,
+        ):
             return cls.reconcile(
                 trade,
                 candidate,
@@ -2337,7 +2890,11 @@ class TakeProfitStageManager:
             state,
             amount_quantizer=amount_quantizer,
         )
-        observed = cls._canonical_amount(trade.amount, amount_quantizer)
+        observed = (
+            cls._canonical_amount(trade.amount, amount_quantizer)
+            if trade.is_open
+            else 0.0
+        )
         return observed - expected
 
     @staticmethod
@@ -2350,6 +2907,28 @@ class TakeProfitStageManager:
         return replace(
             state,
             deferred_stages=tuple(sorted({*state.deferred_stages, stage})),
+        )
+
+    @staticmethod
+    def is_attempt_due(
+        state: TakeProfitStageState,
+        stage: int,
+        current_time: datetime.datetime,
+    ) -> bool:
+        """Return whether the persisted zero-fill backoff allows a new attempt."""
+        if current_time.tzinfo is None:
+            raise ValueError("Take-profit retry timestamp must be timezone-aware")
+        retry_gate = state.retry_gate
+        retry_budget_exhausted = (
+            retry_gate is not None
+            and retry_gate.stage == stage
+            and retry_gate.consecutive_zero_fill_count
+            >= TakeProfitStageState.MAX_CONSECUTIVE_ZERO_FILL_OUTCOMES
+        )
+        return not retry_budget_exhausted and (
+            retry_gate is None
+            or retry_gate.stage != stage
+            or current_time >= _parse_iso_datetime(retry_gate.retry_not_before)
         )
 
     @classmethod
@@ -2396,30 +2975,214 @@ class TakeProfitStageManager:
             raise ValueError("Only a final take-profit attempt can be proposed")
         if current_time.tzinfo is None or recovery_deadline.tzinfo is None:
             raise ValueError("Take-profit attempt timestamps must be timezone-aware")
+        if not cls.is_attempt_due(state, stage, current_time):
+            raise ValueError("Take-profit zero-fill retry backoff is still active")
         if recovery_deadline < current_time:
             raise ValueError("Take-profit recovery deadline precedes creation")
         amount = cls._safe_amount(amount)
         stake_amount = cls._safe_amount(stake_amount)
         if amount == 0.0 or stake_amount == 0.0:
             raise ValueError("Take-profit attempt amounts must be positive")
-        tag = cls.order_tag(trade.trade_direction, stage)
-        submitted_at = current_time.isoformat() if status == "submitting" else None
+        execution_stage = cls.get_execution_stage(state)
+        if stage != execution_stage:
+            raise ValueError(
+                "Take-profit attempt stage does not match the execution stage"
+            )
+        attempt = TakeProfitAttempt(
+            attempt_id=attempt_id,
+            stage=stage,
+            status=status,
+            amount=amount,
+            stake_amount=stake_amount,
+            exit_side=trade.exit_side,
+            tag=cls.order_tag(trade.trade_direction, stage),
+            created_at=current_time.isoformat(),
+            submitted_at=(current_time.isoformat() if status == "submitting" else None),
+            recovery_deadline=recovery_deadline.isoformat(),
+            known_order_ids=tuple(sorted(order.order_id for order in trade.orders)),
+        )
+        cls._validate_attempt_bounds(state, attempt)
         return replace(
             state,
-            active_attempt=TakeProfitAttempt(
-                attempt_id=attempt_id,
-                stage=stage,
-                status=status,
-                amount=amount,
-                stake_amount=stake_amount,
-                exit_side=trade.exit_side,
-                tag=tag,
-                created_at=current_time.isoformat(),
-                submitted_at=submitted_at,
-                recovery_deadline=recovery_deadline.isoformat(),
-                known_order_ids=tuple(sorted(order.order_id for order in trade.orders)),
-            ),
+            active_attempt=attempt,
         )
+
+    @classmethod
+    def _validate_attempt_bounds(
+        cls,
+        state: TakeProfitStageState,
+        attempt: TakeProfitAttempt,
+    ) -> None:
+        if attempt.stage != cls.get_execution_stage(state):
+            raise ValueError(
+                "Take-profit attempt stage does not match the execution stage"
+            )
+        final_stage = state.plan_signature.final_stage.stage
+        # A proposal can predate Freqtrade's wallet fallback. Bound it to orders,
+        # not to an adjustment that may be recorded only after that proposal.
+        order_backed_exposure = cls._canonical_expected_trade_amount(
+            (amount for _, amount in state.entry_order_amounts),
+            (
+                *(amount for _, amount in state.credited_order_amounts),
+                *(amount for _, amount in state.non_take_profit_exit_order_amounts),
+            ),
+            (),
+            None,
+        )
+        maximum_amount = (
+            order_backed_exposure
+            if attempt.stage == final_stage
+            else min(
+                cls.get_stage_progress(state, attempt.stage).remaining_amount,
+                order_backed_exposure,
+            )
+        )
+        if attempt.amount > maximum_amount and not cls._amounts_close(
+            attempt.amount,
+            maximum_amount,
+        ):
+            raise ValueError("Take-profit attempt exceeds its executable exposure")
+
+    @classmethod
+    def _record_zero_fill_outcome(
+        cls,
+        retry_gate: TakeProfitRetryGate | None,
+        attribution: TakeProfitOrderAttribution,
+        order: _Order,
+        *,
+        current_time: datetime.datetime | None,
+    ) -> TakeProfitRetryGate:
+        if retry_gate is not None and retry_gate.last_order_id == order.order_id:
+            return retry_gate
+        if (
+            attribution.attempt_submitted_at is None
+            or attribution.retry_delay_seconds is None
+        ):
+            raise ValueError("Attributed order has no retry evidence")
+        submitted_at = _parse_iso_datetime(attribution.attempt_submitted_at)
+        base_delay = datetime.timedelta(seconds=attribution.retry_delay_seconds)
+        order_date = order.order_date_utc
+        if order_date.tzinfo is None:
+            raise ValueError("Take-profit order timestamp must be timezone-aware")
+        observed_at = max(
+            submitted_at,
+            order_date,
+            current_time or order_date,
+        )
+        consecutive_zero_fill_count = (
+            retry_gate.consecutive_zero_fill_count + 1
+            if retry_gate is not None and retry_gate.stage == attribution.stage
+            else 1
+        )
+        return TakeProfitRetryGate(
+            stage=attribution.stage,
+            consecutive_zero_fill_count=consecutive_zero_fill_count,
+            last_order_id=order.order_id,
+            retry_not_before=(
+                observed_at
+                + base_delay
+                * cls._retry_backoff_multiplier(consecutive_zero_fill_count)
+            ).isoformat(),
+        )
+
+    @classmethod
+    def _reconcile_retry_gate(
+        cls,
+        retry_gate: TakeProfitRetryGate | None,
+        attributions: Iterable[TakeProfitOrderAttribution],
+        credited_order_amounts: Mapping[str, float],
+        *,
+        current_time: datetime.datetime | None,
+    ) -> TakeProfitRetryGate | None:
+        """Derive the causal zero-fill suffix from the complete credited ledger."""
+        latest_zero_fill, consecutive_zero_fill_count = cls._derive_retry_suffix(
+            attributions,
+            credited_order_amounts,
+        )
+        if latest_zero_fill is None:
+            return None
+        if (
+            latest_zero_fill.attempt_submitted_at is None
+            or latest_zero_fill.retry_delay_seconds is None
+        ):
+            raise ValueError("Attributed zero-fill order has no retry evidence")
+
+        base_delay = datetime.timedelta(seconds=latest_zero_fill.retry_delay_seconds)
+        if (
+            retry_gate is not None
+            and retry_gate.last_order_id == latest_zero_fill.order_id
+        ):
+            previous_observed_at = _parse_iso_datetime(retry_gate.retry_not_before) - (
+                base_delay
+                * cls._retry_backoff_multiplier(retry_gate.consecutive_zero_fill_count)
+            )
+            observed_at = max(
+                previous_observed_at,
+                _parse_iso_datetime(latest_zero_fill.attempt_submitted_at),
+                _parse_iso_datetime(latest_zero_fill.order_date),
+            )
+        else:
+            order_date = _parse_iso_datetime(latest_zero_fill.order_date)
+            observed_at = max(
+                _parse_iso_datetime(latest_zero_fill.attempt_submitted_at),
+                order_date,
+                current_time or order_date,
+            )
+        return TakeProfitRetryGate(
+            stage=latest_zero_fill.stage,
+            consecutive_zero_fill_count=consecutive_zero_fill_count,
+            last_order_id=latest_zero_fill.order_id,
+            retry_not_before=(
+                observed_at
+                + base_delay
+                * cls._retry_backoff_multiplier(consecutive_zero_fill_count)
+            ).isoformat(),
+        )
+
+    @staticmethod
+    def _derive_retry_suffix(
+        attributions: Iterable[TakeProfitOrderAttribution],
+        credited_order_amounts: Mapping[str, float],
+    ) -> tuple[TakeProfitOrderAttribution | None, int]:
+        outcomes = sorted(
+            (
+                attribution
+                for attribution in attributions
+                if attribution.order_id in credited_order_amounts
+            ),
+            key=lambda attribution: attribution.attribution_sequence,
+        )
+        consecutive_zero_fill_count = 0
+        latest_zero_fill: TakeProfitOrderAttribution | None = None
+        for attribution in outcomes:
+            credited_amount = credited_order_amounts[attribution.order_id]
+            if credited_amount > 0.0:
+                consecutive_zero_fill_count = 0
+                latest_zero_fill = None
+            elif attribution.attempt_id is not None:
+                if (
+                    latest_zero_fill is None
+                    or latest_zero_fill.stage != attribution.stage
+                ):
+                    consecutive_zero_fill_count = 1
+                else:
+                    consecutive_zero_fill_count += 1
+                latest_zero_fill = attribution
+        return latest_zero_fill, consecutive_zero_fill_count
+
+    @staticmethod
+    def _retry_backoff_multiplier(consecutive_zero_fill_count: int) -> int:
+        if consecutive_zero_fill_count <= 0:
+            raise ValueError("Take-profit zero-fill retry count must be positive")
+        return min(2 ** (consecutive_zero_fill_count - 1), 8)
+
+    @staticmethod
+    def _attempt_retry_delay_seconds(attempt: TakeProfitAttempt) -> float:
+        submitted_at = _parse_iso_datetime(attempt.submitted_at or attempt.created_at)
+        retry_delay = (
+            _parse_iso_datetime(attempt.recovery_deadline) - submitted_at
+        ).total_seconds()
+        return _required_positive_value(retry_delay, "attempt retry delay")
 
     @staticmethod
     def mark_submitting(
@@ -2465,17 +3228,27 @@ class TakeProfitStageManager:
         stake_amount = cls._safe_amount(stake_amount)
         if amount == 0.0 or stake_amount == 0.0:
             raise ValueError("Take-profit attempt amounts must be positive")
+        if amount > attempt.amount and not cls._amounts_close(amount, attempt.amount):
+            raise ValueError("Proposed take-profit attempt amount cannot increase")
+        if stake_amount > attempt.stake_amount and not cls._amounts_close(
+            stake_amount,
+            attempt.stake_amount,
+        ):
+            raise ValueError("Proposed take-profit attempt stake cannot increase")
+        updated_attempt = replace(
+            attempt,
+            amount=amount,
+            stake_amount=stake_amount,
+        )
+        cls._validate_attempt_bounds(state, updated_attempt)
         return replace(
             state,
-            active_attempt=replace(
-                attempt,
-                amount=amount,
-                stake_amount=stake_amount,
-            ),
+            active_attempt=updated_attempt,
         )
 
-    @staticmethod
+    @classmethod
     def mark_ambiguous(
+        cls,
         state: TakeProfitStageState,
         attempt_id: str,
     ) -> TakeProfitStageState:
@@ -2488,7 +3261,10 @@ class TakeProfitStageManager:
             raise ValueError(
                 "Only a submitting take-profit attempt can become ambiguous"
             )
-        return replace(state, active_attempt=replace(attempt, status="ambiguous"))
+        return replace(
+            state,
+            active_attempt=replace(attempt, status="ambiguous"),
+        )
 
     @staticmethod
     def discard_proposed_attempt(
@@ -2532,7 +3308,7 @@ class TakeProfitStageManager:
         )
 
     @classmethod
-    def revalidate_unknown_terminal_fill(
+    def revalidate_terminal_order(
         cls,
         trade: _Trade,
         state: TakeProfitStageState,
@@ -2542,9 +3318,62 @@ class TakeProfitStageManager:
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> TakeProfitStageState:
         """Reconcile one repaired canonical order and record the operator action."""
+        reconciled, credited_amount = cls._prepare_terminal_order_revalidation(
+            trade,
+            state,
+            order_id,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=True,
+        )
+        resolution = TakeProfitOperatorResolution(
+            action="revalidated_terminal_order",
+            order_id=_non_empty_string(order_id),
+            credited_amount=credited_amount,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            reconciled,
+            operator_resolutions=cls._append_operator_resolution(
+                reconciled,
+                resolution,
+            ),
+        )
+
+    @classmethod
+    def validate_terminal_order_revalidation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> None:
+        """Validate repaired terminal evidence without checking trade accounting."""
+        cls._prepare_terminal_order_revalidation(
+            trade,
+            state,
+            order_id,
+            resolved_at,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=False,
+        )
+
+    @classmethod
+    def _prepare_terminal_order_revalidation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None,
+        validate_trade_amount: bool,
+    ) -> tuple[TakeProfitStageState, float]:
         order_id = _non_empty_string(order_id)
         has_matching_block = (
-            state.blocked_reason in _REVALIDATABLE_TERMINAL_BLOCK_REASONS
+            state.blocked_reason in _RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS
             and state.blocked_order_id == order_id
         )
         if not has_matching_block:
@@ -2561,13 +3390,11 @@ class TakeProfitStageManager:
         if order.ft_order_side != trade.exit_side or order.ft_is_open:
             raise ValueError("Revalidated order is not a terminal strategy exit")
         cls._validate_resolution_timeline(order, resolved_at)
-        existing_attribution = next(
-            (
-                attribution
-                for attribution in state.order_attributions
-                if attribution.order_id == order_id
-            ),
-            None,
+        state = cls._prepare_terminal_attribution(
+            trade,
+            state,
+            order,
+            amount_quantizer,
         )
         zero_fill_proof = next(
             (
@@ -2585,7 +3412,11 @@ class TakeProfitStageManager:
         )
         status = (order.status or "").lower()
         filled = _non_negative_float(order.filled) if order.filled is not None else None
-        if status in _OPERATOR_ZERO_FILL_STATUSES and filled is not None and filled > 0:
+        if (
+            status in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES
+            and filled is not None
+            and filled > 0
+        ):
             raise ValueError(
                 "Canceled positive fill requires confirm_terminal_canceled_fill"
             )
@@ -2594,86 +3425,8 @@ class TakeProfitStageManager:
             matching_zero_fill_proof,
         )
 
-        configured_stages = {
-            *(stage for stage, _ in state.stage_targets),
-            state.plan_signature.final_stage.stage,
-        }
-        parsed_tag = cls.parse_order_tag(order.ft_order_tag)
-        order_amount = cls._safe_amount(order.safe_amount)
-        operator_attribution: TakeProfitOrderAttribution | None = None
-        causal_attempt: TakeProfitAttempt | None = None
-        if existing_attribution is not None:
-            if order.ft_order_tag != existing_attribution.tag:
-                raise ValueError(
-                    "Canonical order tag must be repaired before revalidation"
-                )
-            if (
-                order_amount > existing_attribution.maximum_amount
-                and not cls._amounts_close(
-                    order_amount,
-                    existing_attribution.maximum_amount,
-                )
-            ):
-                raise ValueError(
-                    "Canonical order amount exceeds the attributed maximum"
-                )
-            operator_attribution = replace(
-                existing_attribution,
-                order_amount=order_amount,
-            )
-        elif (
-            parsed_tag is not None
-            and parsed_tag[0] == trade.trade_direction
-            and parsed_tag[1] in configured_stages
-        ):
-            stage = parsed_tag[1]
-            active_attempt = state.active_attempt
-            if active_attempt is not None:
-                if (
-                    active_attempt.stage != stage
-                    or active_attempt.tag != order.ft_order_tag
-                    or not cls._is_recovered_attempt_candidate(
-                        order,
-                        active_attempt,
-                    )
-                ):
-                    raise ValueError(
-                        "Canonical order does not match the submitted attempt"
-                    )
-                causal_attempt = active_attempt
-            operator_attribution = TakeProfitOrderAttribution(
-                order_id=order_id,
-                tag=order.ft_order_tag,
-                side=order.ft_order_side,
-                stage=stage,
-                attempt_id=(
-                    causal_attempt.attempt_id if causal_attempt is not None else None
-                ),
-                order_date=order.order_date_utc.isoformat(),
-                maximum_amount=(
-                    causal_attempt.amount
-                    if causal_attempt is not None
-                    else order_amount
-                ),
-                order_amount=order_amount,
-                source="operator",
-            )
-        order_attributions = tuple(
-            attribution
-            for attribution in state.order_attributions
-            if attribution.order_id != order_id
-        )
-        if operator_attribution is not None:
-            order_attributions = tuple(
-                sorted(
-                    (*order_attributions, operator_attribution),
-                    key=lambda attribution: attribution.order_id,
-                )
-            )
-        active_attempt = None if causal_attempt is not None else state.active_attempt
         candidate = replace(
             state,
-            order_attributions=order_attributions,
             confirmed_zero_fill_orders=tuple(
                 proof
                 for proof in state.confirmed_zero_fill_orders
@@ -2694,16 +3447,21 @@ class TakeProfitStageManager:
                 for proof in state.confirmed_canceled_fill_orders
                 if proof.order_id != order_id
             ),
-            active_attempt=active_attempt,
             blocked_reason=None,
             blocked_order_id=None,
         )
-        reconciled = cls.reconcile(
+        reconciled = cls._reconcile(
             trade,
             candidate,
             amount_quantizer=amount_quantizer,
+            validate_trade_amount=validate_trade_amount,
+            current_time=resolved_at,
+            allow_canonical_adjustment_retirement=validate_trade_amount,
         )
-        if reconciled.blocked_reason is not None:
+        if reconciled.blocked_reason not in {
+            None,
+            "zero_fill_retry_limit_reached",
+        }:
             raise ValueError(
                 "Canonical order repair does not produce a valid take-profit state: "
                 f"{reconciled.blocked_reason}"
@@ -2726,19 +3484,81 @@ class TakeProfitStageManager:
         ):
             raise ValueError("Revalidated exit credit does not match the order")
 
-        resolution = TakeProfitOperatorResolution(
-            action="revalidated_terminal_fill",
-            order_id=order_id,
-            credited_amount=credited_amount,
-            resolved_at=resolved_at.isoformat(),
+        return reconciled, credited_amount
+
+    @classmethod
+    def revalidate_state(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Clear an eligible latch only after the complete state validates exactly."""
+        if state.blocked_reason not in _REVALIDATABLE_STATE_BLOCK_REASONS:
+            raise ValueError("Take-profit block is not eligible for state revalidation")
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        if state.blocked_reason == "unknown_attempt_order":
+            matching_orders = [
+                order
+                for order in trade.orders
+                if order.order_id == state.blocked_order_id
+            ]
+            if len(matching_orders) != 1:
+                raise ValueError("Expected exactly one matching canonical order")
+            order = matching_orders[0]
+            if not order.ft_is_open:
+                raise ValueError("Unknown attempt order is no longer open")
+            if order.ft_order_side != trade.exit_side:
+                raise ValueError("Unknown attempt order is not a strategy exit")
+            try:
+                repaired_tag = _non_empty_string(order.ft_order_tag)
+            except ValueError as error:
+                raise ValueError(
+                    "Unknown attempt order requires a non-empty exit tag"
+                ) from error
+            if cls.has_order_tag_prefix(repaired_tag):
+                raise ValueError("Unknown attempt order still has a take-profit tag")
+        candidate = replace(
+            state,
+            blocked_reason=None,
+            blocked_order_id=None,
         )
-        return replace(
+        reconciled = cls._reconcile(
+            trade,
+            candidate,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=True,
+            current_time=resolved_at,
+        )
+        if reconciled.blocked_reason not in {
+            None,
+            "zero_fill_retry_limit_reached",
+        }:
+            raise ValueError(
+                "Repaired take-profit state remains invalid: "
+                f"{reconciled.blocked_reason}"
+            )
+        resolution = TakeProfitOperatorResolution(
+            action="revalidated_state",
+            resolved_at=resolved_at.isoformat(),
+            cleared_block_reason=state.blocked_reason,
+            cleared_block_order_id=state.blocked_order_id,
+        )
+        resolved = replace(
             reconciled,
             operator_resolutions=cls._append_operator_resolution(
                 reconciled,
                 resolution,
             ),
         )
+        if TakeProfitStageState.from_mapping(resolved.to_mapping()) != resolved:
+            raise ValueError(
+                "Revalidated take-profit state failed round-trip validation"
+            )
+        return resolved
 
     @classmethod
     def confirm_terminal_zero_fill(
@@ -2789,7 +3609,7 @@ class TakeProfitStageManager:
         *,
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> None:
-        """Validate a zero-fill proof without requiring wallet restoration."""
+        """Validate zero-fill evidence without enforcing the trade-amount postcondition."""
         cls._prepare_terminal_zero_fill_confirmation(
             trade,
             state,
@@ -2814,10 +3634,10 @@ class TakeProfitStageManager:
     ) -> TakeProfitStageState:
         order_id = _non_empty_string(order_id)
         terminal_status = _non_empty_string(terminal_status).lower()
-        if terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+        if terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             raise ValueError("Terminal zero-fill status is not operator-recoverable")
         if (
-            state.blocked_reason not in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
+            state.blocked_reason not in _RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS
             or state.blocked_order_id != order_id
         ):
             raise ValueError("No matching unknown terminal fill to confirm")
@@ -2828,6 +3648,12 @@ class TakeProfitStageManager:
         ]
         if len(matching_orders) != 1:
             raise ValueError("Expected exactly one matching canonical order")
+        state = cls._prepare_terminal_attribution(
+            trade,
+            state,
+            matching_orders[0],
+            amount_quantizer,
+        )
         proof = cls._build_zero_fill_proof(
             trade,
             matching_orders[0],
@@ -2872,8 +3698,12 @@ class TakeProfitStageManager:
             candidate,
             amount_quantizer=amount_quantizer,
             validate_trade_amount=validate_trade_amount,
+            current_time=resolved_at,
         )
-        if reconciled.blocked_reason is not None:
+        if reconciled.blocked_reason not in {
+            None,
+            "zero_fill_retry_limit_reached",
+        }:
             raise ValueError(
                 "Terminal zero-fill proof does not produce a valid state: "
                 f"{reconciled.blocked_reason}"
@@ -2929,7 +3759,7 @@ class TakeProfitStageManager:
         *,
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> None:
-        """Validate a canceled-fill proof without requiring wallet restoration."""
+        """Validate canceled-fill evidence without enforcing the amount postcondition."""
         cls._prepare_terminal_canceled_fill_confirmation(
             trade,
             state,
@@ -2954,10 +3784,10 @@ class TakeProfitStageManager:
     ) -> tuple[TakeProfitStageState, TakeProfitCanceledFillProof]:
         order_id = _non_empty_string(order_id)
         terminal_status = _non_empty_string(terminal_status).lower()
-        if terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+        if terminal_status not in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             raise ValueError("Terminal canceled-fill status is not recoverable")
         if (
-            state.blocked_reason not in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
+            state.blocked_reason not in _RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS
             or state.blocked_order_id != order_id
         ):
             raise ValueError("No matching canceled terminal fill to confirm")
@@ -2968,6 +3798,12 @@ class TakeProfitStageManager:
         ]
         if len(matching_orders) != 1:
             raise ValueError("Expected exactly one matching canonical order")
+        state = cls._prepare_terminal_attribution(
+            trade,
+            state,
+            matching_orders[0],
+            amount_quantizer,
+        )
         proof = cls._build_canceled_fill_proof(
             trade,
             matching_orders[0],
@@ -3012,6 +3848,8 @@ class TakeProfitStageManager:
             candidate,
             amount_quantizer=amount_quantizer,
             validate_trade_amount=validate_trade_amount,
+            current_time=resolved_at,
+            allow_canonical_adjustment_retirement=validate_trade_amount,
         )
         if reconciled.blocked_reason is not None:
             raise ValueError(
@@ -3019,120 +3857,6 @@ class TakeProfitStageManager:
                 f"{reconciled.blocked_reason}"
             )
         return reconciled, proof
-
-    @classmethod
-    def validate_partial_wallet_mutation_restoration(
-        cls,
-        trade: _Trade,
-        state: TakeProfitStageState,
-        order_id: str,
-        *,
-        amount_quantizer: Callable[[float], float] | None = None,
-    ) -> None:
-        """Validate deterministic terminal evidence without mutating accounting."""
-        cls._prepare_partial_wallet_mutation_restoration(
-            trade,
-            state,
-            order_id,
-            amount_quantizer=amount_quantizer,
-            validate_trade_amount=False,
-        )
-
-    @classmethod
-    def restore_partial_wallet_mutation(
-        cls,
-        trade: _Trade,
-        state: TakeProfitStageState,
-        order_id: str,
-        resolved_at: datetime.datetime,
-        *,
-        amount_quantizer: Callable[[float], float] | None = None,
-    ) -> TakeProfitStageState:
-        """Accept native order accounting after an audited wallet restoration."""
-        if resolved_at.tzinfo is None:
-            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
-        reconciled, mutation, terminal_status = (
-            cls._prepare_partial_wallet_mutation_restoration(
-                trade,
-                state,
-                order_id,
-                amount_quantizer=amount_quantizer,
-                validate_trade_amount=True,
-            )
-        )
-        order = next(order for order in trade.orders if order.order_id == order_id)
-        cls._validate_resolution_timeline(order, resolved_at)
-        resolution = TakeProfitOperatorResolution(
-            action="restored_partial_wallet_mutation",
-            attempt_id=mutation.attempt_id,
-            order_id=mutation.order_id,
-            terminal_status=terminal_status,
-            resolved_at=resolved_at.isoformat(),
-        )
-        return replace(
-            reconciled,
-            operator_resolutions=cls._append_operator_resolution(
-                reconciled,
-                resolution,
-            ),
-        )
-
-    @classmethod
-    def _prepare_partial_wallet_mutation_restoration(
-        cls,
-        trade: _Trade,
-        state: TakeProfitStageState,
-        order_id: str,
-        *,
-        amount_quantizer: Callable[[float], float] | None,
-        validate_trade_amount: bool,
-    ) -> tuple[TakeProfitStageState, TakeProfitPartialWalletMutation, str]:
-        order_id = _non_empty_string(order_id)
-        mutation = state.partial_wallet_mutation
-        if (
-            state.blocked_reason != "partial_wallet_mutation"
-            or mutation is None
-            or mutation.order_id != order_id
-        ):
-            raise ValueError("No matching bound partial-wallet mutation to restore")
-        matching_orders = [
-            order for order in trade.orders if order.order_id == order_id
-        ]
-        if len(matching_orders) != 1:
-            raise ValueError("Expected exactly one matching canonical order")
-        order = matching_orders[0]
-        if order.ft_order_side != trade.exit_side or order.ft_is_open:
-            raise ValueError("Wallet restoration order is not a terminal strategy exit")
-        terminal_status = _non_empty_string(order.status).lower()
-        if terminal_status not in _NATIVE_WALLET_RESTORATION_STATUSES:
-            raise ValueError("Wallet restoration order has no native terminal outcome")
-        candidate = replace(
-            state,
-            blocked_reason=None,
-            blocked_order_id=None,
-        )
-        reconciled = cls._reconcile(
-            trade,
-            candidate,
-            amount_quantizer=amount_quantizer,
-            validate_trade_amount=validate_trade_amount,
-        )
-        if reconciled.blocked_reason is not None:
-            raise ValueError(
-                "Canonical order accounting does not restore the wallet mutation: "
-                f"{reconciled.blocked_reason}"
-            )
-        if validate_trade_amount:
-            if (
-                reconciled.partial_wallet_mutation is not None
-                or reconciled.active_attempt is not None
-            ):
-                raise ValueError("Partial-wallet mutation remains active after restore")
-        elif reconciled.partial_wallet_mutation != mutation:
-            raise ValueError(
-                "Partial-wallet mutation evidence changed during validation"
-            )
-        return reconciled, mutation, terminal_status
 
     @classmethod
     def get_recovery_instruction(
@@ -3143,30 +3867,30 @@ class TakeProfitStageManager:
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> TakeProfitRecoveryInstruction | None:
         """Return the single recovery action supported by canonical evidence."""
-        mutation = state.partial_wallet_mutation
-        if (
-            state.blocked_reason == "partial_wallet_mutation"
-            and mutation is not None
-            and mutation.order_id is not None
-        ):
+        if not trade.is_open:
+            return None
+        if state.partial_wallet_mutation is not None:
+            return None
+        resolved_at = datetime.datetime.now(datetime.timezone.utc)
+        if state.blocked_reason in _REVALIDATABLE_STATE_BLOCK_REASONS:
             try:
-                cls.validate_partial_wallet_mutation_restoration(
+                reconciled = cls.revalidate_state(
                     trade,
                     state,
-                    mutation.order_id,
+                    resolved_at,
                     amount_quantizer=amount_quantizer,
                 )
             except ValueError:
-                return None
-            order = next(
-                order for order in trade.orders if order.order_id == mutation.order_id
-            )
-            return TakeProfitRecoveryInstruction(
-                action="restore_partial_wallet_mutation",
-                attempt_id=mutation.attempt_id,
-                order_id=mutation.order_id,
-                terminal_status=_non_empty_string(order.status).lower(),
-            )
+                pass
+            else:
+                expected_amount = cls.get_expected_trade_amount(
+                    reconciled,
+                    amount_quantizer=amount_quantizer,
+                )
+                return TakeProfitRecoveryInstruction(
+                    action="revalidate_state",
+                    expected_trade_amount=expected_amount,
+                )
 
         order_id = state.blocked_order_id
         if order_id is None:
@@ -3181,19 +3905,16 @@ class TakeProfitStageManager:
             return None
         terminal_status = (order.status or "").lower()
         if (
-            state.blocked_reason in _CONFIRMABLE_TERMINAL_BLOCK_REASONS
-            and terminal_status in _OPERATOR_ZERO_FILL_STATUSES
+            state.blocked_reason in _RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS
+            and terminal_status in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES
             and order.filled is not None
         ):
             try:
                 filled = _non_negative_float(order.filled)
-                resolved_at = datetime.datetime.now(datetime.timezone.utc)
-                has_bound_mutation = (
-                    mutation is not None and mutation.order_id == order_id
-                )
                 if filled == 0.0:
-                    if has_bound_mutation:
-                        cls.validate_terminal_zero_fill_confirmation(
+                    action: TakeProfitRecoveryAction = "confirm_terminal_zero_fill"
+                    try:
+                        reconciled = cls.confirm_terminal_zero_fill(
                             trade,
                             state,
                             order_id,
@@ -3201,19 +3922,23 @@ class TakeProfitStageManager:
                             resolved_at,
                             amount_quantizer=amount_quantizer,
                         )
+                    except ValueError:
+                        reconciled = cls._prepare_terminal_zero_fill_confirmation(
+                            trade,
+                            state,
+                            order_id,
+                            terminal_status,
+                            resolved_at,
+                            amount_quantizer=amount_quantizer,
+                            validate_trade_amount=False,
+                        )
+                        accounting_is_valid = False
                     else:
-                        cls.confirm_terminal_zero_fill(
-                            trade,
-                            state,
-                            order_id,
-                            terminal_status,
-                            resolved_at,
-                            amount_quantizer=amount_quantizer,
-                        )
-                    action: TakeProfitRecoveryAction = "confirm_terminal_zero"
+                        accounting_is_valid = True
                 else:
-                    if has_bound_mutation:
-                        cls.validate_terminal_canceled_fill_confirmation(
+                    action = "confirm_terminal_canceled_fill"
+                    try:
+                        reconciled = cls.confirm_terminal_canceled_fill(
                             trade,
                             state,
                             order_id,
@@ -3221,41 +3946,125 @@ class TakeProfitStageManager:
                             resolved_at,
                             amount_quantizer=amount_quantizer,
                         )
+                    except ValueError:
+                        reconciled, _ = (
+                            cls._prepare_terminal_canceled_fill_confirmation(
+                                trade,
+                                state,
+                                order_id,
+                                terminal_status,
+                                resolved_at,
+                                amount_quantizer=amount_quantizer,
+                                validate_trade_amount=False,
+                            )
+                        )
+                        accounting_is_valid = False
                     else:
-                        cls.confirm_terminal_canceled_fill(
-                            trade,
-                            state,
-                            order_id,
-                            terminal_status,
-                            resolved_at,
-                            amount_quantizer=amount_quantizer,
-                        )
-                    action = "confirm_terminal_canceled"
+                        accounting_is_valid = True
+            except ValueError:
+                return None
+            try:
+                trade_accounting_action, expected_trade_amount = (
+                    cls._trade_accounting_recovery(
+                        trade,
+                        reconciled,
+                        order,
+                        accounting_is_valid=accounting_is_valid,
+                        amount_quantizer=amount_quantizer,
+                    )
+                )
             except ValueError:
                 return None
             return TakeProfitRecoveryInstruction(
                 action=action,
                 order_id=order_id,
                 terminal_status=terminal_status,
+                trade_accounting_action=trade_accounting_action,
+                expected_trade_amount=expected_trade_amount,
             )
-        if terminal_status in _OPERATOR_ZERO_FILL_STATUSES:
+        if terminal_status in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             return None
-        if state.blocked_reason in _REVALIDATABLE_TERMINAL_BLOCK_REASONS:
+        if state.blocked_reason in _RECOVERABLE_TERMINAL_ORDER_BLOCK_REASONS:
             try:
-                cls.revalidate_unknown_terminal_fill(
-                    trade,
-                    state,
-                    order_id,
-                    datetime.datetime.now(datetime.timezone.utc),
-                    amount_quantizer=amount_quantizer,
+                try:
+                    reconciled = cls.revalidate_terminal_order(
+                        trade,
+                        state,
+                        order_id,
+                        resolved_at,
+                        amount_quantizer=amount_quantizer,
+                    )
+                except ValueError:
+                    reconciled, _ = cls._prepare_terminal_order_revalidation(
+                        trade,
+                        state,
+                        order_id,
+                        resolved_at,
+                        amount_quantizer=amount_quantizer,
+                        validate_trade_amount=False,
+                    )
+                    accounting_is_valid = False
+                else:
+                    accounting_is_valid = True
+            except ValueError:
+                return None
+            try:
+                trade_accounting_action, expected_trade_amount = (
+                    cls._trade_accounting_recovery(
+                        trade,
+                        reconciled,
+                        order,
+                        accounting_is_valid=accounting_is_valid,
+                        amount_quantizer=amount_quantizer,
+                    )
                 )
             except ValueError:
                 return None
             return TakeProfitRecoveryInstruction(
-                action="revalidate_terminal",
+                action="revalidate_terminal_order",
                 order_id=order_id,
+                trade_accounting_action=trade_accounting_action,
+                expected_trade_amount=expected_trade_amount,
             )
         return None
+
+    @classmethod
+    def _trade_accounting_recovery(
+        cls,
+        trade: _Trade,
+        reconciled: TakeProfitStageState,
+        order: _Order,
+        *,
+        accounting_is_valid: bool,
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> tuple[TakeProfitTradeAccountingAction, float]:
+        expected_amount = cls.get_expected_trade_amount(
+            reconciled,
+            amount_quantizer=amount_quantizer,
+        )
+        expected_trade_is_open = not cls._amounts_close(expected_amount, 0.0)
+        if not expected_trade_is_open:
+            expected_amount = 0.0
+        filled = _non_negative_float(order.filled) if order.filled is not None else 0.0
+        order_funding_fee = _finite_float(order.funding_fee or 0.0)
+        _finite_float(trade.funding_fee_running or 0.0)
+        has_order_funding_fee = not cls._amounts_close(order_funding_fee, 0.0)
+        if filled == 0.0 and has_order_funding_fee:
+            raise ValueError("Zero-fill recovery order contains funding fees")
+        if filled > 0.0:
+            _required_positive_value(
+                order.safe_price,
+                "terminal recovery order price",
+            )
+        if not trade.is_open:
+            raise ValueError("Closed trades are inspect-only")
+        if not expected_trade_is_open:
+            if filled == 0.0:
+                raise ValueError("Zero-fill recovery cannot close trade exposure")
+            return "native_freqtrade_lifecycle", expected_amount
+        if filled == 0.0 and accounting_is_valid:
+            return "none", expected_amount
+        return "recalculate_from_orders", expected_amount
 
     @staticmethod
     def _append_operator_resolution(
@@ -3328,15 +4137,27 @@ class TakeProfitStageManager:
             cls._validate_terminal_zero_fill(order, allowed_statuses)
             return 0.0
 
-        if status in _OPERATOR_ZERO_FILL_STATUSES:
+        _required_positive_value(
+            order.safe_price,
+            "terminal order execution price",
+        )
+        _finite_float(order.funding_fee or 0.0)
+        filled_at = order.order_filled_utc
+        order_date = order.order_date_utc
+        if filled_at is None:
+            raise ValueError("Terminal positive fill is not explicitly observed")
+        if order_date.tzinfo is None or filled_at.tzinfo is None:
+            raise ValueError("Terminal fill timeline must be timezone-aware")
+        if filled_at < order_date:
+            raise ValueError("Terminal fill precedes order creation")
+
+        if status in _OPERATOR_CONFIRMABLE_CANCELED_STATUSES:
             if canceled_fill_proof is None or not cls._canceled_fill_proof_fields_match(
                 order,
                 canceled_fill_proof,
             ):
                 raise ValueError("Canceled positive fill requires exact operator proof")
             return canceled_fill_proof.credited_amount
-        if status == "rejected" or order.order_filled_utc is None:
-            raise ValueError("Terminal positive fill is not explicitly observed")
         if filled < amount and remaining is None:
             raise ValueError("Terminal partial fill has no reported remainder")
         if fee_base >= filled or cls._amounts_close(fee_base, filled):
@@ -3400,9 +4221,9 @@ class TakeProfitStageManager:
         cls._validate_resolution_timeline(order, confirmed_at)
         if (order.status or "").lower() != terminal_status:
             raise ValueError("Canonical order status does not match terminal-status")
-        amount, remaining, fee_base = cls._validate_terminal_zero_fill(
+        amount, remaining, fee_base, funding_fee = cls._validate_terminal_zero_fill(
             order,
-            _OPERATOR_ZERO_FILL_STATUSES,
+            _OPERATOR_CONFIRMABLE_CANCELED_STATUSES,
         )
         return TakeProfitZeroFillProof(
             order_id=order.order_id,
@@ -3413,6 +4234,7 @@ class TakeProfitStageManager:
             amount=amount,
             remaining=remaining,
             fee_base=fee_base,
+            funding_fee=funding_fee,
             confirmed_at=confirmed_at.isoformat(),
         )
 
@@ -3434,7 +4256,7 @@ class TakeProfitStageManager:
         proof: TakeProfitZeroFillProof,
     ) -> bool:
         try:
-            amount, remaining, fee_base = cls._validate_terminal_zero_fill(
+            amount, remaining, fee_base, funding_fee = cls._validate_terminal_zero_fill(
                 order,
                 {proof.terminal_status},
             )
@@ -3449,6 +4271,7 @@ class TakeProfitStageManager:
             and amount == proof.amount
             and remaining == proof.remaining
             and fee_base == proof.fee_base
+            and funding_fee == proof.funding_fee
         )
 
     @classmethod
@@ -3464,11 +4287,17 @@ class TakeProfitStageManager:
         cls._validate_resolution_timeline(order, confirmed_at)
         if (order.status or "").lower() != terminal_status:
             raise ValueError("Canonical order status does not match terminal-status")
-        amount, filled, remaining, fee_base, filled_at = (
-            cls._validate_terminal_canceled_fill(
-                order,
-                _OPERATOR_ZERO_FILL_STATUSES,
-            )
+        (
+            amount,
+            filled,
+            remaining,
+            fee_base,
+            execution_price,
+            funding_fee,
+            filled_at,
+        ) = cls._validate_terminal_canceled_fill(
+            order,
+            _OPERATOR_CONFIRMABLE_CANCELED_STATUSES,
         )
         return TakeProfitCanceledFillProof(
             order_id=order.order_id,
@@ -3480,6 +4309,8 @@ class TakeProfitStageManager:
             filled=filled,
             remaining=remaining,
             fee_base=fee_base,
+            execution_price=execution_price,
+            funding_fee=funding_fee,
             filled_at=filled_at.isoformat(),
             confirmed_at=confirmed_at.isoformat(),
         )
@@ -3503,11 +4334,17 @@ class TakeProfitStageManager:
         proof: TakeProfitCanceledFillProof,
     ) -> bool:
         try:
-            amount, filled, remaining, fee_base, filled_at = (
-                cls._validate_terminal_canceled_fill(
-                    order,
-                    {proof.terminal_status},
-                )
+            (
+                amount,
+                filled,
+                remaining,
+                fee_base,
+                execution_price,
+                funding_fee,
+                filled_at,
+            ) = cls._validate_terminal_canceled_fill(
+                order,
+                {proof.terminal_status},
             )
         except ValueError:
             return False
@@ -3521,6 +4358,8 @@ class TakeProfitStageManager:
             and filled == proof.filled
             and remaining == proof.remaining
             and fee_base == proof.fee_base
+            and execution_price == proof.execution_price
+            and funding_fee == proof.funding_fee
             and filled_at == _parse_iso_datetime(proof.filled_at)
         )
 
@@ -3551,7 +4390,7 @@ class TakeProfitStageManager:
         cls,
         order: _Order,
         allowed_statuses: set[str] | frozenset[str],
-    ) -> tuple[float, float, float, float, datetime.datetime]:
+    ) -> tuple[float, float, float, float, float, float, datetime.datetime]:
         if order.ft_is_open:
             raise ValueError("Terminal canceled-fill order is open")
         status = (order.status or "").lower()
@@ -3578,17 +4417,30 @@ class TakeProfitStageManager:
         )
         if fee_base >= filled or cls._amounts_close(fee_base, filled):
             raise ValueError("Terminal canceled-fill base fee consumes its fill")
+        execution_price = _required_positive_value(
+            order.safe_price,
+            "terminal canceled-fill execution price",
+        )
+        funding_fee = _finite_float(order.funding_fee or 0.0)
         filled_at = order.order_filled_utc
         if filled_at is None or filled_at.tzinfo is None:
             raise ValueError("Terminal canceled-fill order has no fill timestamp")
-        return amount, filled, remaining, fee_base, filled_at
+        return (
+            amount,
+            filled,
+            remaining,
+            fee_base,
+            execution_price,
+            funding_fee,
+            filled_at,
+        )
 
     @classmethod
     def _validate_terminal_zero_fill(
         cls,
         order: _Order,
         allowed_statuses: set[str] | frozenset[str],
-    ) -> tuple[float, float, float]:
+    ) -> tuple[float, float, float, float]:
         if order.ft_is_open:
             raise ValueError("Terminal zero-fill order is open")
         status = (order.status or "").lower()
@@ -3609,9 +4461,12 @@ class TakeProfitStageManager:
         )
         if fee_base != 0.0:
             raise ValueError("Terminal zero-fill order has a base fee")
+        funding_fee = _finite_float(order.funding_fee or 0.0)
+        if funding_fee != 0.0:
+            raise ValueError("Terminal zero-fill order has a funding fee")
         if order.order_filled_utc is not None:
             raise ValueError("Terminal zero-fill order has a fill timestamp")
-        return amount, remaining, fee_base
+        return amount, remaining, fee_base, funding_fee
 
     @staticmethod
     def _canonical_amount(
@@ -3785,7 +4640,7 @@ class TakeProfitStageManager:
     ) -> bool:
         return (
             attempt is not None
-            and attempt.status in {"submitting", "open", "ambiguous"}
+            and attempt.status in {"submitting", "ambiguous"}
             and (
                 expected_amount > attempt.amount
                 or TakeProfitStageManager._amounts_close(
@@ -3794,7 +4649,179 @@ class TakeProfitStageManager:
                 )
             )
             and observed_amount < attempt.amount
-            and observed_amount >= attempt.amount * 0.98
+            and observed_amount > attempt.amount * 0.98
+        )
+
+    @classmethod
+    def _reconcile_attribution_order_amount(
+        cls,
+        attribution: TakeProfitOrderAttribution,
+        order_amount: float,
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> TakeProfitOrderAttribution | None:
+        if cls._amounts_close(order_amount, attribution.order_amount):
+            return attribution
+        if attribution.source not in {"attempt", "recovered_untagged"}:
+            return None
+        try:
+            canonical_attributed_amount = cls._canonical_amount(
+                attribution.order_amount,
+                amount_quantizer,
+            )
+        except ValueError:
+            return None
+        if (
+            canonical_attributed_amount > 0.0
+            and canonical_attributed_amount < attribution.order_amount
+            and order_amount < attribution.order_amount
+            and cls._amounts_close(order_amount, canonical_attributed_amount)
+        ):
+            return replace(attribution, order_amount=order_amount)
+        return None
+
+    @classmethod
+    def _prepare_terminal_attribution(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order: _Order,
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> TakeProfitStageState:
+        if state.blocked_order_id != order.order_id:
+            raise ValueError("Canonical order does not match the blocked order")
+        matching_attributions = [
+            attribution
+            for attribution in state.order_attributions
+            if attribution.order_id == order.order_id
+        ]
+        if len(matching_attributions) > 1:
+            raise ValueError("Expected exactly one matching order attribution")
+        order_amount = cls._safe_amount(order.safe_amount)
+        if order_amount <= 0.0:
+            raise ValueError("Canonical order has no positive amount")
+        order_date = order.order_date_utc
+        if order_date.tzinfo is None:
+            raise ValueError(
+                "Canonical order creation timestamp must be timezone-aware"
+            )
+
+        if matching_attributions:
+            attribution = matching_attributions[0]
+            if order.ft_order_side != attribution.side:
+                raise ValueError(
+                    "Canonical order side must be repaired before revalidation"
+                )
+            if order.ft_order_tag != attribution.tag:
+                raise ValueError(
+                    "Canonical order tag must be repaired before revalidation"
+                )
+            if order_amount > attribution.maximum_amount and not cls._amounts_close(
+                order_amount,
+                attribution.maximum_amount,
+            ):
+                raise ValueError(
+                    "Canonical order amount exceeds the attributed maximum"
+                )
+            if order_date != _parse_iso_datetime(attribution.order_date):
+                if (
+                    attribution.attempt_submitted_at is None
+                    or attribution.retry_delay_seconds is None
+                ):
+                    raise ValueError(
+                        "Attributed order date has no causal submission window"
+                    )
+                submitted_at = _parse_iso_datetime(attribution.attempt_submitted_at)
+                if not (
+                    submitted_at
+                    <= order_date
+                    <= submitted_at
+                    + datetime.timedelta(seconds=attribution.retry_delay_seconds)
+                ):
+                    raise ValueError("Canonical order is outside its submission window")
+            repaired_attribution = replace(
+                attribution,
+                order_date=order_date.isoformat(),
+                order_amount=order_amount,
+            )
+            return replace(
+                state,
+                order_attributions=tuple(
+                    repaired_attribution
+                    if existing.order_id == order.order_id
+                    else existing
+                    for existing in state.order_attributions
+                ),
+            )
+
+        parsed_tag = cls.parse_order_tag(order.ft_order_tag)
+        configured_stages = {
+            *(stage for stage, _ in state.stage_targets),
+            state.plan_signature.final_stage.stage,
+        }
+        if (
+            parsed_tag is None
+            or parsed_tag[0] != trade.trade_direction
+            or parsed_tag[1] not in configured_stages
+        ):
+            return state
+        if order.ft_order_side != trade.exit_side:
+            raise ValueError("Canonical order is not a strategy exit")
+        stage = parsed_tag[1]
+        causal_attempt = state.active_attempt
+        if causal_attempt is not None and (
+            causal_attempt.stage != stage
+            or causal_attempt.tag != order.ft_order_tag
+            or not cls._is_recovered_attempt_candidate(
+                order,
+                causal_attempt,
+                amount_quantizer,
+            )
+        ):
+            raise ValueError("Canonical order does not match the submitted attempt")
+        operator_attribution = TakeProfitOrderAttribution(
+            order_id=order.order_id,
+            attribution_sequence=(
+                max(
+                    (
+                        attribution.attribution_sequence
+                        for attribution in state.order_attributions
+                    ),
+                    default=-1,
+                )
+                + 1
+            ),
+            tag=order.ft_order_tag,
+            side=order.ft_order_side,
+            stage=stage,
+            attempt_id=(
+                causal_attempt.attempt_id if causal_attempt is not None else None
+            ),
+            order_date=order_date.isoformat(),
+            maximum_amount=(
+                causal_attempt.amount if causal_attempt is not None else order_amount
+            ),
+            order_amount=order_amount,
+            source="operator",
+            attempt_submitted_at=(
+                causal_attempt.submitted_at or causal_attempt.created_at
+                if causal_attempt is not None
+                else None
+            ),
+            retry_delay_seconds=(
+                cls._attempt_retry_delay_seconds(causal_attempt)
+                if causal_attempt is not None
+                else None
+            ),
+        )
+        return replace(
+            state,
+            order_attributions=tuple(
+                sorted(
+                    (*state.order_attributions, operator_attribution),
+                    key=lambda attribution: attribution.order_id,
+                )
+            ),
+            active_attempt=None if causal_attempt is not None else state.active_attempt,
         )
 
     @classmethod
@@ -3802,10 +4829,24 @@ class TakeProfitStageManager:
         cls,
         order: _Order,
         attempt: TakeProfitAttempt,
+        amount_quantizer: Callable[[float], float] | None,
     ) -> bool:
         order_amount = cls._safe_amount(order.safe_amount)
-        amount_matches = cls._amounts_close(order_amount, attempt.amount) or (
-            attempt.amount * 0.98 <= order_amount < attempt.amount
+        canonical_attempt_amount = cls._canonical_amount(
+            attempt.amount,
+            amount_quantizer,
+        )
+        amount_matches = (
+            cls._amounts_close(order_amount, attempt.amount)
+            or attempt.amount * 0.98 < order_amount < attempt.amount
+            or (
+                canonical_attempt_amount > 0.0
+                and order_amount < attempt.amount
+                and cls._amounts_close(
+                    order_amount,
+                    canonical_attempt_amount,
+                )
+            )
         )
         if (
             order.order_id in attempt.known_order_ids
@@ -3861,6 +4902,37 @@ class TakeProfitStageManager:
             abs_tol=cls._AMOUNT_ABS_TOL,
         )
 
+    @classmethod
+    def _raw_and_canonical_amounts_match(
+        cls,
+        left: float,
+        right: float,
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> bool:
+        return cls._amounts_close(left, right) and cls._amounts_close(
+            cls._canonical_amount(left, amount_quantizer),
+            cls._canonical_amount(right, amount_quantizer),
+        )
+
+
+def _require_exact_mapping_keys(
+    value: Mapping[str, object],
+    mapping_type: type[object],
+    label: str,
+) -> None:
+    expected_keys = {field.name for field in fields(mapping_type)}
+    actual_keys = set(value)
+    if actual_keys == expected_keys:
+        return
+    missing = sorted(expected_keys - actual_keys)
+    unexpected = sorted(actual_keys - expected_keys)
+    details = []
+    if missing:
+        details.append(f"missing {missing!r}")
+    if unexpected:
+        details.append(f"unexpected {unexpected!r}")
+    raise ValueError(f"Invalid {label} keys: {', '.join(details)}")
+
 
 def _required_string(value: Mapping[str, object], key: str) -> str:
     return _non_empty_string(value.get(key))
@@ -3876,6 +4948,10 @@ def _required_non_negative_float(value: Mapping[str, object], key: str) -> float
 
 def _required_positive_float(value: Mapping[str, object], key: str) -> float:
     return _required_positive_value(value.get(key), key)
+
+
+def _required_finite_float(value: Mapping[str, object], key: str) -> float:
+    return _finite_float(value.get(key))
 
 
 def _required_positive_value(value: object, name: str) -> float:
@@ -3898,14 +4974,26 @@ def _non_negative_int(value: object) -> int:
 
 
 def _non_negative_float(value: object) -> float:
-    if isinstance(value, bool):
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
         raise ValueError(f"Invalid non-negative float value {value!r}")
     try:
         parsed = float(value)
-    except (TypeError, ValueError) as error:
+    except (TypeError, ValueError, OverflowError) as error:
         raise ValueError(f"Invalid non-negative float value {value!r}") from error
     if not math.isfinite(parsed) or parsed < 0.0:
         raise ValueError(f"Invalid non-negative float value {value!r}")
+    return parsed
+
+
+def _finite_float(value: object) -> float:
+    if isinstance(value, bool) or not isinstance(value, (int, float)):
+        raise ValueError("Expected a finite number")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError, OverflowError) as error:
+        raise ValueError("Expected a finite number") from error
+    if not math.isfinite(parsed):
+        raise ValueError("Expected a finite number")
     return parsed
 
 
@@ -3931,6 +5019,9 @@ def _parse_amount_records(
     for record in value:
         if not isinstance(record, Mapping):
             raise ValueError(f"Invalid take-profit {identifier_key} amount record")
+        expected_keys = {identifier_key, "amount"}
+        if set(record) != expected_keys:
+            raise ValueError(f"Invalid take-profit {identifier_key} amount record keys")
         records.append(
             (
                 identifier_parser(record.get(identifier_key)),

--- a/quickadapter/user_data/strategies/TakeProfitStageManager.py
+++ b/quickadapter/user_data/strategies/TakeProfitStageManager.py
@@ -3,10 +3,11 @@ import math
 from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, replace
 from decimal import Decimal
-from typing import Literal, Protocol, Self
+from typing import Literal, Protocol, Self, final
 
 
 TakeProfitAttemptStatus = Literal["proposed", "submitting", "ambiguous"]
+TakeProfitRecoveryPolicy = Literal["tagged_or_unique_untagged", "tagged_only"]
 TakeProfitOperatorAction = Literal[
     "confirmed_no_remote_order",
     "confirmed_terminal_zero_fill",
@@ -24,6 +25,7 @@ _BLOCKED_ORDER_ID_REASONS = frozenset(
         "unknown_attempt_order",
         "unknown_external_exit_fill",
         "unknown_terminal_fill",
+        "unattributed_exit_fill",
     }
 )
 
@@ -105,6 +107,7 @@ class TakeProfitAttempt:
     submitted_at: str | None
     recovery_deadline: str
     known_order_ids: tuple[str, ...]
+    recovery_policy: TakeProfitRecoveryPolicy
 
     def to_mapping(self) -> dict[str, object]:
         return {
@@ -119,6 +122,7 @@ class TakeProfitAttempt:
             "submitted_at": self.submitted_at,
             "recovery_deadline": self.recovery_deadline,
             "known_order_ids": list(self.known_order_ids),
+            "recovery_policy": self.recovery_policy,
         }
 
     @classmethod
@@ -136,6 +140,12 @@ class TakeProfitAttempt:
             raise ValueError("Invalid take-profit attempt known_order_ids")
         if len(known_order_ids) != len(set(known_order_ids)):
             raise ValueError("Duplicate take-profit attempt known order")
+        recovery_policy = value.get("recovery_policy")
+        if recovery_policy not in {
+            "tagged_or_unique_untagged",
+            "tagged_only",
+        }:
+            raise ValueError("Invalid take-profit recovery policy")
 
         attempt_id = _required_string(value, "attempt_id")
         stage = _required_non_negative_int(value, "stage")
@@ -173,6 +183,91 @@ class TakeProfitAttempt:
             submitted_at=submitted_at,
             recovery_deadline=recovery_deadline,
             known_order_ids=tuple(known_order_ids),
+            recovery_policy=recovery_policy,
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitExposureAdjustment:
+    """Audited correction for Freqtrade's full-exit wallet fallback."""
+
+    adjustment_id: str
+    previous_amount: float
+    adjusted_amount: float
+    amount: float
+    exit_credit_baseline: float
+    exit_reason: str
+    recorded_at: str
+    retired_at: str | None = None
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.adjustment_id)
+        previous_amount = _required_positive_value(
+            self.previous_amount,
+            "exposure adjustment previous amount",
+        )
+        adjusted_amount = _required_positive_value(
+            self.adjusted_amount,
+            "exposure adjustment adjusted amount",
+        )
+        amount = _required_positive_value(
+            self.amount,
+            "exposure adjustment amount",
+        )
+        _non_negative_float(self.exit_credit_baseline)
+        _non_empty_string(self.exit_reason)
+        recorded_at = _parse_iso_datetime(self.recorded_at)
+        if adjusted_amount >= previous_amount:
+            raise ValueError("Exposure adjustment must reduce the trade amount")
+        if not math.isclose(
+            previous_amount - adjusted_amount,
+            amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Exposure adjustment amount is inconsistent")
+        if adjusted_amount <= previous_amount * 0.98:
+            raise ValueError("Exposure adjustment exceeds Freqtrade's wallet fallback")
+        if self.retired_at is not None:
+            retired_at = _parse_iso_datetime(self.retired_at)
+            if retired_at < recorded_at:
+                raise ValueError(
+                    "Exposure adjustment was retired before it was recorded"
+                )
+
+    @property
+    def is_active(self) -> bool:
+        return self.retired_at is None
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "adjustment_id": self.adjustment_id,
+            "previous_amount": self.previous_amount,
+            "adjusted_amount": self.adjusted_amount,
+            "amount": self.amount,
+            "exit_credit_baseline": self.exit_credit_baseline,
+            "exit_reason": self.exit_reason,
+            "recorded_at": self.recorded_at,
+            "retired_at": self.retired_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        retired_at = value.get("retired_at")
+        if retired_at is not None and not isinstance(retired_at, str):
+            raise ValueError("Invalid exposure adjustment retirement timestamp")
+        return cls(
+            adjustment_id=_required_string(value, "adjustment_id"),
+            previous_amount=_required_positive_float(value, "previous_amount"),
+            adjusted_amount=_required_positive_float(value, "adjusted_amount"),
+            amount=_required_positive_float(value, "amount"),
+            exit_credit_baseline=_required_non_negative_float(
+                value,
+                "exit_credit_baseline",
+            ),
+            exit_reason=_required_string(value, "exit_reason"),
+            recorded_at=_required_string(value, "recorded_at"),
+            retired_at=retired_at,
         )
 
 
@@ -449,15 +544,18 @@ class TakeProfitStageState:
     deferred_stages: tuple[int, ...]
     attributed_order_ids: tuple[str, ...]
     credited_order_amounts: tuple[tuple[str, float], ...]
+    non_take_profit_exit_order_amounts: tuple[tuple[str, float], ...]
     entry_order_amounts: tuple[tuple[str, float], ...]
+    exposure_adjustments: tuple[TakeProfitExposureAdjustment, ...]
     confirmed_zero_fill_orders: tuple[TakeProfitZeroFillProof, ...]
     operator_resolutions: tuple[TakeProfitOperatorResolution, ...]
     active_attempt: TakeProfitAttempt | None = None
     blocked_reason: str | None = None
     blocked_order_id: str | None = None
 
-    SCHEMA_VERSION = 4
+    SCHEMA_VERSION = 5
     MAX_OPERATOR_RESOLUTIONS = 32
+    MAX_EXPOSURE_ADJUSTMENTS = 32
 
     def to_mapping(self) -> dict[str, object]:
         return {
@@ -474,9 +572,16 @@ class TakeProfitStageState:
                 {"order_id": order_id, "amount": amount}
                 for order_id, amount in self.credited_order_amounts
             ],
+            "non_take_profit_exit_order_amounts": [
+                {"order_id": order_id, "amount": amount}
+                for order_id, amount in self.non_take_profit_exit_order_amounts
+            ],
             "entry_order_amounts": [
                 {"order_id": order_id, "amount": amount}
                 for order_id, amount in self.entry_order_amounts
+            ],
+            "exposure_adjustments": [
+                adjustment.to_mapping() for adjustment in self.exposure_adjustments
             ],
             "confirmed_zero_fill_orders": [
                 proof.to_mapping() for proof in self.confirmed_zero_fill_orders
@@ -496,10 +601,10 @@ class TakeProfitStageState:
     @classmethod
     def from_mapping(cls, value: Mapping[str, object]) -> Self:
         version = _required_non_negative_int(value, "version")
-        if version != cls.SCHEMA_VERSION:
+        if version not in {4, cls.SCHEMA_VERSION}:
             raise ValueError(
                 f"Unsupported take-profit state version {version!r}; "
-                f"expected {cls.SCHEMA_VERSION}"
+                f"expected 4 or {cls.SCHEMA_VERSION}"
             )
 
         plan_raw = value.get("plan_signature")
@@ -572,11 +677,75 @@ class TakeProfitStageState:
         ):
             raise ValueError("Credited take-profit amount exceeds the initial amount")
 
+        non_take_profit_exit_order_amounts = _parse_amount_records(
+            value.get("non_take_profit_exit_order_amounts", [])
+            if version == 4
+            else value.get("non_take_profit_exit_order_amounts"),
+            identifier_key="order_id",
+            identifier_parser=_non_empty_string,
+        )
+        take_profit_order_ids = set(attributed_order_ids)
+        non_take_profit_order_ids = {
+            order_id for order_id, _ in non_take_profit_exit_order_amounts
+        }
+        if take_profit_order_ids & non_take_profit_order_ids:
+            raise ValueError(
+                "Exit order cannot be both take-profit and non-take-profit"
+            )
+
         entry_order_amounts = _parse_amount_records(
             value.get("entry_order_amounts"),
             identifier_key="order_id",
             identifier_parser=_non_empty_string,
         )
+
+        adjustments_raw = [] if version == 4 else value.get("exposure_adjustments")
+        if not isinstance(adjustments_raw, list) or not all(
+            isinstance(adjustment, Mapping) for adjustment in adjustments_raw
+        ):
+            raise ValueError("Invalid take-profit exposure adjustments")
+        exposure_adjustments = tuple(
+            TakeProfitExposureAdjustment.from_mapping(adjustment)
+            for adjustment in adjustments_raw
+            if isinstance(adjustment, Mapping)
+        )
+        adjustment_ids = tuple(
+            adjustment.adjustment_id for adjustment in exposure_adjustments
+        )
+        if len(adjustment_ids) != len(set(adjustment_ids)):
+            raise ValueError("Duplicate take-profit exposure adjustment")
+        if len(exposure_adjustments) > cls.MAX_EXPOSURE_ADJUSTMENTS:
+            raise ValueError("Too many take-profit exposure adjustments")
+        total_exit_credited = total_credited + math.fsum(
+            amount for _, amount in non_take_profit_exit_order_amounts
+        )
+        if total_exit_credited > initial_amount and not math.isclose(
+            total_exit_credited,
+            initial_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Credited exit amount exceeds the initial amount")
+        active_adjustment_total = math.fsum(
+            adjustment.amount
+            for adjustment in exposure_adjustments
+            if adjustment.is_active
+        )
+        if (
+            total_exit_credited + active_adjustment_total > initial_amount
+            and not math.isclose(
+                total_exit_credited + active_adjustment_total,
+                initial_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+        ):
+            raise ValueError("Exposure credits exceed the initial amount")
+        if any(
+            adjustment.exit_credit_baseline > total_exit_credited
+            for adjustment in exposure_adjustments
+        ):
+            raise ValueError("Exposure adjustment has an invalid fill baseline")
 
         proofs_raw = value.get("confirmed_zero_fill_orders")
         if not isinstance(proofs_raw, list) or not all(
@@ -622,6 +791,16 @@ class TakeProfitStageState:
         active_raw = value.get("active_attempt")
         if active_raw is not None and not isinstance(active_raw, Mapping):
             raise ValueError("Invalid take-profit active_attempt")
+        if version == 4 and isinstance(active_raw, Mapping):
+            active_raw = dict(active_raw)
+            active_raw.setdefault(
+                "recovery_policy",
+                "tagged_or_unique_untagged",
+            )
+            if active_raw.get("status") == "proposed":
+                active_raw["status"] = "ambiguous"
+                active_raw["submitted_at"] = active_raw.get("created_at")
+                active_raw["recovery_policy"] = "tagged_only"
         active_attempt = (
             TakeProfitAttempt.from_mapping(active_raw)
             if isinstance(active_raw, Mapping)
@@ -630,6 +809,12 @@ class TakeProfitStageState:
         if active_attempt is not None and active_attempt.stage not in stages:
             if active_attempt.stage != plan_signature.final_stage.stage:
                 raise ValueError("Invalid take-profit attempt stage")
+        if (
+            active_attempt is not None
+            and active_attempt.status == "proposed"
+            and active_attempt.stage != plan_signature.final_stage.stage
+        ):
+            raise ValueError("Only a final take-profit attempt can be proposed")
         if (
             active_attempt is not None
             and active_attempt.attempt_id in resolved_attempt_ids
@@ -641,21 +826,30 @@ class TakeProfitStageState:
             raise ValueError("Invalid take-profit blocked_reason")
         blocked_order_id = value.get("blocked_order_id")
         if blocked_reason in _BLOCKED_ORDER_ID_REASONS:
-            blocked_order_id = _non_empty_string(blocked_order_id)
+            if not (
+                version == 4
+                and blocked_reason == "unattributed_exit_fill"
+                and blocked_order_id is None
+            ):
+                blocked_order_id = _non_empty_string(blocked_order_id)
         elif blocked_reason is None and blocked_order_id is not None:
             raise ValueError("Take-profit blocked_order_id requires a blocked state")
         elif blocked_order_id is not None:
             blocked_order_id = _non_empty_string(blocked_order_id)
 
         return cls(
-            version=version,
+            version=cls.SCHEMA_VERSION,
             plan_signature=plan_signature,
             initial_amount=initial_amount,
             stage_targets=tuple(sorted(stage_targets)),
             deferred_stages=tuple(sorted(deferred_stages)),
             attributed_order_ids=tuple(sorted(attributed_order_ids)),
             credited_order_amounts=tuple(sorted(credited_order_amounts)),
+            non_take_profit_exit_order_amounts=tuple(
+                sorted(non_take_profit_exit_order_amounts)
+            ),
             entry_order_amounts=tuple(sorted(entry_order_amounts)),
+            exposure_adjustments=exposure_adjustments,
             confirmed_zero_fill_orders=tuple(
                 sorted(
                     confirmed_zero_fill_orders,
@@ -680,6 +874,7 @@ class TakeProfitStageProgress:
     has_deferred_debt: bool
 
 
+@final
 class TakeProfitStageManager:
     """Reconcile take-profit stages with causally attributed Freqtrade orders."""
 
@@ -722,17 +917,20 @@ class TakeProfitStageManager:
     ) -> tuple[str, int, str | None] | None:
         if not isinstance(tag, str):
             return None
-        parts = tag.split("_")
-        if len(parts) not in {4, 5} or parts[:2] != ["take", "profit"]:
+        prefix = f"{cls._TAG_PREFIX}_"
+        if not tag.startswith(prefix):
+            return None
+        parts = tag.removeprefix(prefix).split("_")
+        if len(parts) not in {2, 3}:
             return None
         try:
-            stage = int(parts[3])
+            stage = int(parts[1])
         except ValueError:
             return None
-        if stage < 0 or not parts[2]:
+        if stage < 0 or not parts[0]:
             return None
-        attempt_id = parts[4] if len(parts) == 5 and parts[4] else None
-        return parts[2], stage, attempt_id
+        attempt_id = parts[2] if len(parts) == 3 and parts[2] else None
+        return parts[0], stage, attempt_id
 
     @classmethod
     def initialize(
@@ -741,124 +939,53 @@ class TakeProfitStageManager:
         plan_signature: TakeProfitPlanSignature,
         *,
         amount_quantizer: Callable[[float], float] | None = None,
+        validate_trade_amount: bool = True,
     ) -> TakeProfitStageState:
-        configured_stages = {
-            definition.stage for definition in plan_signature.partial_stages
-        }
-        strategy_exit_orders = [
-            order for order in trade.orders if order.ft_order_side == trade.exit_side
-        ]
-        blocked_reason = None
-        blocked_order_id = None
-        if any(
-            order.ft_order_side == trade.entry_side and order.ft_is_open
-            for order in trade.orders
-        ):
-            blocked_reason = "open_entry_order"
-        for order in trade.orders:
-            if order.ft_order_side in {trade.entry_side, trade.exit_side}:
-                continue
-            external_block = cls._external_exit_block(order)
-            if external_block is not None and blocked_reason is None:
-                blocked_reason = external_block
-                blocked_order_id = order.order_id
-
-        terminal_credits: dict[str, float] = {}
-        for order in strategy_exit_orders:
-            if order.ft_is_open:
-                continue
-            try:
-                terminal_credits[order.order_id] = cls._terminal_credited_amount(order)
-            except ValueError:
-                if blocked_reason is None:
-                    blocked_reason = "unknown_terminal_fill"
-                    blocked_order_id = order.order_id
-
-        attributed_order_ids: set[str] = set()
-        for order in strategy_exit_orders:
-            parsed_tag = cls.parse_order_tag(order.ft_order_tag)
-            if parsed_tag is None:
-                continue
-            direction, stage, attempt_id = parsed_tag
-            if attempt_id is not None:
-                if blocked_reason is None:
-                    blocked_reason = "unknown_attempt_order"
-                    blocked_order_id = order.order_id
-                continue
-            if (
-                direction != trade.trade_direction
-                or stage not in configured_stages
-                or order.ft_order_side != trade.exit_side
-            ):
-                if terminal_credits.get(order.order_id, 0.0) > 0.0:
-                    blocked_reason = blocked_reason or "unattributed_exit_fill"
-                continue
-            attributed_order_ids.add(order.order_id)
-
-        for index, order in enumerate(strategy_exit_orders):
-            if order.ft_order_tag != cls._EMERGENCY_EXIT_TAG:
-                continue
-            predecessor = strategy_exit_orders[index - 1] if index > 0 else None
-            if predecessor is not None and cls._is_legacy_emergency_successor(
-                trade,
-                predecessor,
-                order,
-                configured_stages,
-            ):
-                attributed_order_ids.add(order.order_id)
-            elif terminal_credits.get(order.order_id, 0.0) > 0.0:
-                blocked_reason = blocked_reason or "ambiguous_legacy_exit"
-
-        credited_order_amounts: dict[str, float] = {}
-        for order in strategy_exit_orders:
-            if order.order_id in attributed_order_ids and not order.ft_is_open:
-                credited_order_amounts[order.order_id] = terminal_credits.get(
-                    order.order_id,
-                    0.0,
-                )
-            elif (
-                order.order_id not in attributed_order_ids
-                and terminal_credits.get(order.order_id, 0.0) > 0.0
-            ):
-                blocked_reason = blocked_reason or "unattributed_exit_fill"
-
         entry_order_amounts = cls._entry_order_amounts(trade)
         if entry_order_amounts:
             initial_amount = cls._canonical_amount_sum(
                 entry_order_amounts.values(),
                 amount_quantizer,
             )
+            blocked_reason = None
         else:
-            blocked_reason = blocked_reason or "missing_entry_exposure"
+            blocked_reason = "missing_entry_exposure"
             initial_amount = cls._canonical_amount(
                 cls._safe_amount(trade.amount),
                 amount_quantizer,
             )
         if initial_amount <= 0.0:
             raise ValueError("Cannot initialize take-profit without positive exposure")
-        stage_targets = plan_signature.derive_stage_targets(initial_amount)
-
-        if not cls._trade_amount_is_consistent(
-            trade,
-            entry_order_amounts.values(),
-            credited_order_amounts.values(),
-            amount_quantizer,
+        if any(
+            order.ft_order_side == trade.entry_side and order.ft_is_open
+            for order in trade.orders
         ):
-            blocked_reason = blocked_reason or "trade_amount_mismatch"
+            blocked_reason = "open_entry_order"
 
-        return TakeProfitStageState(
+        state = TakeProfitStageState(
             version=TakeProfitStageState.SCHEMA_VERSION,
             plan_signature=plan_signature,
             initial_amount=initial_amount,
-            stage_targets=stage_targets,
+            stage_targets=plan_signature.derive_stage_targets(initial_amount),
             deferred_stages=(),
-            attributed_order_ids=tuple(sorted(attributed_order_ids)),
-            credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
+            attributed_order_ids=(),
+            credited_order_amounts=(),
+            non_take_profit_exit_order_amounts=(),
             entry_order_amounts=tuple(sorted(entry_order_amounts.items())),
+            exposure_adjustments=(),
             confirmed_zero_fill_orders=(),
             operator_resolutions=(),
             blocked_reason=blocked_reason,
-            blocked_order_id=blocked_order_id,
+        )
+        return (
+            state
+            if state.blocked_reason is not None
+            else cls._reconcile(
+                trade,
+                state,
+                amount_quantizer=amount_quantizer,
+                validate_trade_amount=validate_trade_amount,
+            )
         )
 
     @classmethod
@@ -868,6 +995,22 @@ class TakeProfitStageManager:
         state: TakeProfitStageState,
         *,
         amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        return cls._reconcile(
+            trade,
+            state,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=True,
+        )
+
+    @classmethod
+    def _reconcile(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        amount_quantizer: Callable[[float], float] | None,
+        validate_trade_amount: bool,
     ) -> TakeProfitStageState:
         if state.blocked_reason is not None:
             return state
@@ -921,6 +1064,9 @@ class TakeProfitStageManager:
         configured_stages = {stage for stage, _ in state.stage_targets}
         attributed_order_ids = set(state.attributed_order_ids)
         credited_order_amounts = dict(state.credited_order_amounts)
+        non_take_profit_exit_order_amounts = dict(
+            state.non_take_profit_exit_order_amounts
+        )
         strategy_exit_orders = [
             order for order in trade.orders if order.ft_order_side == trade.exit_side
         ]
@@ -981,10 +1127,26 @@ class TakeProfitStageManager:
                 continue
             parsed_tag = cls.parse_order_tag(order.ft_order_tag)
             if parsed_tag is None:
-                continue
-            if order.order_id in confirmed_zero_fill_orders:
+                if cls.has_order_tag_prefix(order.ft_order_tag):
+                    if order.order_id in confirmed_zero_fill_orders:
+                        continue
+                    return cls._block(
+                        state,
+                        "unknown_attempt_order",
+                        order_id=order.order_id,
+                    )
                 continue
             if order in matching_attempt_orders:
+                continue
+            direction, stage, attempt_id = parsed_tag
+            if (
+                attempt_id is None
+                and direction == trade.trade_direction
+                and stage in configured_stages
+            ):
+                attributed_order_ids.add(order.order_id)
+                continue
+            if order.order_id in confirmed_zero_fill_orders:
                 continue
             return cls._block(
                 state,
@@ -1048,27 +1210,144 @@ class TakeProfitStageManager:
                 return cls._block(state, "attributed_fill_regressed")
             credited_order_amounts[order_id] = current_amount
 
-        total_credited = math.fsum(credited_order_amounts.values())
-        if total_credited > state.initial_amount and not cls._amounts_close(
-            total_credited,
+        for order_id, previous_amount in non_take_profit_exit_order_amounts.items():
+            order = orders_by_id.get(order_id)
+            if order is None:
+                return cls._block(state, "attributed_order_missing")
+            if order.ft_order_side != trade.exit_side:
+                return cls._block(state, "attributed_order_side_changed")
+            if order.ft_is_open:
+                return cls._block(state, "attributed_order_reopened")
+            current_amount = terminal_credits[order_id]
+            if current_amount < previous_amount and not cls._amounts_close(
+                current_amount,
+                previous_amount,
+            ):
+                return cls._block(state, "attributed_fill_regressed")
+            non_take_profit_exit_order_amounts[order_id] = current_amount
+
+        for order in strategy_exit_orders:
+            if order.ft_is_open or order.order_id in attributed_order_ids:
+                continue
+            if order.order_id in credited_order_amounts:
+                return cls._block(state, "exit_order_role_changed")
+            current_amount = terminal_credits[order.order_id]
+            if current_amount > 0.0 and not order.ft_order_tag:
+                return cls._block(
+                    state,
+                    "unattributed_exit_fill",
+                    order_id=order.order_id,
+                )
+            previous_amount = non_take_profit_exit_order_amounts.get(order.order_id)
+            if (
+                previous_amount is not None
+                and current_amount < previous_amount
+                and not cls._amounts_close(current_amount, previous_amount)
+            ):
+                return cls._block(state, "attributed_fill_regressed")
+            non_take_profit_exit_order_amounts[order.order_id] = current_amount
+
+        if set(credited_order_amounts) & set(non_take_profit_exit_order_amounts):
+            return cls._block(state, "exit_order_role_changed")
+
+        total_take_profit_credited = math.fsum(credited_order_amounts.values())
+        total_exit_credited = total_take_profit_credited + math.fsum(
+            non_take_profit_exit_order_amounts.values()
+        )
+        if total_exit_credited > state.initial_amount and not cls._amounts_close(
+            total_exit_credited,
             state.initial_amount,
         ):
             return cls._block(state, "credited_fill_exceeds_initial_amount")
 
-        for order in strategy_exit_orders:
+        exposure_adjustments = state.exposure_adjustments
+        has_open_exit_order = any(
+            order.ft_is_open
+            for order in trade.orders
+            if order.ft_order_side != trade.entry_side
+        )
+        if validate_trade_amount and not has_open_exit_order:
+            exit_credit_amounts = (
+                *credited_order_amounts.values(),
+                *non_take_profit_exit_order_amounts.values(),
+            )
+            active_adjustments = tuple(
+                adjustment
+                for adjustment in exposure_adjustments
+                if adjustment.is_active
+            )
+            active_adjustment_total = math.fsum(
+                adjustment.amount for adjustment in active_adjustments
+            )
             if (
-                order.order_id not in attributed_order_ids
-                and terminal_credits.get(order.order_id, 0.0) > 0.0
+                total_exit_credited + active_adjustment_total > state.initial_amount
+                and not cls._amounts_close(
+                    total_exit_credited + active_adjustment_total,
+                    state.initial_amount,
+                )
             ):
-                return cls._block(state, "unattributed_exit_fill")
-
-        if not cls._trade_amount_is_consistent(
-            trade,
-            persisted_entry_amounts.values(),
-            credited_order_amounts.values(),
-            amount_quantizer,
-        ):
-            return cls._block(state, "trade_amount_mismatch")
+                return cls._block(state, "credited_fill_exceeds_initial_amount")
+            expected_with_adjustments = cls._canonical_expected_trade_amount(
+                persisted_entry_amounts.values(),
+                exit_credit_amounts,
+                (adjustment.amount for adjustment in active_adjustments),
+                amount_quantizer,
+            )
+            try:
+                observed_amount = cls._canonical_amount(
+                    trade.amount,
+                    amount_quantizer,
+                )
+            except ValueError:
+                return cls._block(state, "trade_amount_mismatch")
+            retireable_adjustments = tuple(
+                adjustment
+                for adjustment in active_adjustments
+                if total_exit_credited > adjustment.exit_credit_baseline
+            )
+            adjustments_were_retired = False
+            if retireable_adjustments:
+                expected_after_retirement = cls._canonical_expected_trade_amount(
+                    persisted_entry_amounts.values(),
+                    exit_credit_amounts,
+                    (
+                        adjustment.amount
+                        for adjustment in active_adjustments
+                        if adjustment not in retireable_adjustments
+                    ),
+                    amount_quantizer,
+                )
+                adjustments_were_retired = cls._amounts_close(
+                    observed_amount,
+                    expected_after_retirement,
+                )
+            if adjustments_were_retired:
+                retirement_time = max(
+                    *(
+                        order.order_filled_utc
+                        for order in strategy_exit_orders
+                        if not order.ft_is_open
+                        and terminal_credits.get(order.order_id, 0.0) > 0.0
+                        and order.order_filled_utc is not None
+                    ),
+                    *(
+                        _parse_iso_datetime(adjustment.recorded_at)
+                        for adjustment in retireable_adjustments
+                    ),
+                ).isoformat()
+                retireable_ids = {
+                    adjustment.adjustment_id for adjustment in retireable_adjustments
+                }
+                exposure_adjustments = cls._retire_exposure_adjustments(
+                    exposure_adjustments,
+                    retireable_ids,
+                    retirement_time,
+                )
+            elif not cls._amounts_close(
+                observed_amount,
+                expected_with_adjustments,
+            ):
+                return cls._block(state, "trade_amount_mismatch")
 
         if matching_attempt_orders:
             active_attempt = None
@@ -1077,7 +1356,171 @@ class TakeProfitStageManager:
             state,
             attributed_order_ids=tuple(sorted(attributed_order_ids)),
             credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
+            non_take_profit_exit_order_amounts=tuple(
+                sorted(non_take_profit_exit_order_amounts.items())
+            ),
+            exposure_adjustments=exposure_adjustments,
             active_attempt=active_attempt,
+        )
+
+    @classmethod
+    def reconcile_migrated_state(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        source_version: int,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Re-evaluate only v4 blocks made obsolete by the split exit ledger."""
+        state = cls.prepare_migrated_state(state, source_version)
+        return cls.reconcile(
+            trade,
+            state,
+            amount_quantizer=amount_quantizer,
+        )
+
+    @staticmethod
+    def prepare_migrated_state(
+        state: TakeProfitStageState,
+        source_version: int,
+    ) -> TakeProfitStageState:
+        if source_version != 4:
+            return state
+        if state.blocked_reason in {
+            "unattributed_exit_fill",
+            "trade_amount_mismatch",
+        }:
+            return replace(
+                state,
+                blocked_reason=None,
+                blocked_order_id=None,
+            )
+        return state
+
+    @classmethod
+    def reconcile_for_exit_confirmation(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        confirmed_amount: float,
+        exit_reason: str,
+        adjustment_id: str,
+        current_time: datetime.datetime,
+        allow_wallet_adjustment: bool,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Reconcile the amount mutation made by Freqtrade before full confirmation."""
+        if current_time.tzinfo is None:
+            raise ValueError("Exit confirmation timestamp must be timezone-aware")
+        _non_empty_string(exit_reason)
+        _non_empty_string(adjustment_id)
+        confirmed_amount = _required_positive_value(
+            confirmed_amount,
+            "confirmed exit amount",
+        )
+        observed_amount = _required_positive_value(
+            trade.amount,
+            "observed trade amount",
+        )
+        if not cls._amounts_close(confirmed_amount, observed_amount):
+            return cls._block(state, "trade_amount_mismatch")
+
+        candidate = cls._reconcile(
+            trade,
+            state,
+            amount_quantizer=amount_quantizer,
+            validate_trade_amount=False,
+        )
+        if candidate.blocked_reason is not None:
+            return candidate
+
+        total_exit_credited = math.fsum(
+            amount for _, amount in candidate.credited_order_amounts
+        ) + math.fsum(
+            amount for _, amount in candidate.non_take_profit_exit_order_amounts
+        )
+        retireable_adjustments = tuple(
+            adjustment
+            for adjustment in candidate.exposure_adjustments
+            if adjustment.is_active
+            and total_exit_credited > adjustment.exit_credit_baseline
+        )
+        if retireable_adjustments:
+            retirement_time = max(
+                current_time,
+                *(
+                    _parse_iso_datetime(adjustment.recorded_at)
+                    for adjustment in retireable_adjustments
+                ),
+            ).isoformat()
+            candidate = replace(
+                candidate,
+                exposure_adjustments=cls._retire_exposure_adjustments(
+                    candidate.exposure_adjustments,
+                    {adjustment.adjustment_id for adjustment in retireable_adjustments},
+                    retirement_time,
+                ),
+            )
+        active_adjustment_amounts = (
+            adjustment.amount
+            for adjustment in candidate.exposure_adjustments
+            if adjustment.is_active
+        )
+        expected_amount = cls._raw_expected_trade_amount(
+            (amount for _, amount in candidate.entry_order_amounts),
+            (
+                *(amount for _, amount in candidate.credited_order_amounts),
+                *(amount for _, amount in candidate.non_take_profit_exit_order_amounts),
+            ),
+            active_adjustment_amounts,
+            amount_quantizer,
+        )
+        if cls._amounts_close(observed_amount, expected_amount):
+            return cls.reconcile(
+                trade,
+                candidate,
+                amount_quantizer=amount_quantizer,
+            )
+
+        if (
+            not allow_wallet_adjustment
+            or observed_amount >= expected_amount
+            or observed_amount <= expected_amount * 0.98
+        ):
+            return cls._block(candidate, "trade_amount_mismatch")
+        if any(
+            adjustment.adjustment_id == adjustment_id
+            for adjustment in candidate.exposure_adjustments
+        ):
+            return cls._block(candidate, "duplicate_exposure_adjustment")
+        if (
+            len(candidate.exposure_adjustments)
+            >= TakeProfitStageState.MAX_EXPOSURE_ADJUSTMENTS
+        ):
+            return cls._block(candidate, "exposure_adjustment_limit")
+
+        adjustment = TakeProfitExposureAdjustment(
+            adjustment_id=adjustment_id,
+            previous_amount=expected_amount,
+            adjusted_amount=observed_amount,
+            amount=expected_amount - observed_amount,
+            exit_credit_baseline=total_exit_credited,
+            exit_reason=exit_reason,
+            recorded_at=current_time.isoformat(),
+        )
+        adjusted_state = replace(
+            candidate,
+            exposure_adjustments=(
+                *candidate.exposure_adjustments,
+                adjustment,
+            ),
+        )
+        return cls.reconcile(
+            trade,
+            adjusted_state,
+            amount_quantizer=amount_quantizer,
         )
 
     @classmethod
@@ -1154,9 +1597,17 @@ class TakeProfitStageManager:
         *,
         amount_quantizer: Callable[[float], float] | None = None,
     ) -> float:
-        return cls._canonical_signed_amount_sum(
+        return cls._canonical_expected_trade_amount(
             (amount for _, amount in state.entry_order_amounts),
-            (amount for _, amount in state.credited_order_amounts),
+            (
+                *(amount for _, amount in state.credited_order_amounts),
+                *(amount for _, amount in state.non_take_profit_exit_order_amounts),
+            ),
+            (
+                adjustment.amount
+                for adjustment in state.exposure_adjustments
+                if adjustment.is_active
+            ),
             amount_quantizer,
         )
 
@@ -1212,6 +1663,8 @@ class TakeProfitStageManager:
             raise ValueError(f"Unknown take-profit stage {stage!r}")
         if status not in {"proposed", "submitting"}:
             raise ValueError(f"Invalid initial take-profit attempt status {status!r}")
+        if status == "proposed" and stage != final_stage:
+            raise ValueError("Only a final take-profit attempt can be proposed")
         if current_time.tzinfo is None or recovery_deadline.tzinfo is None:
             raise ValueError("Take-profit attempt timestamps must be timezone-aware")
         if recovery_deadline < current_time:
@@ -1236,6 +1689,7 @@ class TakeProfitStageManager:
                 submitted_at=submitted_at,
                 recovery_deadline=recovery_deadline.isoformat(),
                 known_order_ids=tuple(sorted(order.order_id for order in trade.orders)),
+                recovery_policy="tagged_or_unique_untagged",
             ),
         )
 
@@ -1360,10 +1814,11 @@ class TakeProfitStageManager:
         """Reconcile one repaired canonical order and record the operator action."""
         order_id = _non_empty_string(order_id)
         if (
-            state.blocked_reason != "unknown_terminal_fill"
+            state.blocked_reason
+            not in {"unknown_terminal_fill", "unattributed_exit_fill"}
             or state.blocked_order_id != order_id
         ):
-            raise ValueError("No matching unknown terminal fill to revalidate")
+            raise ValueError("No matching terminal fill to revalidate")
         if resolved_at.tzinfo is None:
             raise ValueError("Take-profit resolution timestamp must be timezone-aware")
 
@@ -1394,14 +1849,18 @@ class TakeProfitStageManager:
             )
 
         attributed = order_id in reconciled.attributed_order_ids
-        persisted_credit = dict(reconciled.credited_order_amounts).get(order_id)
-        if credited_amount > 0.0 and not attributed:
-            raise ValueError("Positive terminal fill is not attributed to take-profit")
-        if attributed and (
-            persisted_credit is None
-            or not cls._amounts_close(persisted_credit, credited_amount)
+        persisted_credit = (
+            dict(reconciled.credited_order_amounts).get(order_id)
+            if attributed
+            else dict(reconciled.non_take_profit_exit_order_amounts).get(order_id)
+        )
+        if credited_amount > 0.0 and persisted_credit is None:
+            raise ValueError("Positive terminal fill is not present in the exit ledger")
+        if persisted_credit is not None and not cls._amounts_close(
+            persisted_credit,
+            credited_amount,
         ):
-            raise ValueError("Revalidated take-profit credit does not match the order")
+            raise ValueError("Revalidated exit credit does not match the order")
 
         resolution = TakeProfitOperatorResolution(
             action="revalidated_terminal_fill",
@@ -1713,9 +2172,8 @@ class TakeProfitStageManager:
             raise ValueError("Terminal zero-fill order has a fill timestamp")
         return amount, remaining, fee_base
 
-    @classmethod
+    @staticmethod
     def _canonical_amount(
-        cls,
         value: object,
         amount_quantizer: Callable[[float], float] | None,
     ) -> float:
@@ -1751,29 +2209,68 @@ class TakeProfitStageManager:
             return float(precise_amount)
         return cls._canonical_amount(float(precise_amount), amount_quantizer)
 
-    @classmethod
-    def _trade_amount_is_consistent(
-        cls,
-        trade: _Trade,
+    @staticmethod
+    def _raw_signed_amount_sum(
         entry_amounts: Iterable[float],
-        credited_amounts: Iterable[float],
+        exit_amounts: Iterable[float],
+    ) -> float:
+        precise_amount = Decimal(0)
+        for amount in entry_amounts:
+            precise_amount += Decimal(str(_non_negative_float(amount)))
+        for amount in exit_amounts:
+            precise_amount -= Decimal(str(_non_negative_float(amount)))
+        return float(precise_amount)
+
+    @classmethod
+    def _raw_expected_trade_amount(
+        cls,
+        entry_amounts: Iterable[float],
+        exit_order_amounts: Iterable[float],
+        exposure_adjustments: Iterable[float],
         amount_quantizer: Callable[[float], float] | None,
-    ) -> bool:
-        try:
-            expected_amount = cls._canonical_signed_amount_sum(
-                entry_amounts,
-                credited_amounts,
-                amount_quantizer,
-            )
-            observed_amount = cls._canonical_amount(
-                trade.amount,
-                amount_quantizer,
-            )
-        except ValueError:
-            return False
-        return expected_amount >= 0.0 and cls._amounts_close(
-            observed_amount,
-            expected_amount,
+    ) -> float:
+        """Mirror Freqtrade's order recalculation, then its raw wallet fallback."""
+        canonical_order_amount = cls._canonical_signed_amount_sum(
+            entry_amounts,
+            exit_order_amounts,
+            amount_quantizer,
+        )
+        if canonical_order_amount < 0.0:
+            return canonical_order_amount
+        return cls._raw_signed_amount_sum(
+            (canonical_order_amount,),
+            exposure_adjustments,
+        )
+
+    @classmethod
+    def _canonical_expected_trade_amount(
+        cls,
+        entry_amounts: Iterable[float],
+        exit_order_amounts: Iterable[float],
+        exposure_adjustments: Iterable[float],
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> float:
+        expected_amount = cls._raw_expected_trade_amount(
+            entry_amounts,
+            exit_order_amounts,
+            exposure_adjustments,
+            amount_quantizer,
+        )
+        if expected_amount < 0.0:
+            return expected_amount
+        return cls._canonical_amount(expected_amount, amount_quantizer)
+
+    @staticmethod
+    def _retire_exposure_adjustments(
+        adjustments: tuple[TakeProfitExposureAdjustment, ...],
+        adjustment_ids: set[str],
+        retired_at: str,
+    ) -> tuple[TakeProfitExposureAdjustment, ...]:
+        return tuple(
+            replace(adjustment, retired_at=retired_at)
+            if adjustment.adjustment_id in adjustment_ids
+            else adjustment
+            for adjustment in adjustments
         )
 
     @classmethod
@@ -1809,7 +2306,8 @@ class TakeProfitStageManager:
         attempt: TakeProfitAttempt,
     ) -> bool:
         if (
-            order.order_id in attempt.known_order_ids
+            attempt.recovery_policy != "tagged_or_unique_untagged"
+            or order.order_id in attempt.known_order_ids
             or order.ft_order_tag is not None
             or order.ft_order_side != attempt.exit_side
             or not cls._amounts_close(

--- a/quickadapter/user_data/strategies/TakeProfitStageManager.py
+++ b/quickadapter/user_data/strategies/TakeProfitStageManager.py
@@ -1,22 +1,672 @@
+import datetime
 import math
-from dataclasses import dataclass
-from typing import Mapping, Protocol, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
+from dataclasses import dataclass, replace
+from decimal import Decimal
+from typing import Literal, Protocol, Self
+
+
+TakeProfitAttemptStatus = Literal["proposed", "submitting", "ambiguous"]
+TakeProfitOperatorAction = Literal[
+    "confirmed_no_remote_order",
+    "confirmed_terminal_zero_fill",
+    "revalidated_terminal_fill",
+]
+TakeProfitOrderRole = Literal["strategy_exit", "external_exit"]
+
+
+_OPERATOR_ZERO_FILL_STATUSES = frozenset({"canceled", "cancelled"})
+_BLOCKED_ORDER_ID_REASONS = frozenset(
+    {
+        "confirmed_terminal_zero_fill_changed",
+        "confirmed_terminal_zero_fill_order_missing",
+        "multiple_attempt_orders",
+        "unknown_attempt_order",
+        "unknown_external_exit_fill",
+        "unknown_terminal_fill",
+    }
+)
 
 
 class _Order(Protocol):
-    ft_order_side: str
-    ft_order_tag: str | None
-    ft_is_open: bool
-    safe_amount: float
-    safe_filled: float
+    @property
+    def filled(self) -> float | None: ...
+
+    @property
+    def ft_fee_base(self) -> float | None: ...
+
+    @property
+    def order_id(self) -> str: ...
+
+    @property
+    def order_date_utc(self) -> datetime.datetime: ...
+
+    @property
+    def order_filled_utc(self) -> datetime.datetime | None: ...
+
+    @property
+    def ft_order_side(self) -> str: ...
+
+    @property
+    def ft_order_tag(self) -> str | None: ...
+
+    @property
+    def ft_is_open(self) -> bool: ...
+
+    @property
+    def remaining(self) -> float | None: ...
+
+    @property
+    def safe_amount(self) -> float: ...
+
+    @property
+    def safe_amount_after_fee(self) -> float: ...
+
+    @property
+    def safe_filled(self) -> float: ...
+
+    @property
+    def safe_remaining(self) -> float: ...
+
+    @property
+    def status(self) -> str | None: ...
 
 
 class _Trade(Protocol):
+    @property
+    def amount(self) -> float: ...
+
+    @property
+    def entry_side(self) -> str: ...
+
+    @property
+    def exit_side(self) -> str: ...
+
+    @property
+    def orders(self) -> Sequence[_Order]: ...
+
+    @property
+    def stake_amount(self) -> float: ...
+
+    @property
+    def trade_direction(self) -> str: ...
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitAttempt:
+    attempt_id: str
+    stage: int
+    status: TakeProfitAttemptStatus
     amount: float
-    exit_side: str
-    orders: Sequence[_Order]
     stake_amount: float
-    trade_direction: str
+    exit_side: str
+    tag: str
+    created_at: str
+    submitted_at: str | None
+    recovery_deadline: str
+    known_order_ids: tuple[str, ...]
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "attempt_id": self.attempt_id,
+            "stage": self.stage,
+            "status": self.status,
+            "amount": self.amount,
+            "stake_amount": self.stake_amount,
+            "exit_side": self.exit_side,
+            "tag": self.tag,
+            "created_at": self.created_at,
+            "submitted_at": self.submitted_at,
+            "recovery_deadline": self.recovery_deadline,
+            "known_order_ids": list(self.known_order_ids),
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        status = value.get("status")
+        if status not in {"proposed", "submitting", "ambiguous"}:
+            raise ValueError(f"Invalid take-profit attempt status {status!r}")
+        submitted_at = value.get("submitted_at")
+        if submitted_at is not None and not isinstance(submitted_at, str):
+            raise ValueError("Invalid take-profit attempt submitted_at")
+        known_order_ids = value.get("known_order_ids")
+        if not isinstance(known_order_ids, list) or not all(
+            isinstance(order_id, str) and order_id for order_id in known_order_ids
+        ):
+            raise ValueError("Invalid take-profit attempt known_order_ids")
+        if len(known_order_ids) != len(set(known_order_ids)):
+            raise ValueError("Duplicate take-profit attempt known order")
+
+        attempt_id = _required_string(value, "attempt_id")
+        stage = _required_non_negative_int(value, "stage")
+        amount = _required_non_negative_float(value, "amount")
+        stake_amount = _required_non_negative_float(value, "stake_amount")
+        tag = _required_string(value, "tag")
+        created_at = _required_string(value, "created_at")
+        recovery_deadline = _required_string(value, "recovery_deadline")
+        created_time = _parse_iso_datetime(created_at)
+        recovery_time = _parse_iso_datetime(recovery_deadline)
+        submitted_time = (
+            _parse_iso_datetime(submitted_at) if submitted_at is not None else None
+        )
+        if amount == 0.0 or stake_amount == 0.0:
+            raise ValueError("Take-profit attempt amounts must be positive")
+        if status in {"submitting", "ambiguous"} and submitted_time is None:
+            raise ValueError("Submitted take-profit attempt has no timestamp")
+        if submitted_time is not None and submitted_time < created_time:
+            raise ValueError("Take-profit attempt was submitted before creation")
+        if recovery_time < (submitted_time or created_time):
+            raise ValueError("Take-profit recovery deadline precedes submission")
+        parsed_tag = TakeProfitStageManager.parse_order_tag(tag)
+        if parsed_tag is None or parsed_tag[1] != stage or parsed_tag[2] != attempt_id:
+            raise ValueError("Take-profit attempt tag does not match its identity")
+
+        return cls(
+            attempt_id=attempt_id,
+            stage=stage,
+            status=status,
+            amount=amount,
+            stake_amount=stake_amount,
+            exit_side=_required_string(value, "exit_side"),
+            tag=tag,
+            created_at=created_at,
+            submitted_at=submitted_at,
+            recovery_deadline=recovery_deadline,
+            known_order_ids=tuple(known_order_ids),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitStageDefinition:
+    stage: int
+    trigger_natr_fraction: float
+    exit_fraction_of_remaining: float
+
+    def __post_init__(self) -> None:
+        _non_negative_int(self.stage)
+        if (
+            not math.isfinite(self.trigger_natr_fraction)
+            or self.trigger_natr_fraction <= 0
+        ):
+            raise ValueError("Take-profit trigger NATR fraction must be positive")
+        if (
+            not math.isfinite(self.exit_fraction_of_remaining)
+            or not 0.0 < self.exit_fraction_of_remaining <= 1.0
+        ):
+            raise ValueError("Take-profit exit fraction must be in range (0, 1]")
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "trigger_natr_fraction": self.trigger_natr_fraction,
+            "exit_fraction_of_remaining": self.exit_fraction_of_remaining,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        return cls(
+            stage=_required_non_negative_int(value, "stage"),
+            trigger_natr_fraction=_required_positive_float(
+                value,
+                "trigger_natr_fraction",
+            ),
+            exit_fraction_of_remaining=_required_positive_float(
+                value,
+                "exit_fraction_of_remaining",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitFinalStageDefinition:
+    stage: int
+    trigger_natr_fraction: float
+
+    def __post_init__(self) -> None:
+        _non_negative_int(self.stage)
+        if (
+            not math.isfinite(self.trigger_natr_fraction)
+            or self.trigger_natr_fraction <= 0
+        ):
+            raise ValueError("Final take-profit trigger NATR fraction must be positive")
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "stage": self.stage,
+            "trigger_natr_fraction": self.trigger_natr_fraction,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        return cls(
+            stage=_required_non_negative_int(value, "stage"),
+            trigger_natr_fraction=_required_positive_float(
+                value,
+                "trigger_natr_fraction",
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitPlanSignature:
+    partial_stages: tuple[TakeProfitStageDefinition, ...]
+    final_stage: TakeProfitFinalStageDefinition
+
+    def __post_init__(self) -> None:
+        stages = tuple(stage.stage for stage in self.partial_stages)
+        if stages != tuple(sorted(stages)) or len(stages) != len(set(stages)):
+            raise ValueError("Take-profit partial stages must be unique and sorted")
+        expected_final_stage = max(stages, default=-1) + 1
+        if self.final_stage.stage != expected_final_stage:
+            raise ValueError(
+                f"Invalid final take-profit stage {self.final_stage.stage!r}; "
+                f"expected {expected_final_stage}"
+            )
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "partial_stages": [stage.to_mapping() for stage in self.partial_stages],
+            "final_stage": self.final_stage.to_mapping(),
+        }
+
+    def derive_stage_targets(
+        self,
+        initial_amount: float,
+    ) -> tuple[tuple[int, float], ...]:
+        remaining_amount = _non_negative_float(initial_amount)
+        targets: list[tuple[int, float]] = []
+        for definition in self.partial_stages:
+            target_amount = remaining_amount * definition.exit_fraction_of_remaining
+            targets.append((definition.stage, target_amount))
+            remaining_amount -= target_amount
+        return tuple(targets)
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        partial_raw = value.get("partial_stages")
+        final_raw = value.get("final_stage")
+        if not isinstance(partial_raw, list) or not all(
+            isinstance(stage, Mapping) for stage in partial_raw
+        ):
+            raise ValueError("Invalid take-profit partial stage plan")
+        if not isinstance(final_raw, Mapping):
+            raise ValueError("Invalid final take-profit stage plan")
+        return cls(
+            partial_stages=tuple(
+                TakeProfitStageDefinition.from_mapping(stage)
+                for stage in partial_raw
+                if isinstance(stage, Mapping)
+            ),
+            final_stage=TakeProfitFinalStageDefinition.from_mapping(final_raw),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitOperatorResolution:
+    action: TakeProfitOperatorAction
+    resolved_at: str
+    attempt_id: str | None = None
+    order_id: str | None = None
+    credited_amount: float | None = None
+    terminal_status: str | None = None
+
+    def __post_init__(self) -> None:
+        _parse_iso_datetime(self.resolved_at)
+        if self.action == "confirmed_no_remote_order":
+            _non_empty_string(self.attempt_id)
+            if (
+                self.order_id is not None
+                or self.credited_amount is not None
+                or self.terminal_status is not None
+            ):
+                raise ValueError("Ambiguous-attempt resolution has order fields")
+        elif self.action == "confirmed_terminal_zero_fill":
+            _non_empty_string(self.order_id)
+            if (
+                self.attempt_id is not None
+                or self.credited_amount != 0.0
+                or self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES
+            ):
+                raise ValueError("Terminal zero-fill resolution has invalid fields")
+        elif self.action == "revalidated_terminal_fill":
+            _non_empty_string(self.order_id)
+            if (
+                self.attempt_id is not None
+                or self.credited_amount is None
+                or self.terminal_status is not None
+            ):
+                raise ValueError("Terminal-fill resolution has invalid fields")
+            _non_negative_float(self.credited_amount)
+        else:
+            raise ValueError(f"Invalid take-profit operator action {self.action!r}")
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "action": self.action,
+            "attempt_id": self.attempt_id,
+            "order_id": self.order_id,
+            "credited_amount": self.credited_amount,
+            "terminal_status": self.terminal_status,
+            "resolved_at": self.resolved_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        action = value.get("action")
+        if action not in {
+            "confirmed_no_remote_order",
+            "confirmed_terminal_zero_fill",
+            "revalidated_terminal_fill",
+        }:
+            raise ValueError(f"Invalid take-profit operator action {action!r}")
+        attempt_id = value.get("attempt_id")
+        order_id = value.get("order_id")
+        credited_amount = value.get("credited_amount")
+        terminal_status = value.get("terminal_status")
+        return cls(
+            action=action,
+            resolved_at=_required_string(value, "resolved_at"),
+            attempt_id=(
+                _non_empty_string(attempt_id) if attempt_id is not None else None
+            ),
+            order_id=_non_empty_string(order_id) if order_id is not None else None,
+            credited_amount=(
+                _non_negative_float(credited_amount)
+                if credited_amount is not None
+                else None
+            ),
+            terminal_status=(
+                _non_empty_string(terminal_status)
+                if terminal_status is not None
+                else None
+            ),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitZeroFillProof:
+    """Immutable canonical snapshot accepted by an explicit operator action."""
+
+    order_id: str
+    order_role: TakeProfitOrderRole
+    order_side: str
+    terminal_status: str
+    amount: float
+    remaining: float
+    fee_base: float
+    confirmed_at: str
+
+    def __post_init__(self) -> None:
+        _non_empty_string(self.order_id)
+        if self.order_role not in {"strategy_exit", "external_exit"}:
+            raise ValueError("Invalid terminal zero-fill order role")
+        _non_empty_string(self.order_side)
+        if self.terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+            raise ValueError("Invalid operator-confirmed zero-fill status")
+        amount = _required_positive_value(self.amount, "zero-fill proof amount")
+        remaining = _non_negative_float(self.remaining)
+        if not math.isclose(remaining, amount, rel_tol=1e-9, abs_tol=1e-12):
+            raise ValueError("Terminal zero-fill proof has an inconsistent remainder")
+        if _non_negative_float(self.fee_base) != 0.0:
+            raise ValueError("Terminal zero-fill proof has a base fee")
+        _parse_iso_datetime(self.confirmed_at)
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "order_id": self.order_id,
+            "order_role": self.order_role,
+            "order_side": self.order_side,
+            "terminal_status": self.terminal_status,
+            "amount": self.amount,
+            "remaining": self.remaining,
+            "fee_base": self.fee_base,
+            "confirmed_at": self.confirmed_at,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        order_role = value.get("order_role")
+        if order_role not in {"strategy_exit", "external_exit"}:
+            raise ValueError("Invalid terminal zero-fill order role")
+        return cls(
+            order_id=_required_string(value, "order_id"),
+            order_role=order_role,
+            order_side=_required_string(value, "order_side"),
+            terminal_status=_required_string(value, "terminal_status"),
+            amount=_required_positive_float(value, "amount"),
+            remaining=_required_non_negative_float(value, "remaining"),
+            fee_base=_required_non_negative_float(value, "fee_base"),
+            confirmed_at=_required_string(value, "confirmed_at"),
+        )
+
+
+@dataclass(frozen=True, slots=True)
+class TakeProfitStageState:
+    version: int
+    plan_signature: TakeProfitPlanSignature
+    initial_amount: float
+    stage_targets: tuple[tuple[int, float], ...]
+    deferred_stages: tuple[int, ...]
+    attributed_order_ids: tuple[str, ...]
+    credited_order_amounts: tuple[tuple[str, float], ...]
+    entry_order_amounts: tuple[tuple[str, float], ...]
+    confirmed_zero_fill_orders: tuple[TakeProfitZeroFillProof, ...]
+    operator_resolutions: tuple[TakeProfitOperatorResolution, ...]
+    active_attempt: TakeProfitAttempt | None = None
+    blocked_reason: str | None = None
+    blocked_order_id: str | None = None
+
+    SCHEMA_VERSION = 4
+    MAX_OPERATOR_RESOLUTIONS = 32
+
+    def to_mapping(self) -> dict[str, object]:
+        return {
+            "version": self.version,
+            "plan_signature": self.plan_signature.to_mapping(),
+            "initial_amount": self.initial_amount,
+            "stage_targets": [
+                {"stage": stage, "amount": amount}
+                for stage, amount in self.stage_targets
+            ],
+            "deferred_stages": list(self.deferred_stages),
+            "attributed_order_ids": list(self.attributed_order_ids),
+            "credited_order_amounts": [
+                {"order_id": order_id, "amount": amount}
+                for order_id, amount in self.credited_order_amounts
+            ],
+            "entry_order_amounts": [
+                {"order_id": order_id, "amount": amount}
+                for order_id, amount in self.entry_order_amounts
+            ],
+            "confirmed_zero_fill_orders": [
+                proof.to_mapping() for proof in self.confirmed_zero_fill_orders
+            ],
+            "operator_resolutions": [
+                resolution.to_mapping() for resolution in self.operator_resolutions
+            ],
+            "active_attempt": (
+                self.active_attempt.to_mapping()
+                if self.active_attempt is not None
+                else None
+            ),
+            "blocked_reason": self.blocked_reason,
+            "blocked_order_id": self.blocked_order_id,
+        }
+
+    @classmethod
+    def from_mapping(cls, value: Mapping[str, object]) -> Self:
+        version = _required_non_negative_int(value, "version")
+        if version != cls.SCHEMA_VERSION:
+            raise ValueError(
+                f"Unsupported take-profit state version {version!r}; "
+                f"expected {cls.SCHEMA_VERSION}"
+            )
+
+        plan_raw = value.get("plan_signature")
+        if not isinstance(plan_raw, Mapping):
+            raise ValueError("Invalid take-profit plan signature")
+        plan_signature = TakeProfitPlanSignature.from_mapping(plan_raw)
+        initial_amount = _required_positive_float(value, "initial_amount")
+
+        stage_targets = _parse_amount_records(
+            value.get("stage_targets"),
+            identifier_key="stage",
+            identifier_parser=_non_negative_int,
+        )
+        stages = tuple(stage for stage, _ in stage_targets)
+        if len(stages) != len(set(stages)):
+            raise ValueError("Duplicate take-profit stage target")
+        planned_stages = tuple(stage.stage for stage in plan_signature.partial_stages)
+        if stages != planned_stages:
+            raise ValueError("Take-profit targets do not match the persisted plan")
+        expected_targets = plan_signature.derive_stage_targets(initial_amount)
+        if any(
+            stage != expected_stage
+            or not math.isclose(
+                amount,
+                expected_amount,
+                rel_tol=1e-9,
+                abs_tol=1e-12,
+            )
+            for (stage, amount), (expected_stage, expected_amount) in zip(
+                stage_targets,
+                expected_targets,
+                strict=True,
+            )
+        ):
+            raise ValueError("Take-profit targets do not match the persisted plan")
+
+        deferred_raw = value.get("deferred_stages")
+        if not isinstance(deferred_raw, list):
+            raise ValueError("Invalid take-profit deferred_stages")
+        deferred_stages = tuple(_non_negative_int(stage) for stage in deferred_raw)
+        if len(deferred_stages) != len(set(deferred_stages)) or not set(
+            deferred_stages
+        ).issubset(stages):
+            raise ValueError("Invalid take-profit deferred stage")
+
+        attributed_raw = value.get("attributed_order_ids")
+        if not isinstance(attributed_raw, list) or not all(
+            isinstance(order_id, str) and order_id for order_id in attributed_raw
+        ):
+            raise ValueError("Invalid take-profit attributed_order_ids")
+        attributed_order_ids = tuple(attributed_raw)
+        if len(attributed_order_ids) != len(set(attributed_order_ids)):
+            raise ValueError("Duplicate attributed take-profit order")
+
+        credited_order_amounts = _parse_amount_records(
+            value.get("credited_order_amounts"),
+            identifier_key="order_id",
+            identifier_parser=_non_empty_string,
+        )
+        if not set(order_id for order_id, _ in credited_order_amounts).issubset(
+            attributed_order_ids
+        ):
+            raise ValueError("Credited take-profit order is not attributed")
+        total_credited = math.fsum(amount for _, amount in credited_order_amounts)
+        if total_credited > initial_amount and not math.isclose(
+            total_credited,
+            initial_amount,
+            rel_tol=1e-9,
+            abs_tol=1e-12,
+        ):
+            raise ValueError("Credited take-profit amount exceeds the initial amount")
+
+        entry_order_amounts = _parse_amount_records(
+            value.get("entry_order_amounts"),
+            identifier_key="order_id",
+            identifier_parser=_non_empty_string,
+        )
+
+        proofs_raw = value.get("confirmed_zero_fill_orders")
+        if not isinstance(proofs_raw, list) or not all(
+            isinstance(proof, Mapping) for proof in proofs_raw
+        ):
+            raise ValueError("Invalid take-profit confirmed zero-fill orders")
+        confirmed_zero_fill_orders = tuple(
+            TakeProfitZeroFillProof.from_mapping(proof)
+            for proof in proofs_raw
+            if isinstance(proof, Mapping)
+        )
+        proof_order_ids = tuple(proof.order_id for proof in confirmed_zero_fill_orders)
+        if len(proof_order_ids) != len(set(proof_order_ids)):
+            raise ValueError("Duplicate terminal zero-fill proof")
+
+        resolutions_raw = value.get("operator_resolutions")
+        if not isinstance(resolutions_raw, list) or not all(
+            isinstance(resolution, Mapping) for resolution in resolutions_raw
+        ):
+            raise ValueError("Invalid take-profit operator resolutions")
+        if len(resolutions_raw) > cls.MAX_OPERATOR_RESOLUTIONS:
+            raise ValueError("Too many take-profit operator resolutions")
+        operator_resolutions = tuple(
+            TakeProfitOperatorResolution.from_mapping(resolution)
+            for resolution in resolutions_raw
+            if isinstance(resolution, Mapping)
+        )
+        resolved_attempt_ids = tuple(
+            resolution.attempt_id
+            for resolution in operator_resolutions
+            if resolution.action == "confirmed_no_remote_order"
+        )
+        if len(resolved_attempt_ids) != len(set(resolved_attempt_ids)):
+            raise ValueError("Duplicate take-profit operator resolution")
+        revalidated_order_ids = tuple(
+            resolution.order_id
+            for resolution in operator_resolutions
+            if resolution.action == "revalidated_terminal_fill"
+        )
+        if len(revalidated_order_ids) != len(set(revalidated_order_ids)):
+            raise ValueError("Duplicate take-profit terminal-fill resolution")
+
+        active_raw = value.get("active_attempt")
+        if active_raw is not None and not isinstance(active_raw, Mapping):
+            raise ValueError("Invalid take-profit active_attempt")
+        active_attempt = (
+            TakeProfitAttempt.from_mapping(active_raw)
+            if isinstance(active_raw, Mapping)
+            else None
+        )
+        if active_attempt is not None and active_attempt.stage not in stages:
+            if active_attempt.stage != plan_signature.final_stage.stage:
+                raise ValueError("Invalid take-profit attempt stage")
+        if (
+            active_attempt is not None
+            and active_attempt.attempt_id in resolved_attempt_ids
+        ):
+            raise ValueError("Resolved take-profit attempt cannot remain active")
+
+        blocked_reason = value.get("blocked_reason")
+        if blocked_reason is not None and not isinstance(blocked_reason, str):
+            raise ValueError("Invalid take-profit blocked_reason")
+        blocked_order_id = value.get("blocked_order_id")
+        if blocked_reason in _BLOCKED_ORDER_ID_REASONS:
+            blocked_order_id = _non_empty_string(blocked_order_id)
+        elif blocked_reason is None and blocked_order_id is not None:
+            raise ValueError("Take-profit blocked_order_id requires a blocked state")
+        elif blocked_order_id is not None:
+            blocked_order_id = _non_empty_string(blocked_order_id)
+
+        return cls(
+            version=version,
+            plan_signature=plan_signature,
+            initial_amount=initial_amount,
+            stage_targets=tuple(sorted(stage_targets)),
+            deferred_stages=tuple(sorted(deferred_stages)),
+            attributed_order_ids=tuple(sorted(attributed_order_ids)),
+            credited_order_amounts=tuple(sorted(credited_order_amounts)),
+            entry_order_amounts=tuple(sorted(entry_order_amounts)),
+            confirmed_zero_fill_orders=tuple(
+                sorted(
+                    confirmed_zero_fill_orders,
+                    key=lambda proof: proof.order_id,
+                )
+            ),
+            operator_resolutions=operator_resolutions,
+            active_attempt=active_attempt,
+            blocked_reason=blocked_reason,
+            blocked_order_id=blocked_order_id,
+        )
 
 
 @dataclass(frozen=True, slots=True)
@@ -26,30 +676,1171 @@ class TakeProfitStageProgress:
     filled_amount: float
     remaining_amount: float
     is_complete: bool
+    is_deferred: bool
+    has_deferred_debt: bool
 
 
 class TakeProfitStageManager:
-    """Derive take-profit progress from persisted Freqtrade orders."""
+    """Reconcile take-profit stages with causally attributed Freqtrade orders."""
 
+    STATE_KEY = "take_profit_state"
     _TAG_PREFIX = "take_profit"
+    _EMERGENCY_EXIT_TAG = "emergency_exit"
     _AMOUNT_REL_TOL = 1e-9
     _AMOUNT_ABS_TOL = 1e-12
+    _TERMINAL_STATUSES = frozenset(
+        {"canceled", "cancelled", "closed", "expired", "rejected"}
+    )
+    _ZERO_FILL_RETRY_STATUSES = frozenset({"expired", "rejected"})
 
     @classmethod
-    def order_tag(cls, trade_direction: str, stage: int) -> str:
+    def order_tag(
+        cls,
+        trade_direction: str,
+        stage: int,
+        attempt_id: str | None = None,
+    ) -> str:
         if stage < 0:
-            raise ValueError(f"Invalid take-profit stage {stage!r}: must be non-negative")
-        return f"{cls._TAG_PREFIX}_{trade_direction}_{stage}"
+            raise ValueError(
+                f"Invalid take-profit stage {stage!r}: must be non-negative"
+            )
+        tag = f"{cls._TAG_PREFIX}_{trade_direction}_{stage}"
+        if attempt_id is not None:
+            if not attempt_id or "_" in attempt_id:
+                raise ValueError(f"Invalid take-profit attempt ID {attempt_id!r}")
+            tag = f"{tag}_{attempt_id}"
+        return tag
 
     @classmethod
-    def _stage_orders(cls, trade: _Trade, stage: int) -> list[_Order]:
-        order_tag = cls.order_tag(trade.trade_direction, stage)
-        return [
-            order
-            for order in trade.orders
-            if order.ft_order_side == trade.exit_side
-            and order.ft_order_tag == order_tag
+    def has_order_tag_prefix(cls, value: object) -> bool:
+        return isinstance(value, str) and value.startswith(f"{cls._TAG_PREFIX}_")
+
+    @classmethod
+    def parse_order_tag(
+        cls,
+        tag: object,
+    ) -> tuple[str, int, str | None] | None:
+        if not isinstance(tag, str):
+            return None
+        parts = tag.split("_")
+        if len(parts) not in {4, 5} or parts[:2] != ["take", "profit"]:
+            return None
+        try:
+            stage = int(parts[3])
+        except ValueError:
+            return None
+        if stage < 0 or not parts[2]:
+            return None
+        attempt_id = parts[4] if len(parts) == 5 and parts[4] else None
+        return parts[2], stage, attempt_id
+
+    @classmethod
+    def initialize(
+        cls,
+        trade: _Trade,
+        plan_signature: TakeProfitPlanSignature,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        configured_stages = {
+            definition.stage for definition in plan_signature.partial_stages
+        }
+        strategy_exit_orders = [
+            order for order in trade.orders if order.ft_order_side == trade.exit_side
         ]
+        blocked_reason = None
+        blocked_order_id = None
+        if any(
+            order.ft_order_side == trade.entry_side and order.ft_is_open
+            for order in trade.orders
+        ):
+            blocked_reason = "open_entry_order"
+        for order in trade.orders:
+            if order.ft_order_side in {trade.entry_side, trade.exit_side}:
+                continue
+            external_block = cls._external_exit_block(order)
+            if external_block is not None and blocked_reason is None:
+                blocked_reason = external_block
+                blocked_order_id = order.order_id
+
+        terminal_credits: dict[str, float] = {}
+        for order in strategy_exit_orders:
+            if order.ft_is_open:
+                continue
+            try:
+                terminal_credits[order.order_id] = cls._terminal_credited_amount(order)
+            except ValueError:
+                if blocked_reason is None:
+                    blocked_reason = "unknown_terminal_fill"
+                    blocked_order_id = order.order_id
+
+        attributed_order_ids: set[str] = set()
+        for order in strategy_exit_orders:
+            parsed_tag = cls.parse_order_tag(order.ft_order_tag)
+            if parsed_tag is None:
+                continue
+            direction, stage, attempt_id = parsed_tag
+            if attempt_id is not None:
+                if blocked_reason is None:
+                    blocked_reason = "unknown_attempt_order"
+                    blocked_order_id = order.order_id
+                continue
+            if (
+                direction != trade.trade_direction
+                or stage not in configured_stages
+                or order.ft_order_side != trade.exit_side
+            ):
+                if terminal_credits.get(order.order_id, 0.0) > 0.0:
+                    blocked_reason = blocked_reason or "unattributed_exit_fill"
+                continue
+            attributed_order_ids.add(order.order_id)
+
+        for index, order in enumerate(strategy_exit_orders):
+            if order.ft_order_tag != cls._EMERGENCY_EXIT_TAG:
+                continue
+            predecessor = strategy_exit_orders[index - 1] if index > 0 else None
+            if predecessor is not None and cls._is_legacy_emergency_successor(
+                trade,
+                predecessor,
+                order,
+                configured_stages,
+            ):
+                attributed_order_ids.add(order.order_id)
+            elif terminal_credits.get(order.order_id, 0.0) > 0.0:
+                blocked_reason = blocked_reason or "ambiguous_legacy_exit"
+
+        credited_order_amounts: dict[str, float] = {}
+        for order in strategy_exit_orders:
+            if order.order_id in attributed_order_ids and not order.ft_is_open:
+                credited_order_amounts[order.order_id] = terminal_credits.get(
+                    order.order_id,
+                    0.0,
+                )
+            elif (
+                order.order_id not in attributed_order_ids
+                and terminal_credits.get(order.order_id, 0.0) > 0.0
+            ):
+                blocked_reason = blocked_reason or "unattributed_exit_fill"
+
+        entry_order_amounts = cls._entry_order_amounts(trade)
+        if entry_order_amounts:
+            initial_amount = cls._canonical_amount_sum(
+                entry_order_amounts.values(),
+                amount_quantizer,
+            )
+        else:
+            blocked_reason = blocked_reason or "missing_entry_exposure"
+            initial_amount = cls._canonical_amount(
+                cls._safe_amount(trade.amount),
+                amount_quantizer,
+            )
+        if initial_amount <= 0.0:
+            raise ValueError("Cannot initialize take-profit without positive exposure")
+        stage_targets = plan_signature.derive_stage_targets(initial_amount)
+
+        if not cls._trade_amount_is_consistent(
+            trade,
+            entry_order_amounts.values(),
+            credited_order_amounts.values(),
+            amount_quantizer,
+        ):
+            blocked_reason = blocked_reason or "trade_amount_mismatch"
+
+        return TakeProfitStageState(
+            version=TakeProfitStageState.SCHEMA_VERSION,
+            plan_signature=plan_signature,
+            initial_amount=initial_amount,
+            stage_targets=stage_targets,
+            deferred_stages=(),
+            attributed_order_ids=tuple(sorted(attributed_order_ids)),
+            credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
+            entry_order_amounts=tuple(sorted(entry_order_amounts.items())),
+            confirmed_zero_fill_orders=(),
+            operator_resolutions=(),
+            blocked_reason=blocked_reason,
+            blocked_order_id=blocked_order_id,
+        )
+
+    @classmethod
+    def reconcile(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        if state.blocked_reason is not None:
+            return state
+
+        orders_by_id: dict[str, _Order] = {}
+        for order in trade.orders:
+            if order.order_id in orders_by_id:
+                return cls._block(state, "duplicate_order_id")
+            orders_by_id[order.order_id] = order
+
+        confirmed_zero_fill_orders = {
+            proof.order_id: proof for proof in state.confirmed_zero_fill_orders
+        }
+        for proof in state.confirmed_zero_fill_orders:
+            order = orders_by_id.get(proof.order_id)
+            if order is None:
+                return cls._block(
+                    state,
+                    "confirmed_terminal_zero_fill_order_missing",
+                    order_id=proof.order_id,
+                )
+            if not cls._zero_fill_proof_matches(trade, order, proof):
+                return cls._block(
+                    state,
+                    "confirmed_terminal_zero_fill_changed",
+                    order_id=proof.order_id,
+                )
+
+        if any(
+            order.ft_order_side == trade.entry_side and order.ft_is_open
+            for order in trade.orders
+        ):
+            return cls._block(state, "entry_exposure_changed")
+        current_entry_amounts = cls._entry_order_amounts(trade)
+        persisted_entry_amounts = dict(state.entry_order_amounts)
+        if current_entry_amounts.keys() != persisted_entry_amounts.keys() or any(
+            not cls._amounts_close(amount, persisted_entry_amounts[order_id])
+            for order_id, amount in current_entry_amounts.items()
+        ):
+            return cls._block(state, "entry_exposure_changed")
+        try:
+            canonical_initial_amount = cls._canonical_amount_sum(
+                persisted_entry_amounts.values(),
+                amount_quantizer,
+            )
+        except ValueError:
+            return cls._block(state, "initial_exposure_mismatch")
+        if not cls._amounts_close(canonical_initial_amount, state.initial_amount):
+            return cls._block(state, "initial_exposure_mismatch")
+
+        configured_stages = {stage for stage, _ in state.stage_targets}
+        attributed_order_ids = set(state.attributed_order_ids)
+        credited_order_amounts = dict(state.credited_order_amounts)
+        strategy_exit_orders = [
+            order for order in trade.orders if order.ft_order_side == trade.exit_side
+        ]
+        for order in trade.orders:
+            if order.ft_order_side in {trade.entry_side, trade.exit_side}:
+                continue
+            external_block = cls._external_exit_block(
+                order,
+                confirmed_zero_fill_orders.get(order.order_id),
+            )
+            if external_block is not None:
+                return cls._block(
+                    state,
+                    external_block,
+                    order_id=order.order_id,
+                )
+
+        terminal_credits: dict[str, float] = {}
+        for order in strategy_exit_orders:
+            if order.ft_is_open:
+                continue
+            try:
+                terminal_credits[order.order_id] = cls._terminal_credited_amount(
+                    order,
+                    confirmed_zero_fill_orders.get(order.order_id),
+                )
+            except ValueError:
+                return cls._block(
+                    state,
+                    "unknown_terminal_fill",
+                    order_id=order.order_id,
+                )
+
+        active_attempt = state.active_attempt
+        matching_attempt_orders: list[_Order] = []
+        if active_attempt is not None:
+            same_attempt_orders = [
+                order
+                for order in strategy_exit_orders
+                if (parsed_tag := cls.parse_order_tag(order.ft_order_tag)) is not None
+                and parsed_tag[2] == active_attempt.attempt_id
+            ]
+            if len(same_attempt_orders) > 1:
+                return cls._block(
+                    state,
+                    "multiple_attempt_orders",
+                    order_id=same_attempt_orders[0].order_id,
+                )
+            matching_attempt_orders = [
+                order
+                for order in same_attempt_orders
+                if order.ft_order_tag == active_attempt.tag
+                and order.ft_order_side == active_attempt.exit_side
+            ]
+
+        for order in strategy_exit_orders:
+            if order.order_id in attributed_order_ids:
+                continue
+            parsed_tag = cls.parse_order_tag(order.ft_order_tag)
+            if parsed_tag is None:
+                continue
+            if order.order_id in confirmed_zero_fill_orders:
+                continue
+            if order in matching_attempt_orders:
+                continue
+            return cls._block(
+                state,
+                "unknown_attempt_order",
+                order_id=order.order_id,
+            )
+
+        for index, order in enumerate(strategy_exit_orders):
+            if order.order_id in attributed_order_ids:
+                continue
+            predecessor = strategy_exit_orders[index - 1] if index > 0 else None
+            if (
+                order.ft_order_tag == cls._EMERGENCY_EXIT_TAG
+                and predecessor is not None
+                and cls._is_legacy_emergency_successor(
+                    trade,
+                    predecessor,
+                    order,
+                    configured_stages,
+                )
+            ):
+                attributed_order_ids.add(order.order_id)
+
+        if active_attempt is not None:
+            attributed_order_ids.update(
+                order.order_id for order in matching_attempt_orders
+            )
+
+            if not matching_attempt_orders and active_attempt.status in {
+                "submitting",
+                "ambiguous",
+            }:
+                recovered_candidates = [
+                    order
+                    for order in strategy_exit_orders
+                    if cls._is_recovered_attempt_candidate(order, active_attempt)
+                ]
+                if len(recovered_candidates) == 1:
+                    matching_attempt_orders = recovered_candidates
+                    attributed_order_ids.add(recovered_candidates[0].order_id)
+                elif len(recovered_candidates) > 1:
+                    return cls._block(state, "ambiguous_recovered_exit")
+
+        for order_id in attributed_order_ids:
+            order = orders_by_id.get(order_id)
+            if order is None:
+                return cls._block(state, "attributed_order_missing")
+            if order.ft_order_side != trade.exit_side:
+                return cls._block(state, "attributed_order_side_changed")
+            previous_amount = credited_order_amounts.get(order_id)
+            if order.ft_is_open:
+                if previous_amount is not None:
+                    return cls._block(state, "attributed_order_reopened")
+                continue
+            current_amount = terminal_credits[order_id]
+            if (
+                previous_amount is not None
+                and current_amount < previous_amount
+                and not (cls._amounts_close(current_amount, previous_amount))
+            ):
+                return cls._block(state, "attributed_fill_regressed")
+            credited_order_amounts[order_id] = current_amount
+
+        total_credited = math.fsum(credited_order_amounts.values())
+        if total_credited > state.initial_amount and not cls._amounts_close(
+            total_credited,
+            state.initial_amount,
+        ):
+            return cls._block(state, "credited_fill_exceeds_initial_amount")
+
+        for order in strategy_exit_orders:
+            if (
+                order.order_id not in attributed_order_ids
+                and terminal_credits.get(order.order_id, 0.0) > 0.0
+            ):
+                return cls._block(state, "unattributed_exit_fill")
+
+        if not cls._trade_amount_is_consistent(
+            trade,
+            persisted_entry_amounts.values(),
+            credited_order_amounts.values(),
+            amount_quantizer,
+        ):
+            return cls._block(state, "trade_amount_mismatch")
+
+        if matching_attempt_orders:
+            active_attempt = None
+
+        return replace(
+            state,
+            attributed_order_ids=tuple(sorted(attributed_order_ids)),
+            credited_order_amounts=tuple(sorted(credited_order_amounts.items())),
+            active_attempt=active_attempt,
+        )
+
+    @classmethod
+    def get_stage_progress(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        stage: int,
+    ) -> TakeProfitStageProgress:
+        targets = dict(state.stage_targets)
+        if stage not in targets:
+            raise ValueError(f"Unknown take-profit stage {stage!r}")
+        ordered_stages = [
+            configured_stage for configured_stage, _ in state.stage_targets
+        ]
+        stage_index = ordered_stages.index(stage)
+        cumulative_target_before = math.fsum(
+            targets[configured_stage]
+            for configured_stage in ordered_stages[:stage_index]
+        )
+        cumulative_target = cumulative_target_before + targets[stage]
+        cumulative_filled = math.fsum(
+            amount for _, amount in state.credited_order_amounts
+        )
+        filled_amount = min(
+            targets[stage],
+            max(0.0, cumulative_filled - cumulative_target_before),
+        )
+        remaining_amount = max(0.0, cumulative_target - cumulative_filled)
+        is_filled = cumulative_filled >= cumulative_target or cls._amounts_close(
+            cumulative_filled,
+            cumulative_target,
+        )
+        deferred_stages = set(state.deferred_stages)
+        return TakeProfitStageProgress(
+            stage=stage,
+            target_amount=targets[stage],
+            filled_amount=filled_amount,
+            remaining_amount=0.0 if is_filled else remaining_amount,
+            is_complete=is_filled,
+            is_deferred=stage in deferred_stages,
+            has_deferred_debt=any(
+                deferred_stage <= stage for deferred_stage in deferred_stages
+            )
+            and remaining_amount > 0.0,
+        )
+
+    @classmethod
+    def get_exit_stage(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+    ) -> int:
+        cumulative_filled = math.fsum(
+            amount for _, amount in state.credited_order_amounts
+        )
+        cumulative_target = 0.0
+        deferred_stages = set(state.deferred_stages)
+        for stage, target in state.stage_targets:
+            cumulative_target += target
+            is_filled = cumulative_filled >= cumulative_target or cls._amounts_close(
+                cumulative_filled,
+                cumulative_target,
+            )
+            if stage in deferred_stages or is_filled:
+                continue
+            return stage
+        return state.plan_signature.final_stage.stage
+
+    @classmethod
+    def get_expected_trade_amount(
+        cls,
+        state: TakeProfitStageState,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> float:
+        return cls._canonical_signed_amount_sum(
+            (amount for _, amount in state.entry_order_amounts),
+            (amount for _, amount in state.credited_order_amounts),
+            amount_quantizer,
+        )
+
+    @classmethod
+    def get_trade_amount_delta(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> float:
+        expected = cls.get_expected_trade_amount(
+            state,
+            amount_quantizer=amount_quantizer,
+        )
+        observed = cls._canonical_amount(trade.amount, amount_quantizer)
+        return observed - expected
+
+    @staticmethod
+    def defer_stage(
+        state: TakeProfitStageState,
+        stage: int,
+    ) -> TakeProfitStageState:
+        if stage not in dict(state.stage_targets):
+            raise ValueError(f"Unknown take-profit stage {stage!r}")
+        return replace(
+            state,
+            deferred_stages=tuple(sorted({*state.deferred_stages, stage})),
+        )
+
+    @classmethod
+    def start_attempt(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        *,
+        stage: int,
+        amount: float,
+        stake_amount: float,
+        attempt_id: str,
+        status: TakeProfitAttemptStatus,
+        current_time: datetime.datetime,
+        recovery_deadline: datetime.datetime,
+    ) -> TakeProfitStageState:
+        if state.blocked_reason is not None:
+            raise ValueError(
+                "Cannot start a take-profit attempt while state is blocked"
+            )
+        if state.active_attempt is not None:
+            raise ValueError("A take-profit attempt is already active")
+        final_stage = state.plan_signature.final_stage.stage
+        if stage not in dict(state.stage_targets) and stage != final_stage:
+            raise ValueError(f"Unknown take-profit stage {stage!r}")
+        if status not in {"proposed", "submitting"}:
+            raise ValueError(f"Invalid initial take-profit attempt status {status!r}")
+        if current_time.tzinfo is None or recovery_deadline.tzinfo is None:
+            raise ValueError("Take-profit attempt timestamps must be timezone-aware")
+        if recovery_deadline < current_time:
+            raise ValueError("Take-profit recovery deadline precedes creation")
+        amount = cls._safe_amount(amount)
+        stake_amount = cls._safe_amount(stake_amount)
+        if amount == 0.0 or stake_amount == 0.0:
+            raise ValueError("Take-profit attempt amounts must be positive")
+        tag = cls.order_tag(trade.trade_direction, stage, attempt_id)
+        submitted_at = current_time.isoformat() if status == "submitting" else None
+        return replace(
+            state,
+            active_attempt=TakeProfitAttempt(
+                attempt_id=attempt_id,
+                stage=stage,
+                status=status,
+                amount=amount,
+                stake_amount=stake_amount,
+                exit_side=trade.exit_side,
+                tag=tag,
+                created_at=current_time.isoformat(),
+                submitted_at=submitted_at,
+                recovery_deadline=recovery_deadline.isoformat(),
+                known_order_ids=tuple(sorted(order.order_id for order in trade.orders)),
+            ),
+        )
+
+    @staticmethod
+    def mark_submitting(
+        state: TakeProfitStageState,
+        attempt_id: str,
+        current_time: datetime.datetime,
+    ) -> TakeProfitStageState:
+        attempt = state.active_attempt
+        if attempt is None or attempt.attempt_id != attempt_id:
+            return state
+        if attempt.status != "proposed":
+            return state
+        if current_time.tzinfo is None:
+            raise ValueError("Take-profit submission timestamp must be timezone-aware")
+        created_at = _parse_iso_datetime(attempt.created_at)
+        if current_time < created_at:
+            raise ValueError("Take-profit attempt was submitted before creation")
+        recovery_window = _parse_iso_datetime(attempt.recovery_deadline) - created_at
+        return replace(
+            state,
+            active_attempt=replace(
+                attempt,
+                status="submitting",
+                submitted_at=current_time.isoformat(),
+                recovery_deadline=(current_time + recovery_window).isoformat(),
+            ),
+        )
+
+    @classmethod
+    def update_attempt_amount(
+        cls,
+        state: TakeProfitStageState,
+        attempt_id: str,
+        amount: float,
+        stake_amount: float,
+    ) -> TakeProfitStageState:
+        attempt = state.active_attempt
+        if attempt is None or attempt.attempt_id != attempt_id:
+            return state
+        amount = cls._safe_amount(amount)
+        stake_amount = cls._safe_amount(stake_amount)
+        if amount == 0.0 or stake_amount == 0.0:
+            raise ValueError("Take-profit attempt amounts must be positive")
+        return replace(
+            state,
+            active_attempt=replace(
+                attempt,
+                amount=amount,
+                stake_amount=stake_amount,
+            ),
+        )
+
+    @staticmethod
+    def mark_ambiguous(
+        state: TakeProfitStageState,
+        attempt_id: str,
+    ) -> TakeProfitStageState:
+        attempt = state.active_attempt
+        if attempt is None or attempt.attempt_id != attempt_id:
+            return state
+        if attempt.status == "ambiguous":
+            return state
+        if attempt.status != "submitting":
+            raise ValueError(
+                "Only a submitting take-profit attempt can become ambiguous"
+            )
+        return replace(state, active_attempt=replace(attempt, status="ambiguous"))
+
+    @staticmethod
+    def discard_proposed_attempt(
+        state: TakeProfitStageState,
+    ) -> TakeProfitStageState:
+        attempt = state.active_attempt
+        if attempt is None or attempt.status != "proposed":
+            return state
+        return replace(state, active_attempt=None)
+
+    @classmethod
+    def resolve_ambiguous_attempt(
+        cls,
+        state: TakeProfitStageState,
+        attempt_id: str,
+        resolved_at: datetime.datetime,
+    ) -> TakeProfitStageState:
+        attempt = state.active_attempt
+        if (
+            attempt is None
+            or attempt.attempt_id != attempt_id
+            or attempt.status != "ambiguous"
+        ):
+            raise ValueError("No matching ambiguous take-profit attempt")
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        recovery_deadline = _parse_iso_datetime(attempt.recovery_deadline)
+        if resolved_at < recovery_deadline:
+            raise ValueError(
+                "Take-profit attempt cannot be cleared before its recovery deadline"
+            )
+        resolution = TakeProfitOperatorResolution(
+            action="confirmed_no_remote_order",
+            attempt_id=attempt_id,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            state,
+            active_attempt=None,
+            operator_resolutions=cls._append_operator_resolution(state, resolution),
+        )
+
+    @classmethod
+    def revalidate_unknown_terminal_fill(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Reconcile one repaired canonical order and record the operator action."""
+        order_id = _non_empty_string(order_id)
+        if (
+            state.blocked_reason != "unknown_terminal_fill"
+            or state.blocked_order_id != order_id
+        ):
+            raise ValueError("No matching unknown terminal fill to revalidate")
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+
+        matching_orders = [
+            order for order in trade.orders if order.order_id == order_id
+        ]
+        if len(matching_orders) != 1:
+            raise ValueError("Expected exactly one matching canonical order")
+        order = matching_orders[0]
+        if order.ft_order_side != trade.exit_side or order.ft_is_open:
+            raise ValueError("Revalidated order is not a terminal strategy exit")
+        credited_amount = cls._terminal_credited_amount(order)
+
+        candidate = replace(
+            state,
+            blocked_reason=None,
+            blocked_order_id=None,
+        )
+        reconciled = cls.reconcile(
+            trade,
+            candidate,
+            amount_quantizer=amount_quantizer,
+        )
+        if reconciled.blocked_reason is not None:
+            raise ValueError(
+                "Canonical order repair does not produce a valid take-profit state: "
+                f"{reconciled.blocked_reason}"
+            )
+
+        attributed = order_id in reconciled.attributed_order_ids
+        persisted_credit = dict(reconciled.credited_order_amounts).get(order_id)
+        if credited_amount > 0.0 and not attributed:
+            raise ValueError("Positive terminal fill is not attributed to take-profit")
+        if attributed and (
+            persisted_credit is None
+            or not cls._amounts_close(persisted_credit, credited_amount)
+        ):
+            raise ValueError("Revalidated take-profit credit does not match the order")
+
+        resolution = TakeProfitOperatorResolution(
+            action="revalidated_terminal_fill",
+            order_id=order_id,
+            credited_amount=credited_amount,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            reconciled,
+            operator_resolutions=cls._append_operator_resolution(
+                reconciled,
+                resolution,
+            ),
+        )
+
+    @classmethod
+    def confirm_terminal_zero_fill(
+        cls,
+        trade: _Trade,
+        state: TakeProfitStageState,
+        order_id: str,
+        terminal_status: str,
+        resolved_at: datetime.datetime,
+        *,
+        amount_quantizer: Callable[[float], float] | None = None,
+    ) -> TakeProfitStageState:
+        """Persist an exact operator-verified canceled zero-fill snapshot."""
+        order_id = _non_empty_string(order_id)
+        terminal_status = _non_empty_string(terminal_status).lower()
+        if terminal_status not in _OPERATOR_ZERO_FILL_STATUSES:
+            raise ValueError("Terminal zero-fill status is not operator-recoverable")
+        if (
+            state.blocked_reason
+            not in {"unknown_terminal_fill", "unknown_external_exit_fill"}
+            or state.blocked_order_id != order_id
+        ):
+            raise ValueError("No matching unknown terminal fill to confirm")
+        if resolved_at.tzinfo is None:
+            raise ValueError("Take-profit resolution timestamp must be timezone-aware")
+        if any(
+            proof.order_id == order_id for proof in state.confirmed_zero_fill_orders
+        ):
+            raise ValueError("Terminal zero-fill order is already confirmed")
+
+        matching_orders = [
+            order for order in trade.orders if order.order_id == order_id
+        ]
+        if len(matching_orders) != 1:
+            raise ValueError("Expected exactly one matching canonical order")
+        proof = cls._build_zero_fill_proof(
+            trade,
+            matching_orders[0],
+            terminal_status,
+            resolved_at,
+        )
+        candidate = replace(
+            state,
+            confirmed_zero_fill_orders=tuple(
+                sorted(
+                    (*state.confirmed_zero_fill_orders, proof),
+                    key=lambda item: item.order_id,
+                )
+            ),
+            blocked_reason=None,
+            blocked_order_id=None,
+        )
+        reconciled = cls.reconcile(
+            trade,
+            candidate,
+            amount_quantizer=amount_quantizer,
+        )
+        if reconciled.blocked_reason in {
+            "confirmed_terminal_zero_fill_changed",
+            "confirmed_terminal_zero_fill_order_missing",
+        }:
+            raise ValueError("Terminal zero-fill proof failed its postcondition")
+
+        resolution = TakeProfitOperatorResolution(
+            action="confirmed_terminal_zero_fill",
+            order_id=order_id,
+            credited_amount=0.0,
+            terminal_status=terminal_status,
+            resolved_at=resolved_at.isoformat(),
+        )
+        return replace(
+            reconciled,
+            operator_resolutions=cls._append_operator_resolution(
+                reconciled,
+                resolution,
+            ),
+        )
+
+    @staticmethod
+    def _append_operator_resolution(
+        state: TakeProfitStageState,
+        resolution: TakeProfitOperatorResolution,
+    ) -> tuple[TakeProfitOperatorResolution, ...]:
+        return (*state.operator_resolutions, resolution)[
+            -TakeProfitStageState.MAX_OPERATOR_RESOLUTIONS :
+        ]
+
+    @classmethod
+    def _entry_order_amounts(cls, trade: _Trade) -> dict[str, float]:
+        return {
+            order.order_id: cls._safe_amount(order.safe_amount_after_fee)
+            for order in trade.orders
+            if order.ft_order_side == trade.entry_side
+            and not order.ft_is_open
+            and cls._safe_amount(order.safe_amount_after_fee) > 0.0
+        }
+
+    @classmethod
+    def _terminal_credited_amount(
+        cls,
+        order: _Order,
+        zero_fill_proof: TakeProfitZeroFillProof | None = None,
+    ) -> float:
+        if order.ft_is_open:
+            return 0.0
+
+        amount = _non_negative_float(order.safe_amount)
+        if amount == 0.0:
+            raise ValueError("Terminal order has no amount")
+
+        status = (order.status or "").lower()
+        if status not in cls._TERMINAL_STATUSES:
+            raise ValueError("Order is closed locally without a terminal status")
+
+        remaining = (
+            _non_negative_float(order.remaining)
+            if order.remaining is not None
+            else None
+        )
+        if order.filled is None:
+            raise ValueError("Terminal order fill is unknown")
+        filled = _non_negative_float(order.filled)
+
+        if filled > amount and not cls._amounts_close(filled, amount):
+            raise ValueError("Terminal order fill exceeds its amount")
+        filled = min(filled, amount)
+        if remaining is not None and (
+            remaining > amount or not cls._amounts_close(filled + remaining, amount)
+        ):
+            raise ValueError("Terminal order fill and remainder are inconsistent")
+
+        fee_base = (
+            _non_negative_float(order.ft_fee_base)
+            if order.ft_fee_base is not None
+            else 0.0
+        )
+        if fee_base > filled and not cls._amounts_close(fee_base, filled):
+            raise ValueError("Terminal order base fee exceeds its fill")
+
+        if filled == 0.0:
+            allowed_statuses = cls._ZERO_FILL_RETRY_STATUSES
+            if zero_fill_proof is not None:
+                if not cls._zero_fill_proof_fields_match(order, zero_fill_proof):
+                    raise ValueError("Terminal zero-fill proof no longer matches")
+                allowed_statuses = allowed_statuses | {zero_fill_proof.terminal_status}
+            cls._validate_terminal_zero_fill(order, allowed_statuses)
+            return 0.0
+
+        if status == "rejected" or order.order_filled_utc is None:
+            raise ValueError("Terminal positive fill is not explicitly observed")
+        if filled < amount and remaining is None:
+            raise ValueError("Terminal partial fill has no reported remainder")
+        if fee_base >= filled or cls._amounts_close(fee_base, filled):
+            raise ValueError("Terminal order base fee consumes its entire fill")
+
+        return filled - fee_base
+
+    @classmethod
+    def _external_exit_block(
+        cls,
+        order: _Order,
+        zero_fill_proof: TakeProfitZeroFillProof | None = None,
+    ) -> str | None:
+        try:
+            amount = _required_positive_value(
+                order.safe_amount,
+                "external exit amount",
+            )
+            filled = (
+                _non_negative_float(order.filled) if order.filled is not None else None
+            )
+            fee_base = (
+                _non_negative_float(order.ft_fee_base)
+                if order.ft_fee_base is not None
+                else 0.0
+            )
+        except ValueError:
+            return "unknown_external_exit_fill"
+        if filled is not None and filled > 0.0:
+            return "external_exit_fill"
+        if order.ft_is_open:
+            if fee_base != 0.0:
+                return "unknown_external_exit_fill"
+            if order.remaining is not None:
+                try:
+                    remaining = _non_negative_float(order.remaining)
+                except ValueError:
+                    return "unknown_external_exit_fill"
+                if not cls._amounts_close(remaining, amount):
+                    return "unknown_external_exit_fill"
+            return None
+        try:
+            credited_amount = cls._terminal_credited_amount(order, zero_fill_proof)
+        except ValueError:
+            return "unknown_external_exit_fill"
+        return "external_exit_fill" if credited_amount > 0.0 else None
+
+    @classmethod
+    def _build_zero_fill_proof(
+        cls,
+        trade: _Trade,
+        order: _Order,
+        terminal_status: str,
+        confirmed_at: datetime.datetime,
+    ) -> TakeProfitZeroFillProof:
+        if order.ft_order_side == trade.exit_side:
+            order_role: TakeProfitOrderRole = "strategy_exit"
+        elif order.ft_order_side != trade.entry_side:
+            order_role = "external_exit"
+        else:
+            raise ValueError("Entry orders cannot be confirmed as terminal exits")
+        if (order.status or "").lower() != terminal_status:
+            raise ValueError("Canonical order status does not match terminal-status")
+        amount, remaining, fee_base = cls._validate_terminal_zero_fill(
+            order,
+            _OPERATOR_ZERO_FILL_STATUSES,
+        )
+        return TakeProfitZeroFillProof(
+            order_id=order.order_id,
+            order_role=order_role,
+            order_side=order.ft_order_side,
+            terminal_status=terminal_status,
+            amount=amount,
+            remaining=remaining,
+            fee_base=fee_base,
+            confirmed_at=confirmed_at.isoformat(),
+        )
+
+    @classmethod
+    def _zero_fill_proof_matches(
+        cls,
+        trade: _Trade,
+        order: _Order,
+        proof: TakeProfitZeroFillProof,
+    ) -> bool:
+        if proof.order_role == "strategy_exit":
+            expected_side = trade.exit_side
+        else:
+            if order.ft_order_side in {trade.entry_side, trade.exit_side}:
+                return False
+            expected_side = proof.order_side
+        if order.ft_order_side != expected_side:
+            return False
+        return cls._zero_fill_proof_fields_match(order, proof)
+
+    @classmethod
+    def _zero_fill_proof_fields_match(
+        cls,
+        order: _Order,
+        proof: TakeProfitZeroFillProof,
+    ) -> bool:
+        try:
+            amount, remaining, fee_base = cls._validate_terminal_zero_fill(
+                order,
+                {proof.terminal_status},
+            )
+        except ValueError:
+            return False
+        return (
+            order.order_id == proof.order_id
+            and order.ft_order_side == proof.order_side
+            and (order.status or "").lower() == proof.terminal_status
+            and amount == proof.amount
+            and remaining == proof.remaining
+            and fee_base == proof.fee_base
+        )
+
+    @classmethod
+    def _validate_terminal_zero_fill(
+        cls,
+        order: _Order,
+        allowed_statuses: set[str] | frozenset[str],
+    ) -> tuple[float, float, float]:
+        if order.ft_is_open:
+            raise ValueError("Terminal zero-fill order is open")
+        status = (order.status or "").lower()
+        if status not in allowed_statuses:
+            raise ValueError("Terminal zero-fill status is not retryable")
+        amount = _required_positive_value(order.safe_amount, "terminal order amount")
+        if order.filled is None or _non_negative_float(order.filled) != 0.0:
+            raise ValueError("Terminal zero-fill order has no explicit zero fill")
+        if order.remaining is None:
+            raise ValueError("Terminal zero-fill order has no explicit remainder")
+        remaining = _non_negative_float(order.remaining)
+        if not cls._amounts_close(remaining, amount):
+            raise ValueError("Terminal zero-fill remainder is inconsistent")
+        fee_base = (
+            _non_negative_float(order.ft_fee_base)
+            if order.ft_fee_base is not None
+            else 0.0
+        )
+        if fee_base != 0.0:
+            raise ValueError("Terminal zero-fill order has a base fee")
+        if order.order_filled_utc is not None:
+            raise ValueError("Terminal zero-fill order has a fill timestamp")
+        return amount, remaining, fee_base
+
+    @classmethod
+    def _canonical_amount(
+        cls,
+        value: object,
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> float:
+        amount = _non_negative_float(value)
+        if amount_quantizer is not None:
+            amount = _non_negative_float(amount_quantizer(amount))
+        return amount
+
+    @classmethod
+    def _canonical_amount_sum(
+        cls,
+        amounts: Iterable[float],
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> float:
+        precise_amount = Decimal(0)
+        for amount in amounts:
+            precise_amount += Decimal(str(_non_negative_float(amount)))
+        return cls._canonical_amount(float(precise_amount), amount_quantizer)
+
+    @classmethod
+    def _canonical_signed_amount_sum(
+        cls,
+        entry_amounts: Iterable[float],
+        exit_amounts: Iterable[float],
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> float:
+        precise_amount = Decimal(0)
+        for amount in entry_amounts:
+            precise_amount += Decimal(str(_non_negative_float(amount)))
+        for amount in exit_amounts:
+            precise_amount -= Decimal(str(_non_negative_float(amount)))
+        if precise_amount < 0:
+            return float(precise_amount)
+        return cls._canonical_amount(float(precise_amount), amount_quantizer)
+
+    @classmethod
+    def _trade_amount_is_consistent(
+        cls,
+        trade: _Trade,
+        entry_amounts: Iterable[float],
+        credited_amounts: Iterable[float],
+        amount_quantizer: Callable[[float], float] | None,
+    ) -> bool:
+        try:
+            expected_amount = cls._canonical_signed_amount_sum(
+                entry_amounts,
+                credited_amounts,
+                amount_quantizer,
+            )
+            observed_amount = cls._canonical_amount(
+                trade.amount,
+                amount_quantizer,
+            )
+        except ValueError:
+            return False
+        return expected_amount >= 0.0 and cls._amounts_close(
+            observed_amount,
+            expected_amount,
+        )
+
+    @classmethod
+    def _is_legacy_emergency_successor(
+        cls,
+        trade: _Trade,
+        predecessor: _Order,
+        emergency_order: _Order,
+        configured_stages: set[int],
+    ) -> bool:
+        parsed_tag = cls.parse_order_tag(predecessor.ft_order_tag)
+        if parsed_tag is None:
+            return False
+        direction, stage, _ = parsed_tag
+        remaining_amount = cls._safe_amount(predecessor.safe_remaining)
+        return (
+            direction == trade.trade_direction
+            and stage in configured_stages
+            and not predecessor.ft_is_open
+            and predecessor.ft_order_side == trade.exit_side
+            and emergency_order.ft_order_side == trade.exit_side
+            and remaining_amount > 0.0
+            and cls._amounts_close(
+                cls._safe_amount(emergency_order.safe_amount),
+                remaining_amount,
+            )
+        )
+
+    @classmethod
+    def _is_recovered_attempt_candidate(
+        cls,
+        order: _Order,
+        attempt: TakeProfitAttempt,
+    ) -> bool:
+        if (
+            order.order_id in attempt.known_order_ids
+            or order.ft_order_tag is not None
+            or order.ft_order_side != attempt.exit_side
+            or not cls._amounts_close(
+                cls._safe_amount(order.safe_amount),
+                attempt.amount,
+            )
+            or attempt.submitted_at is None
+        ):
+            return False
+        submitted_at = datetime.datetime.fromisoformat(attempt.submitted_at)
+        recovery_deadline = datetime.datetime.fromisoformat(attempt.recovery_deadline)
+        return submitted_at <= order.order_date_utc <= recovery_deadline
+
+    @staticmethod
+    def _block(
+        state: TakeProfitStageState,
+        reason: str,
+        *,
+        order_id: str | None = None,
+    ) -> TakeProfitStageState:
+        if reason in _BLOCKED_ORDER_ID_REASONS:
+            order_id = _non_empty_string(order_id)
+        elif order_id is not None:
+            order_id = _non_empty_string(order_id)
+        if state.blocked_reason is not None:
+            return state
+        return replace(
+            state,
+            blocked_reason=reason,
+            blocked_order_id=order_id,
+        )
 
     @staticmethod
     def _safe_amount(value: object) -> float:
@@ -60,74 +1851,91 @@ class TakeProfitStageManager:
         return amount if math.isfinite(amount) and amount > 0.0 else 0.0
 
     @classmethod
-    def get_stage_progress(
-        cls,
-        trade: _Trade,
-        stage: int,
-        stake_fraction: float,
-    ) -> TakeProfitStageProgress:
-        if not 0.0 < stake_fraction <= 1.0:
-            raise ValueError(
-                f"Invalid take-profit stake fraction {stake_fraction!r}: "
-                "must be in range (0, 1]"
-            )
-
-        orders = cls._stage_orders(trade, stage)
-        target_amount = next(
-            (
-                amount
-                for order in orders
-                if (amount := cls._safe_amount(order.safe_amount)) > 0.0
-            ),
-            cls._safe_amount(trade.amount) * stake_fraction,
-        )
-        filled_amount = sum(cls._safe_amount(order.safe_filled) for order in orders)
-        remaining_amount = max(0.0, target_amount - filled_amount)
-        is_filled = filled_amount >= target_amount or math.isclose(
-            filled_amount,
-            target_amount,
+    def _amounts_close(cls, left: float, right: float) -> bool:
+        return math.isclose(
+            left,
+            right,
             rel_tol=cls._AMOUNT_REL_TOL,
             abs_tol=cls._AMOUNT_ABS_TOL,
         )
-        is_complete = bool(orders) and is_filled and not any(
-            order.ft_is_open for order in orders
-        )
 
-        return TakeProfitStageProgress(
-            stage=stage,
-            target_amount=target_amount,
-            filled_amount=filled_amount,
-            remaining_amount=remaining_amount,
-            is_complete=is_complete,
-        )
 
-    @classmethod
-    def get_exit_stage(
-        cls,
-        trade: _Trade,
-        stage_stake_fractions: Mapping[int, float],
-    ) -> int:
-        for stage in sorted(stage_stake_fractions):
-            progress = cls.get_stage_progress(
-                trade,
-                stage,
-                stage_stake_fractions[stage],
+def _required_string(value: Mapping[str, object], key: str) -> str:
+    return _non_empty_string(value.get(key))
+
+
+def _required_non_negative_int(value: Mapping[str, object], key: str) -> int:
+    return _non_negative_int(value.get(key))
+
+
+def _required_non_negative_float(value: Mapping[str, object], key: str) -> float:
+    return _non_negative_float(value.get(key))
+
+
+def _required_positive_float(value: Mapping[str, object], key: str) -> float:
+    return _required_positive_value(value.get(key), key)
+
+
+def _required_positive_value(value: object, name: str) -> float:
+    parsed = _non_negative_float(value)
+    if parsed == 0.0:
+        raise ValueError(f"Invalid positive float value for {name!r}")
+    return parsed
+
+
+def _non_empty_string(value: object) -> str:
+    if not isinstance(value, str) or not value:
+        raise ValueError(f"Invalid non-empty string value {value!r}")
+    return value
+
+
+def _non_negative_int(value: object) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or value < 0:
+        raise ValueError(f"Invalid non-negative integer value {value!r}")
+    return value
+
+
+def _non_negative_float(value: object) -> float:
+    if isinstance(value, bool):
+        raise ValueError(f"Invalid non-negative float value {value!r}")
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError) as error:
+        raise ValueError(f"Invalid non-negative float value {value!r}") from error
+    if not math.isfinite(parsed) or parsed < 0.0:
+        raise ValueError(f"Invalid non-negative float value {value!r}")
+    return parsed
+
+
+def _parse_iso_datetime(value: str) -> datetime.datetime:
+    try:
+        parsed = datetime.datetime.fromisoformat(value)
+    except ValueError as error:
+        raise ValueError(f"Invalid ISO datetime value {value!r}") from error
+    if parsed.tzinfo is None:
+        raise ValueError(f"Timezone-naive datetime value {value!r}")
+    return parsed
+
+
+def _parse_amount_records(
+    value: object,
+    *,
+    identifier_key: str,
+    identifier_parser: Callable[[object], object],
+) -> tuple[tuple, ...]:
+    if not isinstance(value, list):
+        raise ValueError(f"Invalid take-profit {identifier_key} amount records")
+    records = []
+    for record in value:
+        if not isinstance(record, Mapping):
+            raise ValueError(f"Invalid take-profit {identifier_key} amount record")
+        records.append(
+            (
+                identifier_parser(record.get(identifier_key)),
+                _non_negative_float(record.get("amount")),
             )
-            if not progress.is_complete:
-                return stage
-        return max(stage_stake_fractions, default=-1) + 1
-
-    @classmethod
-    def get_remaining_stake_amount(
-        cls,
-        trade: _Trade,
-        progress: TakeProfitStageProgress,
-    ) -> float:
-        trade_amount = cls._safe_amount(trade.amount)
-        trade_stake_amount = cls._safe_amount(trade.stake_amount)
-        if trade_amount == 0.0 or trade_stake_amount == 0.0:
-            return 0.0
-        remaining_stake_amount = (
-            progress.remaining_amount * trade_stake_amount / trade_amount
         )
-        return min(trade_stake_amount, remaining_stake_amount)
+    identifiers = [identifier for identifier, _ in records]
+    if len(identifiers) != len(set(identifiers)):
+        raise ValueError(f"Duplicate take-profit {identifier_key} amount record")
+    return tuple(records)


### PR DESCRIPTION
## Summary

- persist take-profit intent before CEX submission and credit progression only from causally attributed terminal fills
- reconcile Freqtrade wallet fallbacks on the canonical ORM trade without advancing a stage on failed or ambiguous exits
- wait for finalized spot entry fees before initializing exposure, while preserving ordinary non-take-profit exits
- preflight live partial exits against canonical exposure, sell-side free balance, and Freqtrade's exchange minimum
- require a fresh post-deadline inspection before issuing an ambiguous-clear confirmation token
- document the recovery workflow

## Root cause

The strategy derived take-profit progression from successful and open exit counts. This conflated local intent and order lifecycle with confirmed CEX execution. Freqtrade can also adjust the canonical trade amount before `confirm_trade_exit()` receives its defensive copy, while CEX submission, cancellation, refresh, and custom-data persistence failures can leave incomplete evidence. Exposure, retry state, and stage credit could therefore diverge after an unsuccessful exit.

## Design and impact

- stage scheduling is separate from credited execution; only attributable terminal fills advance progress
- failed, rejected, canceled, expired, zero-fill, partial-fill, and ambiguous outcomes have explicit fail-closed transitions
- native wallet fallbacks are captured from the ORM trade, persisted before take-profit submission, and restored only when the corresponding state was not persisted
- spot-like ledger initialization waits for finalized entry fees; before then, a non-take-profit strategy exit remains available when no ledger or open order exists
- live partial-exit preflight requires total base-asset coverage of canonical exposure and enough free base balance for a sell order; buy-to-cover exits do not inherit that sell-side constraint
- live exit minimums delegate to Freqtrade's exchange calculation; backtests retain the callback-provided minimum
- custom-data transaction recovery targets Freqtrade's dedicated custom-data session without rolling back the trade session
- operator maintenance remains evidence-bound to the complete persisted state and canonical order fingerprint; ambiguous-clear tokens are withheld until the recovery deadline
- the unmerged feature uses one strict schema without compatibility aliases

Failed take-profit submission or execution no longer advances the stage or tightens its dependent stoploss. Safety exits remain available, and automatic take-profit resumes only after canonical evidence reconciles exactly.

## Validation

- 222/222 local tests passed in `freqtradeorg/freqtrade:2026.6_freqai`
- Ruff check and format validation
- `compileall` and `git diff --check`

Tests are intentionally local and are not included in this PR.
