### PR TITLE
fix(quickadapter): sample PnL momentum per candle

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -498,8 +498,8 @@ class QuickAdapterV3(IStrategy):
                 self._pnl_momentum_window_size - 1
             ) * self.timeframe_minutes
             logger.warning(
-                f"Timeframe {self.timeframe}: a 30-minute PnL momentum window has "
-                f"only {nominal_pnl_momentum_window_size} samples "
+                f"Timeframe {self.timeframe}: the nominal 30-minute PnL momentum "
+                f"window resolves to only {nominal_pnl_momentum_window_size} samples "
                 f"(< {QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE} needed "
                 f"to compute an acceleration t-statistic); flooring to "
                 f"{self._pnl_momentum_window_size} candles "
@@ -1365,6 +1365,13 @@ class QuickAdapterV3(IStrategy):
         return min(n_filled_take_profit_exits, QuickAdapterV3._FINAL_EXIT_STAGE_INDEX)
 
     @staticmethod
+    def _take_profit_order_tag(trade_direction: str, exit_stage: int) -> str:
+        return (
+            f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}"
+            f"{trade_direction}_{exit_stage}"
+        )
+
+    @staticmethod
     @lru_cache(maxsize=128)
     def get_stoploss_factor(trade_duration_candles: int) -> float:
         return 2.75 / (1.2675 + math.atan(0.25 * trade_duration_candles))
@@ -1688,7 +1695,9 @@ class QuickAdapterV3(IStrategy):
                 )
             return (
                 -trade_partial_stake_amount,
-                f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}{trade.trade_direction}_{trade_exit_stage}",
+                QuickAdapterV3._take_profit_order_tag(
+                    trade.trade_direction, trade_exit_stage
+                ),
             )
 
         return None
@@ -2130,10 +2139,13 @@ class QuickAdapterV3(IStrategy):
         last_candle = df.iloc[-1]
         last_candle_date = last_candle.get("date")
         has_valid_candle_date = not isna(last_candle_date)
-        if has_valid_candle_date:
+        trade_unrealized_pnl_history: Optional[list[float]] = (
             self.safe_append_trade_unrealized_pnl(
                 trade, current_profit, last_candle_date
             )
+            if has_valid_candle_date
+            else None
+        )
         if last_candle.get("do_predict") == 2:
             return "model_expired"
         if last_candle.get("DI_catch") == 0:
@@ -2221,9 +2233,10 @@ class QuickAdapterV3(IStrategy):
             )
             return None
 
-        trade_unrealized_pnl_history = QuickAdapterV3.get_trade_unrealized_pnl_history(
-            trade
-        )
+        if trade_unrealized_pnl_history is None:
+            trade_unrealized_pnl_history = (
+                QuickAdapterV3.get_trade_unrealized_pnl_history(trade)
+            )
         if len(trade_unrealized_pnl_history) < self._pnl_momentum_window_size:
             # Warm-up: without a full momentum window a 30-minute decline is not
             # measurable yet; fail open (never block a profitable take-profit
@@ -2239,9 +2252,8 @@ class QuickAdapterV3(IStrategy):
                     "take-profit exit not gated (fail-open)"
                 ),
             )
-            return (
-                f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}"
-                f"{trade.trade_direction}_{trade_exit_stage}"
+            return QuickAdapterV3._take_profit_order_tag(
+                trade.trade_direction, trade_exit_stage
             )
         (
             trade_recent_velocity_values,
@@ -2316,7 +2328,9 @@ class QuickAdapterV3(IStrategy):
             )
 
         if trade_exit:
-            return f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}{trade.trade_direction}_{trade_exit_stage}"
+            return QuickAdapterV3._take_profit_order_tag(
+                trade.trade_direction, trade_exit_stage
+            )
 
         return None
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -191,6 +191,7 @@ class QuickAdapterV3(IStrategy):
     )
 
     _TAKE_PROFIT_ORDER_TAG_PREFIX: Final[str] = "take_profit_"
+    _UNREALIZED_PNL_CANDLE_DATE_KEY: Final[str] = "unrealized_pnl_candle_date"
 
     minimal_roi = {str(timeframe_minutes * 864): -1}
 
@@ -454,11 +455,8 @@ class QuickAdapterV3(IStrategy):
             )
         self._candle_duration_secs = int(self.timeframe_minutes * 60)
         self.last_candle_start_secs: dict[str, Optional[int]] = {}
-        process_throttle_secs = self.config.get("internals", {}).get(
-            "process_throttle_secs", 5
-        )
-        self._max_history_size = int(12 * 60 * 60 / process_throttle_secs)
-        self._pnl_momentum_window_size = int(30 * 60 / process_throttle_secs)
+        self._max_history_size = max(1, int(12 * 60 / self.timeframe_minutes))
+        self._pnl_momentum_window_size = max(1, int(30 / self.timeframe_minutes))
         self._exit_thresholds_calibration: dict[str, float] = {
             **QuickAdapterV3.default_exit_thresholds_calibration,
             **self.config.get("exit_pricing", {}).get("thresholds_calibration", {}),
@@ -1470,7 +1468,7 @@ class QuickAdapterV3(IStrategy):
         return take_profit_price
 
     @staticmethod
-    def _get_trade_history(trade: Trade) -> dict[str, list[float | tuple[int, float]]]:
+    def _get_trade_history(trade: Trade) -> dict[str, Any]:
         return trade.get_custom_data(
             "history", {"unrealized_pnl": [], "take_profit_price": []}
         )
@@ -1487,27 +1485,33 @@ class QuickAdapterV3(IStrategy):
         history = QuickAdapterV3._get_trade_history(trade)
         return history.get("take_profit_price", [])
 
-    def append_trade_unrealized_pnl(self, trade: Trade, pnl: float) -> list[float]:
+    def append_trade_unrealized_pnl(
+        self, trade: Trade, pnl: float, candle_date: datetime.datetime
+    ) -> list[float]:
         history = QuickAdapterV3._get_trade_history(trade)
         pnl_history = history.setdefault("unrealized_pnl", [])
         pnl_history.append(pnl)
         if len(pnl_history) > self._max_history_size:
             pnl_history = pnl_history[-self._max_history_size :]
             history["unrealized_pnl"] = pnl_history
+        history[QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY] = (
+            candle_date.isoformat()
+        )
         trade.set_custom_data("history", history)
         return pnl_history
 
-    def safe_append_trade_unrealized_pnl(self, trade: Trade, pnl: float) -> list[float]:
-        trade_unrealized_pnl_history = QuickAdapterV3.get_trade_unrealized_pnl_history(
-            trade
-        )
-        previous_unrealized_pnl = (
-            trade_unrealized_pnl_history[-1] if trade_unrealized_pnl_history else None
-        )
-        if previous_unrealized_pnl is None or not np.isclose(
-            previous_unrealized_pnl, pnl
+    def safe_append_trade_unrealized_pnl(
+        self, trade: Trade, pnl: float, candle_date: datetime.datetime
+    ) -> list[float]:
+        history = QuickAdapterV3._get_trade_history(trade)
+        trade_unrealized_pnl_history = history.get("unrealized_pnl", [])
+        if (
+            history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY)
+            != candle_date.isoformat()
         ):
-            trade_unrealized_pnl_history = self.append_trade_unrealized_pnl(trade, pnl)
+            trade_unrealized_pnl_history = self.append_trade_unrealized_pnl(
+                trade, pnl, candle_date
+            )
         return trade_unrealized_pnl_history
 
     def append_trade_take_profit_price(
@@ -2057,8 +2061,6 @@ class QuickAdapterV3(IStrategy):
         current_profit: float,
         **kwargs,
     ) -> Optional[str]:
-        self.safe_append_trade_unrealized_pnl(trade, current_profit)
-
         df, _ = self.dp.get_analyzed_dataframe(
             pair=pair, timeframe=self.config.get("timeframe")
         )
@@ -2066,10 +2068,11 @@ class QuickAdapterV3(IStrategy):
             return None
 
         last_candle = df.iloc[-1]
+        last_candle_date = last_candle.get("date")
+        self.safe_append_trade_unrealized_pnl(trade, current_profit, last_candle_date)
         if last_candle.get("do_predict") == 2:
             return "model_expired"
         if last_candle.get("DI_catch") == 0:
-            last_candle_date = last_candle.get("date")
             last_outlier_date_isoformat = trade.get_custom_data("last_outlier_date")
             last_outlier_date = (
                 datetime.datetime.fromisoformat(last_outlier_date_isoformat)

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -2226,12 +2226,10 @@ class QuickAdapterV3(IStrategy):
                     "take-profit exit not gated (fail-open)"
                 ),
             )
-            if trade_take_profit_exit:
-                return (
-                    f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}"
-                    f"{trade.trade_direction}_{trade_exit_stage}"
-                )
-            return None
+            return (
+                f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}"
+                f"{trade.trade_direction}_{trade_exit_stage}"
+            )
         (
             trade_recent_velocity_values,
             trade_recent_velocity_mean,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -498,10 +498,12 @@ class QuickAdapterV3(IStrategy):
                 self._pnl_momentum_window_size - 1
             ) * self.timeframe_minutes
             logger.warning(
-                f"Timeframe {self.timeframe} cannot fit a 30-minute PnL momentum "
-                f"window; flooring to {self._pnl_momentum_window_size} candles "
-                f"(~{velocity_span_minutes} min velocity span). The declining-PnL "
-                "take-profit confirmation runs on a coarser window."
+                f"Timeframe {self.timeframe}: a 30-minute PnL momentum window has "
+                f"only {nominal_pnl_momentum_window_size} samples "
+                f"(< {QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE} needed "
+                f"for a finite acceleration t-statistic); flooring to "
+                f"{self._pnl_momentum_window_size} candles "
+                f"(~{velocity_span_minutes} min velocity span)."
             )
         self._exit_thresholds_calibration: dict[str, float] = {
             **QuickAdapterV3.default_exit_thresholds_calibration,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -212,8 +212,8 @@ class QuickAdapterV3(IStrategy):
 
     # get_pnl_momentum differences the window twice: velocity needs >=2 first
     # diffs (window>=3), acceleration >=2 second diffs (window>=4). 4 is the
-    # binding floor keeping both t-statistics finite; below it the declining-PnL
-    # take-profit gate silently degrades to an unconditional exit.
+    # binding floor so both t-statistics are computable (n>=2); with fewer
+    # samples the acceleration t-statistic is structurally NaN.
     _MIN_PNL_MOMENTUM_WINDOW_SIZE: Final[int] = 4
 
     minimal_roi = {str(timeframe_minutes * 864): -1}
@@ -501,7 +501,7 @@ class QuickAdapterV3(IStrategy):
                 f"Timeframe {self.timeframe}: a 30-minute PnL momentum window has "
                 f"only {nominal_pnl_momentum_window_size} samples "
                 f"(< {QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE} needed "
-                f"for a finite acceleration t-statistic); flooring to "
+                f"to compute an acceleration t-statistic); flooring to "
                 f"{self._pnl_momentum_window_size} candles "
                 f"(~{velocity_span_minutes} min velocity span)."
             )

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1506,6 +1506,13 @@ class QuickAdapterV3(IStrategy):
         history = QuickAdapterV3._get_trade_history(trade)
         trade_unrealized_pnl_history = history.get("unrealized_pnl", [])
         if (
+            QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY not in history
+            and trade_unrealized_pnl_history
+        ):
+            trade_unrealized_pnl_history = []
+            history["unrealized_pnl"] = trade_unrealized_pnl_history
+            trade.set_custom_data("history", history)
+        if (
             history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY)
             != candle_date.isoformat()
         ):

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -10,8 +10,10 @@ from typing import (
     ClassVar,
     Final,
     Literal,
+    NotRequired,
     Optional,
     Sequence,
+    TypedDict,
     TypeVar,
 )
 
@@ -96,6 +98,16 @@ CandleDeviationCacheKey = tuple[
 ]
 CandleThresholdCacheKey = tuple[str, DfSignature, str, int, float, float]
 _PairCacheT = TypeVar("_PairCacheT", bound=dict)
+
+
+class _TradeHistory(TypedDict):
+    # unrealized_pnl_candle_date is written lazily on first append (NotRequired);
+    # its literal name must mirror _UNREALIZED_PNL_CANDLE_DATE_KEY since TypedDict
+    # fields cannot reference a constant.
+    unrealized_pnl: list[float]
+    take_profit_price: list[float | tuple[int, float]]
+    unrealized_pnl_candle_date: NotRequired[str]
+
 
 logger = logging.getLogger(__name__)
 
@@ -192,6 +204,12 @@ class QuickAdapterV3(IStrategy):
 
     _TAKE_PROFIT_ORDER_TAG_PREFIX: Final[str] = "take_profit_"
     _UNREALIZED_PNL_CANDLE_DATE_KEY: Final[str] = "unrealized_pnl_candle_date"
+
+    # get_pnl_momentum differences the window twice: velocity needs >=2 first
+    # diffs (window>=3), acceleration >=2 second diffs (window>=4). 4 is the
+    # binding floor keeping both t-statistics finite; below it the declining-PnL
+    # take-profit gate silently degrades to an unconditional exit.
+    _MIN_PNL_MOMENTUM_WINDOW_SIZE: Final[int] = 4
 
     minimal_roi = {str(timeframe_minutes * 864): -1}
 
@@ -455,8 +473,25 @@ class QuickAdapterV3(IStrategy):
             )
         self._candle_duration_secs = int(self.timeframe_minutes * 60)
         self.last_candle_start_secs: dict[str, Optional[int]] = {}
-        self._max_history_size = max(1, int(12 * 60 / self.timeframe_minutes))
-        self._pnl_momentum_window_size = max(1, int(30 / self.timeframe_minutes))
+        nominal_pnl_momentum_window_size = int(30 / self.timeframe_minutes)
+        self._pnl_momentum_window_size = max(
+            QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE,
+            nominal_pnl_momentum_window_size,
+        )
+        self._max_history_size = max(
+            self._pnl_momentum_window_size,
+            int(12 * 60 / self.timeframe_minutes),
+        )
+        if (
+            nominal_pnl_momentum_window_size
+            < QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE
+        ):
+            logger.warning(
+                f"Timeframe {self.timeframe} cannot fit a 30-minute PnL momentum "
+                f"window; flooring to {self._pnl_momentum_window_size} candles "
+                f"(~{self._pnl_momentum_window_size * self.timeframe_minutes} min). "
+                "The declining-PnL take-profit confirmation runs on a coarser window."
+            )
         self._exit_thresholds_calibration: dict[str, float] = {
             **QuickAdapterV3.default_exit_thresholds_calibration,
             **self.config.get("exit_pricing", {}).get("thresholds_calibration", {}),
@@ -1468,7 +1503,7 @@ class QuickAdapterV3(IStrategy):
         return take_profit_price
 
     @staticmethod
-    def _get_trade_history(trade: Trade) -> dict[str, Any]:
+    def _get_trade_history(trade: Trade) -> _TradeHistory:
         return trade.get_custom_data(
             "history", {"unrealized_pnl": [], "take_profit_price": []}
         )
@@ -1511,7 +1546,6 @@ class QuickAdapterV3(IStrategy):
         ):
             trade_unrealized_pnl_history = []
             history["unrealized_pnl"] = trade_unrealized_pnl_history
-            trade.set_custom_data("history", history)
         if (
             history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY)
             != candle_date.isoformat()
@@ -2076,7 +2110,11 @@ class QuickAdapterV3(IStrategy):
 
         last_candle = df.iloc[-1]
         last_candle_date = last_candle.get("date")
-        self.safe_append_trade_unrealized_pnl(trade, current_profit, last_candle_date)
+        has_valid_candle_date = not isna(last_candle_date)
+        if has_valid_candle_date:
+            self.safe_append_trade_unrealized_pnl(
+                trade, current_profit, last_candle_date
+            )
         if last_candle.get("do_predict") == 2:
             return "model_expired"
         if last_candle.get("DI_catch") == 0:
@@ -2086,7 +2124,7 @@ class QuickAdapterV3(IStrategy):
                 if QuickAdapterV3.is_isoformat(last_outlier_date_isoformat)
                 else None
             )
-            if last_outlier_date != last_candle_date:
+            if has_valid_candle_date and last_outlier_date != last_candle_date:
                 n_outliers = trade.get_custom_data("n_outliers", 0)
                 n_outliers += 1
                 logger.warning(

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -473,7 +473,9 @@ class QuickAdapterV3(IStrategy):
             )
         self._candle_duration_secs = int(self.timeframe_minutes * 60)
         self.last_candle_start_secs: dict[str, Optional[int]] = {}
-        nominal_pnl_momentum_window_size = int(30 / self.timeframe_minutes)
+        # +1 endpoint: N samples yield N-1 velocity intervals, so covering a
+        # 30-minute velocity span needs floor(30/tf)+1 samples.
+        nominal_pnl_momentum_window_size = int(30 / self.timeframe_minutes) + 1
         self._pnl_momentum_window_size = max(
             QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE,
             nominal_pnl_momentum_window_size,
@@ -486,11 +488,14 @@ class QuickAdapterV3(IStrategy):
             nominal_pnl_momentum_window_size
             < QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE
         ):
+            velocity_span_minutes = (
+                self._pnl_momentum_window_size - 1
+            ) * self.timeframe_minutes
             logger.warning(
                 f"Timeframe {self.timeframe} cannot fit a 30-minute PnL momentum "
                 f"window; flooring to {self._pnl_momentum_window_size} candles "
-                f"(~{self._pnl_momentum_window_size * self.timeframe_minutes} min). "
-                "The declining-PnL take-profit confirmation runs on a coarser window."
+                f"(~{velocity_span_minutes} min velocity span). The declining-PnL "
+                "take-profit confirmation runs on a coarser window."
             )
         self._exit_thresholds_calibration: dict[str, float] = {
             **QuickAdapterV3.default_exit_thresholds_calibration,
@@ -2206,6 +2211,27 @@ class QuickAdapterV3(IStrategy):
         trade_unrealized_pnl_history = QuickAdapterV3.get_trade_unrealized_pnl_history(
             trade
         )
+        if len(trade_unrealized_pnl_history) < self._pnl_momentum_window_size:
+            # Warm-up: without a full momentum window a 30-minute decline is not
+            # measurable yet; fail open (never block a profitable take-profit
+            # exit) rather than gate on a partial, low-power series.
+            self.throttle_callback(
+                pair=pair,
+                current_time=current_time,
+                callback=lambda: logger.info(
+                    f"[{pair}] Trade {trade.trade_direction} stage "
+                    f"{trade_exit_stage} | PnL momentum gate warming up "
+                    f"({len(trade_unrealized_pnl_history)}/"
+                    f"{self._pnl_momentum_window_size} samples); "
+                    "take-profit exit not gated (fail-open)"
+                ),
+            )
+            if trade_take_profit_exit:
+                return (
+                    f"{QuickAdapterV3._TAKE_PROFIT_ORDER_TAG_PREFIX}"
+                    f"{trade.trade_direction}_{trade_exit_stage}"
+                )
+            return None
         (
             trade_recent_velocity_values,
             trade_recent_velocity_mean,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1546,6 +1546,7 @@ class QuickAdapterV3(IStrategy):
         ):
             trade_unrealized_pnl_history = []
             history["unrealized_pnl"] = trade_unrealized_pnl_history
+            trade.set_custom_data("history", history)
         if (
             history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY)
             != candle_date.isoformat()

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -101,12 +101,14 @@ _PairCacheT = TypeVar("_PairCacheT", bound=dict)
 
 
 class _TradeHistory(TypedDict):
-    # unrealized_pnl_candle_date is written lazily on first append (NotRequired);
-    # its literal name must mirror _UNREALIZED_PNL_CANDLE_DATE_KEY since TypedDict
-    # fields cannot reference a constant.
+    # unrealized_pnl_candle_date and unrealized_pnl_timeframe_minutes are written
+    # lazily on first append (NotRequired); their literal names must mirror
+    # _UNREALIZED_PNL_CANDLE_DATE_KEY / _UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY since
+    # TypedDict fields cannot reference a constant.
     unrealized_pnl: list[float]
     take_profit_price: list[float | tuple[int, float]]
     unrealized_pnl_candle_date: NotRequired[str]
+    unrealized_pnl_timeframe_minutes: NotRequired[int]
 
 
 logger = logging.getLogger(__name__)
@@ -204,6 +206,9 @@ class QuickAdapterV3(IStrategy):
 
     _TAKE_PROFIT_ORDER_TAG_PREFIX: Final[str] = "take_profit_"
     _UNREALIZED_PNL_CANDLE_DATE_KEY: Final[str] = "unrealized_pnl_candle_date"
+    _UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY: Final[str] = (
+        "unrealized_pnl_timeframe_minutes"
+    )
 
     # get_pnl_momentum differences the window twice: velocity needs >=2 first
     # diffs (window>=3), acceleration >=2 second diffs (window>=4). 4 is the
@@ -474,8 +479,9 @@ class QuickAdapterV3(IStrategy):
         self._candle_duration_secs = int(self.timeframe_minutes * 60)
         self.last_candle_start_secs: dict[str, Optional[int]] = {}
         # +1 endpoint: N samples yield N-1 velocity intervals, so covering a
-        # 30-minute velocity span needs floor(30/tf)+1 samples.
-        nominal_pnl_momentum_window_size = int(30 / self.timeframe_minutes) + 1
+        # 30-minute velocity span needs ceil(30/tf)+1 samples (ceil so a
+        # timeframe not dividing 30 still spans >=30 min).
+        nominal_pnl_momentum_window_size = math.ceil(30 / self.timeframe_minutes) + 1
         self._pnl_momentum_window_size = max(
             QuickAdapterV3._MIN_PNL_MOMENTUM_WINDOW_SIZE,
             nominal_pnl_momentum_window_size,
@@ -1537,6 +1543,9 @@ class QuickAdapterV3(IStrategy):
         history[QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY] = (
             candle_date.isoformat()
         )
+        history[QuickAdapterV3._UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY] = (
+            self.timeframe_minutes
+        )
         trade.set_custom_data("history", history)
         return pnl_history
 
@@ -1545,12 +1554,14 @@ class QuickAdapterV3(IStrategy):
     ) -> list[float]:
         history = QuickAdapterV3._get_trade_history(trade)
         trade_unrealized_pnl_history = history.get("unrealized_pnl", [])
-        if (
+        if trade_unrealized_pnl_history and (
             QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY not in history
-            and trade_unrealized_pnl_history
+            or history.get(QuickAdapterV3._UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY)
+            != self.timeframe_minutes
         ):
             trade_unrealized_pnl_history = []
             history["unrealized_pnl"] = trade_unrealized_pnl_history
+            history.pop(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY, None)
             trade.set_custom_data("history", history)
         if (
             history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY)

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -101,10 +101,9 @@ _PairCacheT = TypeVar("_PairCacheT", bound=dict)
 
 
 class _TradeHistory(TypedDict):
-    # unrealized_pnl_candle_date and unrealized_pnl_timeframe_minutes are written
-    # lazily on first append (NotRequired); their literal names must mirror
-    # _UNREALIZED_PNL_CANDLE_DATE_KEY / _UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY since
-    # TypedDict fields cannot reference a constant.
+    # Key names must mirror the _UNREALIZED_PNL_CANDLE_DATE_KEY /
+    # _UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY constants (a TypedDict field
+    # cannot reference a constant).
     unrealized_pnl: list[float]
     take_profit_price: list[float | tuple[int, float]]
     unrealized_pnl_candle_date: NotRequired[str]
@@ -1570,12 +1569,10 @@ class QuickAdapterV3(IStrategy):
             stored_candle_date_isoformat
         )
         elapsed_minutes = (candle_date - stored_candle_date).total_seconds() / 60.0
-        # get_pnl_momentum() differences the PnL series assuming a single
-        # timeframe between consecutive samples; any non-adjacent step -- a
-        # forward gap (missed candles after downtime/outage) or a
-        # non-monotonic/backward candle date -- breaks that uniform spacing, so
-        # the series must reset rather than span the discontinuity. elapsed == 0
-        # is the same-candle re-evaluation, not a discontinuity.
+        # get_pnl_momentum() differences the series assuming one timeframe
+        # between consecutive samples; any non-adjacent step (forward gap or
+        # backward/non-monotonic date) breaks that spacing and forces a reset.
+        # elapsed == 0 is a same-candle re-evaluation, not a discontinuity.
         return not math.isclose(
             elapsed_minutes, timeframe_minutes, rel_tol=1e-9, abs_tol=1e-9
         ) and not math.isclose(elapsed_minutes, 0.0, abs_tol=1e-9)

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1558,6 +1558,26 @@ class QuickAdapterV3(IStrategy):
         trade.set_custom_data("history", history)
         return pnl_history
 
+    @staticmethod
+    def _is_pnl_history_discontinuous(
+        stored_candle_date_isoformat: Optional[str],
+        candle_date: datetime.datetime,
+        timeframe_minutes: int,
+    ) -> bool:
+        if not QuickAdapterV3.is_isoformat(stored_candle_date_isoformat):
+            return False
+        stored_candle_date = datetime.datetime.fromisoformat(
+            stored_candle_date_isoformat
+        )
+        elapsed_minutes = (candle_date - stored_candle_date).total_seconds() / 60.0
+        # get_pnl_momentum() differences the PnL series assuming a single
+        # timeframe between consecutive samples; a wider gap (missed candles
+        # after downtime/outage) collapses into one interval, so the series
+        # must reset rather than span the discontinuity.
+        return elapsed_minutes > timeframe_minutes and not math.isclose(
+            elapsed_minutes, timeframe_minutes, rel_tol=1e-9, abs_tol=1e-9
+        )
+
     def safe_append_trade_unrealized_pnl(
         self, trade: Trade, pnl: float, candle_date: datetime.datetime
     ) -> list[float]:
@@ -1567,6 +1587,11 @@ class QuickAdapterV3(IStrategy):
             QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY not in history
             or history.get(QuickAdapterV3._UNREALIZED_PNL_TIMEFRAME_MINUTES_KEY)
             != self.timeframe_minutes
+            or QuickAdapterV3._is_pnl_history_discontinuous(
+                history.get(QuickAdapterV3._UNREALIZED_PNL_CANDLE_DATE_KEY),
+                candle_date,
+                self.timeframe_minutes,
+            )
         ):
             trade_unrealized_pnl_history = []
             history["unrealized_pnl"] = trade_unrealized_pnl_history

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1571,12 +1571,14 @@ class QuickAdapterV3(IStrategy):
         )
         elapsed_minutes = (candle_date - stored_candle_date).total_seconds() / 60.0
         # get_pnl_momentum() differences the PnL series assuming a single
-        # timeframe between consecutive samples; a wider gap (missed candles
-        # after downtime/outage) collapses into one interval, so the series
-        # must reset rather than span the discontinuity.
-        return elapsed_minutes > timeframe_minutes and not math.isclose(
+        # timeframe between consecutive samples; any non-adjacent step -- a
+        # forward gap (missed candles after downtime/outage) or a
+        # non-monotonic/backward candle date -- breaks that uniform spacing, so
+        # the series must reset rather than span the discontinuity. elapsed == 0
+        # is the same-candle re-evaluation, not a discontinuity.
+        return not math.isclose(
             elapsed_minutes, timeframe_minutes, rel_tol=1e-9, abs_tol=1e-9
-        )
+        ) and not math.isclose(elapsed_minutes, 0.0, abs_tol=1e-9)
 
     def safe_append_trade_unrealized_pnl(
         self, trade: Trade, pnl: float, candle_date: datetime.datetime
@@ -2259,8 +2261,12 @@ class QuickAdapterV3(IStrategy):
             return None
 
         if trade_unrealized_pnl_history is None:
-            trade_unrealized_pnl_history = (
-                QuickAdapterV3.get_trade_unrealized_pnl_history(trade)
+            # Last candle lacks a valid date, so the current-candle PnL sample
+            # could not be recorded and the momentum series is unmeasurable for
+            # this call; fail open (never block a profitable take-profit exit)
+            # rather than gate on a stale series, as during warm-up.
+            return QuickAdapterV3._take_profit_order_tag(
+                trade.trade_direction, trade_exit_stage
             )
         if len(trade_unrealized_pnl_history) < self._pnl_momentum_window_size:
             # Warm-up: without a full momentum window a 30-minute decline is not


### PR DESCRIPTION
## Summary

- sample one unrealized-PnL observation per strategy candle timestamp
- express momentum history and smoothing windows in timeframe candles
- retain an unchanged PnL value when the next candle arrives
- collect the sample only after the latest analyzed candle is available
- migrate an existing callback-cadence PnL series by resetting that series once
- preserve the trade's take-profit price history during migration

## Rationale

`process_throttle_secs` describes live loop cadence, not candle duration or
backtest callback frequency. Sampling per callback can overweight a candle and
produce different momentum windows between backtest and live execution.

Existing open trades may contain callback-cadence samples. Mixing those samples
with the new candle-cadence series gives the statistic inconsistent time units,
so only the legacy unrealized-PnL list is reset on first use of the new format.

## Validation

- local out-of-repository migration and post-migration tests: **2 passed**
- verifies take-profit history preservation
- Ruff check and format check
- Python compileall
- `git diff --check`

No tests are committed. Stacked directly on #116 and independent of #118/#119.
