### PR TITLE
fix(quickadapter): preserve valid partial-exit remainder

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1701,22 +1701,28 @@ class QuickAdapterV3(IStrategy):
                 ),
             )
         if trade_partial_exit:
-            if min_stake is None:
-                min_stake = 0.0
-            if min_stake > trade.stake_amount:
-                return None
             trade_stake_percent = QuickAdapterV3.partial_exit_stages[trade_exit_stage][
                 1
             ]
             trade_partial_stake_amount = trade_stake_percent * trade.stake_amount
-            remaining_stake_amount = trade.stake_amount - trade_partial_stake_amount
-            if remaining_stake_amount < min_stake:
-                initial_trade_partial_stake_amount = trade_partial_stake_amount
-                trade_partial_stake_amount = trade.stake_amount - min_stake
-                logger.info(
-                    f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
-                    f"Partial stake amount adjusted from {format_number(initial_trade_partial_stake_amount)} to {format_number(trade_partial_stake_amount)} to respect min_stake {format_number(min_stake)}"
+            if min_stake is not None and min_stake > 0:
+                current_position_value = trade.amount * current_exit_rate
+                if current_position_value <= min_stake:
+                    return None
+                remaining_position_value = current_position_value * (
+                    1 - trade_stake_percent
                 )
+                if remaining_position_value < min_stake:
+                    initial_trade_partial_stake_amount = trade_partial_stake_amount
+                    trade_partial_stake_amount = trade.stake_amount * (
+                        1 - min_stake / current_position_value
+                    )
+                    logger.info(
+                        f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
+                        f"Partial stake amount adjusted from {format_number(initial_trade_partial_stake_amount)} "
+                        f"to {format_number(trade_partial_stake_amount)} to preserve min_stake "
+                        f"{format_number(min_stake)} at exit rate {format_number(current_exit_rate)}"
+                    )
             return (
                 -trade_partial_stake_amount,
                 QuickAdapterV3._take_profit_order_tag(

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1689,7 +1689,7 @@ class QuickAdapterV3(IStrategy):
         )
 
         trade_partial_exit = QuickAdapterV3.can_take_profit(
-            trade, current_rate, trade_take_profit_price
+            trade, current_exit_rate, trade_take_profit_price
         )
         if not trade_partial_exit:
             self.throttle_callback(
@@ -1697,7 +1697,7 @@ class QuickAdapterV3(IStrategy):
                 current_time=current_time,
                 callback=lambda: logger.info(
                     f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
-                    f"Take Profit: {format_number(trade_take_profit_price)}, Rate: {format_number(current_rate)}"
+                    f"Take Profit: {format_number(trade_take_profit_price)}, Rate: {format_number(current_exit_rate)}"
                 ),
             )
         if trade_partial_exit:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1715,7 +1715,7 @@ class QuickAdapterV3(IStrategy):
                 # the larger min_exit_stake. For both the cost- and amount-driven
                 # minimum, min_exit_stake <= min_stake * max(exit/entry, 1/(1-|sl|)),
                 # so this upper bound keeps the shrunk remainder above the guard.
-                min_exit_stake = (
+                min_exit_stake_bound = (
                     min_stake
                     * max(
                         current_exit_rate / current_entry_rate,
@@ -1723,22 +1723,22 @@ class QuickAdapterV3(IStrategy):
                     )
                     * (1.0 + QuickAdapterV3._PARTIAL_EXIT_MIN_STAKE_MARGIN)
                 )
-                if current_position_value <= min_exit_stake:
+                if current_position_value <= min_exit_stake_bound:
                     return None
                 remaining_position_value = current_position_value * (
                     1 - trade_stake_percent
                 )
-                if remaining_position_value < min_exit_stake:
+                if remaining_position_value < min_exit_stake_bound:
                     initial_trade_partial_stake_amount = trade_partial_stake_amount
                     trade_partial_stake_amount = trade.stake_amount * (
-                        1 - min_exit_stake / current_position_value
+                        1 - min_exit_stake_bound / current_position_value
                     )
                     logger.info(
                         f"[{pair}] Trade {trade.trade_direction} stage "
                         f"{trade_exit_stage} | partial stake "
                         f"{format_number(initial_trade_partial_stake_amount)} -> "
                         f"{format_number(trade_partial_stake_amount)} to preserve "
-                        f"min_exit_stake {format_number(min_exit_stake)}"
+                        f"min_exit_stake_bound {format_number(min_exit_stake_bound)}"
                     )
             return (
                 -trade_partial_stake_amount,

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -215,6 +215,10 @@ class QuickAdapterV3(IStrategy):
     # samples the acceleration t-statistic is structurally NaN.
     _MIN_PNL_MOMENTUM_WINDOW_SIZE: Final[int] = 4
 
+    # Rounding margin so the sized partial-exit remainder clears freqtrade's
+    # strict `remaining < min_exit_stake` guard.
+    _PARTIAL_EXIT_MIN_STAKE_MARGIN: Final[float] = 1e-3
+
     minimal_roi = {str(timeframe_minutes * 864): -1}
 
     # FreqAI is crashing if minimal_roi is a property
@@ -1707,21 +1711,34 @@ class QuickAdapterV3(IStrategy):
             trade_partial_stake_amount = trade_stake_percent * trade.stake_amount
             if min_stake is not None and min_stake > 0:
                 current_position_value = trade.amount * current_exit_rate
-                if current_position_value <= min_stake:
+                # min_stake is freqtrade's min_entry_stake, but its exit guard uses
+                # the larger min_exit_stake. For both the cost- and amount-driven
+                # minimum, min_exit_stake <= min_stake * max(exit/entry, 1/(1-|sl|)),
+                # so this upper bound keeps the shrunk remainder above the guard.
+                min_exit_stake = (
+                    min_stake
+                    * max(
+                        current_exit_rate / current_entry_rate,
+                        1.0 / (1.0 - abs(self.stoploss)),
+                    )
+                    * (1.0 + QuickAdapterV3._PARTIAL_EXIT_MIN_STAKE_MARGIN)
+                )
+                if current_position_value <= min_exit_stake:
                     return None
                 remaining_position_value = current_position_value * (
                     1 - trade_stake_percent
                 )
-                if remaining_position_value < min_stake:
+                if remaining_position_value < min_exit_stake:
                     initial_trade_partial_stake_amount = trade_partial_stake_amount
                     trade_partial_stake_amount = trade.stake_amount * (
-                        1 - min_stake / current_position_value
+                        1 - min_exit_stake / current_position_value
                     )
                     logger.info(
-                        f"[{pair}] Trade {trade.trade_direction} stage {trade_exit_stage} | "
-                        f"Partial stake amount adjusted from {format_number(initial_trade_partial_stake_amount)} "
-                        f"to {format_number(trade_partial_stake_amount)} to preserve min_stake "
-                        f"{format_number(min_stake)} at exit rate {format_number(current_exit_rate)}"
+                        f"[{pair}] Trade {trade.trade_direction} stage "
+                        f"{trade_exit_stage} | partial stake "
+                        f"{format_number(initial_trade_partial_stake_amount)} -> "
+                        f"{format_number(trade_partial_stake_amount)} to preserve "
+                        f"min_exit_stake {format_number(min_exit_stake)}"
                     )
             return (
                 -trade_partial_stake_amount,


### PR DESCRIPTION
## Summary

- keep QuickAdapter's partial-exit adjustment
- trigger partial take-profit using Freqtrade's executable `current_exit_rate`
- evaluate the remaining position at the same exit rate
- reduce the requested exit when needed to preserve `min_stake`
- skip an exit that cannot leave the required minimum
- leave amount precision and final exchange validation to Freqtrade

## Rationale

Freqtrade provides separate entry and exit rates to `adjust_trade_position()` and
executes an exit at `current_exit_rate`. Testing the target with `current_rate`
(the current entry rate in this callback) can trigger a long exit below its bid
target or the symmetric short case.

The existing remainder workaround remains useful: Freqtrade validates and may
reject an invalid remainder, but does not reduce the requested exit for the
strategy. The corrected equation uses `trade.amount * current_exit_rate` and
leaves Freqtrade as the final validator.

## Validation

- local out-of-repository bid/ask trigger tests: **2 passed**
- covers false entry-rate trigger and true executable-rate trigger
- Ruff check and format check
- Python compileall
- `git diff --check`

No tests are committed. Stacked directly on #116 and independent of #117/#119.
