### PR TITLE
fix(quickadapter): guard filtfilt padding length

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -797,6 +797,14 @@ assert SMOOTHING_KERNELS == (
 )
 
 
+def _filtfilt_default_padlen(
+    numerator_length: int,
+    denominator_length: int,
+) -> int:
+    """Return SciPy's default ``filtfilt`` pad length."""
+    return 3 * max(numerator_length, denominator_length)
+
+
 def get_smoothing_kernel_half_width(
     config: dict[str, Any],
     *,
@@ -819,8 +827,7 @@ def get_smoothing_kernel_half_width(
     ``int(4.0 * sigma + 0.5)`` (scipy's ``round`` form). Returns 0 for
     ``method == "none"``, for ``series_length < max(window_candles, 3)``
     (``smooth()`` top-level no-op), and for the filtfilt/savgol routes
-    when ``series_length < effective_window`` (downstream short-series
-    no-op in ``zero_phase_filter`` / ``savgol_filter``).
+    when their downstream short-series guards make smoothing a no-op.
     """
     method = config.get("method", SMOOTHING_METHODS[0])
     if method == SMOOTHING_METHODS[0]:  # "none"
@@ -844,13 +851,12 @@ def get_smoothing_kernel_half_width(
         effective_window = get_even_window(raw_window)
     else:
         effective_window = get_odd_window(raw_window)
-    # ``zero_phase_filter`` / ``savgol_filter`` short-series gate
-    if (
-        method in SMOOTHING_KERNELS or method == SMOOTHING_METHODS[7]
-    ) and series_length < effective_window:
-        return 0
     if method in SMOOTHING_KERNELS:
+        if series_length <= _filtfilt_default_padlen(effective_window, 1):
+            return 0
         return effective_window - 1
+    if method == SMOOTHING_METHODS[7] and series_length < effective_window:
+        return 0
     return effective_window // 2
 
 
@@ -1747,14 +1753,14 @@ def zero_phase_filter(
     if len(series) < window:
         return series
 
-    values = series.to_numpy(dtype=float)
-    if values.size <= 1:
-        return series
-
     b = _calculate_coeffs(window=window, win_type=win_type, std=std, beta=beta)
     a = np.array([1.0], dtype=float)
+    padlen = _filtfilt_default_padlen(len(b), len(a))
+    if len(series) <= padlen:
+        return series
 
-    filtered_values = sp.signal.filtfilt(b, a, values)
+    values = series.to_numpy(dtype=float)
+    filtered_values = sp.signal.filtfilt(b, a, values, padlen=padlen)
     return pd.Series(filtered_values, index=series.index)
 
 


### PR DESCRIPTION
## Summary

- derive SciPy's default `filtfilt` pad length once from the numerator and denominator coefficient lengths
- return FIR-smoothed series unchanged when the input does not satisfy SciPy's strict length requirement
- use the same no-op boundary in the label-availability/lookahead helper
- preserve the existing `filtfilt` output for sufficiently long series by passing the derived default `padlen` explicitly
- remove the now-unreachable single-value guard after the stricter shared boundary

## Root cause and SciPy evidence

Validated against the current local `freqtradeorg/freqtrade:stable_freqai` environment:

- Python 3.14.6
- NumPy 2.4.6
- SciPy 1.17.1
- `scipy.signal.filtfilt` calls `_validate_pad(..., ntaps=max(len(a), len(b)))`
- with `padlen=None`, `_validate_pad` sets `edge = ntaps * 3` and rejects `x.shape[axis] <= edge`

Therefore `padlen = 3 * max(len(a), len(b))` and filtering is valid exactly when `len(x) > padlen`. An effective FIR window of 5 has `padlen=15` and requires at least 16 samples. The Kaiser-Bessel-derived route normalizes a requested window of 5 to an effective even window of 6, so it has `padlen=18` and requires at least 19 samples.

The previous guard only checked `len(series) < effective_window`, and the lookahead helper mirrored that insufficient boundary.

## Validation

External focused tests were kept outside the repository, as requested.

- pre-fix reproduction: 23 failed, 10 passed, with SciPy `ValueError` at the affected boundaries
- post-fix adversarial matrix: 73 passed, covering all four FIR methods, requested windows 3-6, direct SciPy rejection through `padlen`, acceptance at `padlen + 1`, empty and exact-boundary series, direct filter calls, integer/float/pandas extension dtypes, NaN behavior, and every non-FIR smoothing route
- sufficiently long outputs matched SciPy bit-for-bit; pre/post SHA-256 prefixes for the normal 64-sample window-5 outputs remained unchanged:
  - Gaussian: `c6553600d6512e88`
  - Kaiser: `a85dbe33af33ee03`
  - Kaiser-Bessel-derived: `1122256565860baa`
  - triangular: `12b472a35dc376cf`
- synthetic merge with PR #141 (`fix(quickadapter): validate smoothing modes per method`) was conflict-free; the combined tree passed the same 73-test matrix, and its configuration mode validation remains separate from the shared filtering/lookahead boundary
- `ruff check --no-cache quickadapter`
- `ruff format --check --no-cache quickadapter`
- `python -m compileall -q quickadapter/user_data`
- `git diff --check`

Fixes #130