### PR TITLE
fix(quickadapter): migrate legacy hp_rmse state

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,15 @@ docker compose up -d --build
 | freqai.optuna_hyperopt.seed                                    | 1                             | int >= 0                                                                                                                                                                                                     | HPO RNG seed used by the Optuna samplers and label-candle shuffling.                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                     |
 | freqai.optuna_hyperopt.vary_model_seed_by_trial                | true                          | bool                                                                                                                                                                                                         | Add `trial.number` to each regressor's configured model seed (or its default seed of `1`) during HPO. `true` samples model randomness across trials and preserves the historical behavior; `false` evaluates every trial and the final fit with the same model seed. This does not change `freqai.optuna_hyperopt.seed`.                                                                                                                                                                                                                                                                                 |
 
+### Compatibility migrations
+
+QuickAdapter 3.x accepts the deprecated `hp_rmse` key in
+`freqai.extra_returns_per_train` and in saved live prediction histories. It is
+migrated once to `holdout_rmse`; when both keys exist, `holdout_rmse` takes
+precedence. New histories contain only `holdout_rmse`. Remove `hp_rmse` from
+custom consumers before QuickAdapter 4.0, when this compatibility alias may be
+removed.
+
 ## ReforceXY
 
 ### Quick start

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1433,6 +1433,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         migrate_config(self.config, logger)
+        self._migrate_holdout_rmse_history()
         self.pairs: list[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
@@ -1507,6 +1508,23 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             self.regressor = DEFAULT_REGRESSOR
             self.freqai_info["regressor"] = self.regressor
         self._log_model_configuration()
+
+    def _migrate_holdout_rmse_history(self) -> None:
+        for pair, historic in self.dd.historic_predictions.items():
+            if "hp_rmse" not in historic:
+                continue
+            if "holdout_rmse" in historic:
+                historic.drop(columns="hp_rmse", inplace=True)
+                logger.warning(
+                    f"[{pair}] Historic predictions contain both 'holdout_rmse' "
+                    f"and deprecated 'hp_rmse'; using 'holdout_rmse'"
+                )
+            else:
+                historic.rename(columns={"hp_rmse": "holdout_rmse"}, inplace=True)
+                logger.warning(
+                    f"[{pair}] Historic prediction column 'hp_rmse' is deprecated; "
+                    f"migrated it to 'holdout_rmse'"
+                )
 
     def _log_model_configuration(self) -> None:
         logger.info("=" * 60)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -1055,6 +1055,10 @@ CONFIG_MIGRATIONS: Final[tuple[tuple[str, str], ...]] = (
     ("freqai.label_weighting.minmax_range", "freqai.label_pipeline.minmax_range"),
     ("freqai.label_weighting.sigmoid_scale", "freqai.label_pipeline.sigmoid_scale"),
     ("freqai.label_weighting.gamma", "freqai.label_pipeline.gamma"),
+    (
+        "freqai.extra_returns_per_train.hp_rmse",
+        "freqai.extra_returns_per_train.holdout_rmse",
+    ),
 )
 
 


### PR DESCRIPTION
## Summary

- migrate the deprecated `freqai.extra_returns_per_train.hp_rmse` configuration key through the existing config migration path
- normalize loaded `historic_predictions.pkl` DataFrames from `hp_rmse` to `holdout_rmse` before FreqAI builds its first live return arrays
- document the compatibility window and deterministic precedence

## Compatibility and precedence

This is a one-way reader migration for QuickAdapter 3.x. `hp_rmse` remains accepted in configuration and saved live histories through the 3.x line and may be removed in QuickAdapter 4.0.

- absent legacy key: no change
- only `hp_rmse`: rename it to `holdout_rmse` and preserve its values
- only `holdout_rmse`: no change
- both keys/columns: `holdout_rmse` wins as-is and `hp_rmse` is removed
- non-finite or invalid migrated values: use the existing `holdout_rmse` validation/fallback behavior (`inf` when no valid score can be restored)
- new writes: `holdout_rmse` only; no indefinite duplicate state

The change does not modify seed semantics: `freqai.optuna_hyperopt.seed` still controls Optuna samplers and label-candle shuffling, `vary_model_seed_by_trial` remains independent, and regressor model seeds are untouched.

## Evidence

On current `main` (`bda5bfd`) with Freqtrade 2026.6, a realistic `.live` history whose last `hp_rmse` was `0.42` loaded the legacy column but published `holdout_rmse=inf` before retraining.

Post-fix checks were kept outside the repository and covered:

- absent, legacy-only, canonical-only, and both-key config/history payloads
- canonical precedence plus NaN, infinity, invalid text, and prior-finite histories
- live upgrade, persisted canonical save, and restart
- Freqtrade `set_initial_return_values` then `append_model_predictions` on a realistic legacy DataFrame
- non-live/backtest replay behavior
- independent Optuna sampler/label-shuffle seed, trial-vary toggle, and model seed values

Quality gates:

- `ruff check` on the changed Python files
- `ruff format --check` on the changed Python files
- `compileall` with bytecode output outside the repository
- `git diff --check`

Fixes #139