### PR TITLE
fix(quickadapter): avoid duplicate backtest exit reserve

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1708,17 +1708,18 @@ class QuickAdapterV3(IStrategy):
             trade_partial_stake_amount = trade_stake_percent * trade.stake_amount
             if min_stake is not None and min_stake > 0:
                 current_position_value = trade.amount * current_exit_rate
-                # min_stake is freqtrade's min_entry_stake, but its exit guard uses
-                # the larger min_exit_stake. For both the cost- and amount-driven
-                # minimum, min_exit_stake <= min_stake * max(exit/entry, 1/(1-|sl|)),
-                # so this upper bound keeps the shrunk remainder above the guard.
-                min_exit_stake_bound = (
-                    min_stake
-                    * max(
+                # Live/dry-run passes min_entry_stake, while freqtrade's
+                # backtesting path already passes the adjusted minimum it guards.
+                min_exit_stake_bound = min_stake
+                if self.is_trade_runmode:
+                    # For both the cost- and amount-driven minimum, min_exit_stake
+                    # <= min_stake * max(exit/entry, 1/(1-|sl|)).
+                    min_exit_stake_bound *= max(
                         current_exit_rate / current_entry_rate,
                         1.0 / (1.0 - abs(self.stoploss)),
                     )
-                    * (1.0 + QuickAdapterV3._PARTIAL_EXIT_MIN_STAKE_MARGIN)
+                min_exit_stake_bound *= (
+                    1.0 + QuickAdapterV3._PARTIAL_EXIT_MIN_STAKE_MARGIN
                 )
                 if current_position_value <= min_exit_stake_bound:
                     return None

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1710,33 +1710,33 @@ class QuickAdapterV3(IStrategy):
                 current_position_value = trade.amount * current_exit_rate
                 # Live/dry-run passes min_entry_stake, while freqtrade's
                 # backtesting path already passes the adjusted minimum it guards.
-                min_exit_stake_bound = min_stake
+                min_remaining_position_value = min_stake
                 if self.is_trade_runmode:
                     # For both the cost- and amount-driven minimum, min_exit_stake
                     # <= min_stake * max(exit/entry, 1/(1-|sl|)).
-                    min_exit_stake_bound *= max(
+                    min_remaining_position_value *= max(
                         current_exit_rate / current_entry_rate,
                         1.0 / (1.0 - abs(self.stoploss)),
                     )
-                min_exit_stake_bound *= (
+                min_remaining_position_value *= (
                     1.0 + QuickAdapterV3._PARTIAL_EXIT_MIN_STAKE_MARGIN
                 )
-                if current_position_value <= min_exit_stake_bound:
+                if current_position_value <= min_remaining_position_value:
                     return None
                 remaining_position_value = current_position_value * (
                     1 - trade_stake_percent
                 )
-                if remaining_position_value < min_exit_stake_bound:
+                if remaining_position_value < min_remaining_position_value:
                     initial_trade_partial_stake_amount = trade_partial_stake_amount
                     trade_partial_stake_amount = trade.stake_amount * (
-                        1 - min_exit_stake_bound / current_position_value
+                        1 - min_remaining_position_value / current_position_value
                     )
                     logger.info(
                         f"[{pair}] Trade {trade.trade_direction} stage "
                         f"{trade_exit_stage} | partial stake "
                         f"{format_number(initial_trade_partial_stake_amount)} -> "
                         f"{format_number(trade_partial_stake_amount)} to preserve "
-                        f"min_exit_stake_bound {format_number(min_exit_stake_bound)}"
+                        f"min_remaining_position_value {format_number(min_remaining_position_value)}"
                     )
             return (
                 -trade_partial_stake_amount,


### PR DESCRIPTION
## Summary

- preserve QuickAdapter's live/dry-run minimum-exit bound exactly;
- use Freqtrade's callback-provided minimum as the semantic base in backtest and other non-trading modes;
- retain the existing 0.1% numerical clearance without duplicating the stoploss/rate reserve;
- keep Freqtrade responsible for amount precision and final pre-order minimum validation.

## Root cause and API proof

Freqtrade 2026.6 has different callback contracts in this path:

- live/dry-run computes `min_entry_stake` with stoploss `0.0` and a separate `min_exit_stake` with the strategy stoploss, passes only `min_entry_stake` to `adjust_trade_position()`, then validates the remainder against `min_exit_stake` ([live path](https://github.com/freqtrade/freqtrade/blob/2026.6/freqtrade/freqtradebot.py#L757-L831));
- backtesting computes one already adjusted minimum with its internal `-0.1` stoploss, passes it to the callback, and validates the remainder against that same value ([backtest path](https://github.com/freqtrade/freqtrade/blob/2026.6/freqtrade/optimize/backtesting.py#L719-L777));
- the exchange minimum applies the configured amount reserve and stoploss factor before considering leverage ([minimum formula](https://github.com/freqtrade/freqtrade/blob/2026.6/freqtrade/exchange/exchange.py#L1066-L1139)).

QuickAdapter previously multiplied `min_stake` by its stoploss/rate upper bound in every runmode. That conversion remains necessary when live/dry-run supplies the entry minimum, but it duplicated the stoploss reserve in backtesting paths where the callback value is already the value used by Freqtrade's final guard.

The existing `is_trade_runmode` discriminator maps exactly to Freqtrade's `TRADE_MODES = [LIVE, DRY_RUN]`; backtest and hyperopt remain non-trading modes.

## Numerical clearance

The 0.1% margin is retained after the runmode-specific conversion. Removing it and targeting exact equality is unsafe: a real Freqtrade 2026.6 case with minimum `35.0`, amount `0.7`, rate `70`, stake `15`, and amount precision `1e-8` converts the requested exit to `0.2`, then evaluates `(0.7 - 0.2) * 70` as `34.99999999999999`. Freqtrade rejects the adjustment before creating an order, so the unchanged stage can repeat the same rejected request.

A one-ULP `math.nextafter()` clearance is also insufficient across the mixed float, `FtPrecise`, contract, and exchange-precision path. Reusing the established 0.1% margin avoids a new unproven tolerance framework.

## Before and after

For an exchange cost minimum of `10`, the default 5% amount reserve, rate `100`, and a backtest position value of `19.7` at partial stage 0 (40%):

- Freqtrade's backtest callback/guard minimum is `11.6667`;
- **before:** QuickAdapter applies its current stoploss factor and numerical margin, raises the bound to `11.9778`, and shrinks the requested exit from `7.88` to `7.7222`;
- **after:** QuickAdapter applies only the numerical margin, producing a safe bound of `11.6783`; the nominal `7.88` exit leaves `11.82`, which Freqtrade accepts.

Live/dry-run is bit-for-bit unchanged: with the same cost minimum and QuickAdapter's `-0.025` stoploss, the callback entry minimum `10.5` is still converted to the conservative `10.78` bound.

## Upstream limitations

This removes only the extra QuickAdapter stoploss-reserve divergence. Freqtrade 2026.6 itself still uses a hard-coded `-0.1` stoploss and default leverage in backtesting while live/dry-run uses the strategy stoploss and trade leverage. Exact economic equivalence beyond QuickAdapter's additional reserve is therefore not claimed or reimplemented here.

Freqtrade's live wallet reconciliation and custom exit-price processing occur after the adjustment guard. “Final validation” here means Freqtrade's final pre-order validation of the adjustment amount and remainder, not a durable post-wallet or post-price invariant.

## Validation

- external, uncommitted regression matrix in `freqtradeorg/freqtrade:2026.6_freqai`: 10 tests passed through the real live and backtest adjustment methods;
- covered positive entry and negative exit semantics, live/dry-run versus backtest/hyperopt, all partial stages, long/short, exact and sub-minimum remainders, `None`/zero minimums, rate- and stoploss-driven bounds, cost/amount exchange limits, leverage 1/5/20, fee-reduced amounts, amount precision truncation, the `35.0 -> 34.99999999999999` regression, repeated callbacks/canonical fill stages, and live wallet fallback mutation;
- adversarial two-million-case scan proved that one ULP is not a general replacement for the established numerical clearance;
- `ruff check quickadapter`;
- `ruff format --check .` (39 files);
- `python -m compileall -q quickadapter ReforceXY`;
- `git diff --check`.

Repository-wide `ruff check .` still reports four pre-existing Unicode ambiguity diagnostics in `ReforceXY/reward_space_analysis`; this PR does not touch those files.

Fixes #138
