### PR TITLE
refactor(quickadapter)!: rename mislabeled log-return feature columns

### DIFF
--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -73,8 +73,7 @@ class RLAgentStrategy(IStrategy):
     def feature_engineering_expand_basic(
         self, dataframe: DataFrame, metadata: dict[str, Any], **kwargs
     ) -> DataFrame:
-        # TODO [BREAKING]: Rename %-close_pct_change -> %-close_log_return
-        dataframe["%-close_pct_change"] = np.log(dataframe.get("close")).diff()
+        dataframe["%-close_log_return"] = np.log(dataframe.get("close")).diff()
         dataframe["%-raw_volume"] = dataframe.get("volume")
 
         return dataframe

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -698,12 +698,10 @@ class QuickAdapterV3(IStrategy):
             volumes,
             length=period,
         )
-        # TODO [BREAKING]: Rename %-tcp-period -> %-top_log_return-period
-        dataframe["%-tcp-period"] = top_log_return(
+        dataframe["%-top_log_return-period"] = top_log_return(
             dataframe, period=period, logger=logger
         )
-        # TODO [BREAKING]: Rename %-bcp-period -> %-bottom_log_return-period
-        dataframe["%-bcp-period"] = bottom_log_return(
+        dataframe["%-bottom_log_return-period"] = bottom_log_return(
             dataframe, period=period, logger=logger
         )
         dataframe["%-prp-period"] = price_retracement_percent(
@@ -732,7 +730,6 @@ class QuickAdapterV3(IStrategy):
         closes = dataframe.get("close")
         volumes = dataframe.get("volume")
 
-        # TODO [BREAKING]: Rename %-close_pct_change -> %-close_log_return
         close_values = closes.to_numpy(dtype=float)
         invalid_close_count = int(
             np.count_nonzero(~np.isfinite(close_values) | (close_values <= 0.0))
@@ -743,7 +740,7 @@ class QuickAdapterV3(IStrategy):
                 invalid_close_count,
             )
         with np.errstate(divide="ignore", invalid="ignore"):
-            dataframe["%-close_pct_change"] = Series(
+            dataframe["%-close_log_return"] = Series(
                 np.where(
                     np.isfinite(close_values) & (close_values > 0.0),
                     np.log(close_values),

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -812,9 +812,9 @@ class QuickAdapterV3(IStrategy):
         dataframe["zlema_50"] = zlema(closes, period=50)
         dataframe["zlema_12"] = zlema(closes, period=12)
         dataframe["zlema_26"] = zlema(closes, period=26)
-        dataframe["%-distzlema50"] = get_distance(closes, dataframe["zlema_50"])
-        dataframe["%-distzlema12"] = get_distance(closes, dataframe["zlema_12"])
-        dataframe["%-distzlema26"] = get_distance(closes, dataframe["zlema_26"])
+        dataframe["%-dist_to_zlema_50"] = get_distance(closes, dataframe["zlema_50"])
+        dataframe["%-dist_to_zlema_12"] = get_distance(closes, dataframe["zlema_12"])
+        dataframe["%-dist_to_zlema_26"] = get_distance(closes, dataframe["zlema_26"])
         macd = ta.MACD(dataframe)
         dataframe["%-macd"] = macd["macd"]
         dataframe["%-macdsignal"] = macd["macdsignal"]


### PR DESCRIPTION
## Summary

Rename FreqAI feature columns for name/computation coherence, surfaced by a full semantic + naming-harmonization audit of every `%-` feature.

Mislabeled log returns (resolve the `TODO [BREAKING]` markers):

- `%-tcp-period` → `%-top_log_return-period`
- `%-bcp-period` → `%-bottom_log_return-period`
- `%-close_pct_change` → `%-close_log_return` (QuickAdapterV3 and ReforceXY `RLAgentStrategy`)

Namespace harmonization (same audit) — align the ZLEMA distance features with the dominant `%-dist_to_<x>` convention:

- `%-distzlema50` → `%-dist_to_zlema_50`
- `%-distzlema12` → `%-dist_to_zlema_12`
- `%-distzlema26` → `%-dist_to_zlema_26`

## Rationale

- `top_log_return` / `bottom_log_return` compute `log(close / rolling_max|min)` and `%-close_pct_change` computes `log(close).diff()` — all log returns, contradicting the opaque `tcp`/`bcp` and the factually wrong `pct_change`. Their neighbor `%-prp-period` (`log(close/low)/log(high/low)`, price retracement percent) is accurate and left unchanged.
- The ZLEMA distances are produced by the same `get_distance()` helper as every other `%-dist_to_*` feature (psar, alligator, macdsignal, vwap bands, pivots) yet were named off-convention (`distzlema50` — no `dist_to_`, no separator). Accurate but inconsistent; renamed for a single coherent namespace.
- A semantic audit of all `%-` features found no other mislabel; terse-but-accurate abbreviations (`er`, `ewo`, `ibs`, `cti`, `chop`, `prp`, …) are left unchanged to avoid gratuitous breaking renames.
- These are freqai `%-` auto-collected features with no by-name consumers (verified across `QuickAdapterV3`, `Utils`, `QuickAdapterRegressorV3`, `LabelTransformer`, `RLAgentStrategy`, and repo-wide docs/tests/config), so renaming the assignment is sufficient.

## Validation

- `ruff check --select E,F,W` unchanged vs `main`: `QuickAdapterV3.py` 51 → 51, `RLAgentStrategy.py` 2 → 2
- `ruff format --check`: clean (both files)
- `python -m py_compile`: OK (both files)
- `QuickAdapterV3` imports in the freqtrade image
- no residual old names (`tcp`, `bcp`, `close_pct_change`, `distzlema`) or `TODO [BREAKING]` markers anywhere in the repo

## BREAKING CHANGE

FreqAI feature column names changed; existing trained models must be retrained since the feature identifiers differ.