### PR TITLE
fix(quickadapter): invalidate reversal caches together

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -14,7 +14,6 @@ from typing import (
     Optional,
     Sequence,
     TypedDict,
-    TypeVar,
 )
 
 import numpy as np
@@ -97,7 +96,6 @@ CandleDeviationCacheKey = tuple[
     str, DfSignature, float, float, int, InterpolationDirection, float
 ]
 CandleThresholdCacheKey = tuple[str, DfSignature, str, int, float, float]
-_PairCacheT = TypeVar("_PairCacheT", bound=dict)
 
 
 class _TradeHistory(TypedDict):
@@ -899,7 +897,13 @@ class QuickAdapterV3(IStrategy):
 
     def set_label_period_candles(self, pair: str, label_period_candles: Any) -> None:
         if is_finite_number(label_period_candles) and int(label_period_candles) > 0:
-            self._label_params[pair]["label_period_candles"] = int(label_period_candles)
+            label_period_candles = int(label_period_candles)
+            if (
+                self._label_params[pair].get("label_period_candles")
+                != label_period_candles
+            ):
+                self._label_params[pair]["label_period_candles"] = label_period_candles
+                self._invalidate_pair_caches(pair)
 
     def get_label_horizon_candles(self, pair: str) -> int:
         period = self.get_label_period_candles(pair)
@@ -936,9 +940,15 @@ class QuickAdapterV3(IStrategy):
             is_finite_number(label_natr_multiplier)
             and float(label_natr_multiplier) > 0.0
         ):
-            self._label_params[pair]["label_natr_multiplier"] = float(
-                label_natr_multiplier
-            )
+            label_natr_multiplier = float(label_natr_multiplier)
+            if (
+                self._label_params[pair].get("label_natr_multiplier")
+                != label_natr_multiplier
+            ):
+                self._label_params[pair]["label_natr_multiplier"] = (
+                    label_natr_multiplier
+                )
+                self._invalidate_pair_caches(pair)
 
     def get_label_natr_multiplier_fraction(
         self,
@@ -1765,13 +1775,20 @@ class QuickAdapterV3(IStrategy):
             idx = length + idx
         return min(max(0, idx), length - 1)
 
-    def _invalidate_pair_cache(
-        self, cache: _PairCacheT, pair: str, df_signature: DfSignature
-    ) -> _PairCacheT:
-        if self._cached_df_signature.get(pair) != df_signature:
-            cache = type(cache)({k: v for k, v in cache.items() if k[0] != pair})
-            self._cached_df_signature[pair] = df_signature
-        return cache
+    def _invalidate_pair_caches(
+        self, pair: str, df_signature: Optional[DfSignature] = None
+    ) -> None:
+        if df_signature is None or self._cached_df_signature.get(pair) != df_signature:
+            self._candle_deviation_cache = {
+                k: v for k, v in self._candle_deviation_cache.items() if k[0] != pair
+            }
+            self._candle_threshold_cache = {
+                k: v for k, v in self._candle_threshold_cache.items() if k[0] != pair
+            }
+            if df_signature is None:
+                self._cached_df_signature.pop(pair, None)
+            else:
+                self._cached_df_signature[pair] = df_signature
 
     def _calculate_candle_deviation(
         self,
@@ -1784,9 +1801,7 @@ class QuickAdapterV3(IStrategy):
         quantile_exponent: float = 1.5,
     ) -> float:
         df_signature = QuickAdapterV3._df_signature(df)
-        self._candle_deviation_cache = self._invalidate_pair_cache(
-            self._candle_deviation_cache, pair, df_signature
-        )
+        self._invalidate_pair_caches(pair, df_signature)
         cache_key: CandleDeviationCacheKey = (
             pair,
             df_signature,
@@ -1854,9 +1869,7 @@ class QuickAdapterV3(IStrategy):
         candle_idx: int = -1,
     ) -> float:
         df_signature = QuickAdapterV3._df_signature(df)
-        self._candle_threshold_cache = self._invalidate_pair_cache(
-            self._candle_threshold_cache, pair, df_signature
-        )
+        self._invalidate_pair_caches(pair, df_signature)
         cache_key: CandleThresholdCacheKey = (
             pair,
             df_signature,


### PR DESCRIPTION
## Summary

- invalidate reversal threshold and deviation caches together at the existing per-pair dataframe-signature lifecycle point
- invalidate both caches immediately when the effective live/HPO label period or NATR multiplier changes for a pair
- preserve same-signature key variants, unchanged/invalid setter calls, and cache entries belonging to other pairs

## Root cause

Both cache families shared `_cached_df_signature`. The threshold path purged its own entries and updated that signature before calling the deviation path, so the deviation cache retained every stale dataframe signature.

The counter-review also found that `set_label_period_candles()` and `set_label_natr_multiplier()` could change pair-local fallback state while both caches still held results computed from the previous values. The shared invalidation point now handles explicit pair-state changes as well as dataframe-signature changes.

## Cache invariants

- every threshold and deviation entry for a pair belongs to that pair's current dataframe signature
- threshold variants remain keyed by side, candle index, and min/max reversal NATR fractions
- deviation variants remain keyed by candle index, min/max fractions, interpolation direction, and quantile exponent
- effective pair-local label period or multiplier changes purge both cache families for that pair only
- identical or invalid setter inputs do not invalidate caches
- Freqtrade executes strategy analysis pair-by-pair on the main bot loop; FreqAI training processes do not share these instance dictionaries, so no lock or dataframe-wide content hash is needed

## Before / after

Measured in Freqtrade 2026.6 over 1,000 successive BTC/USDT dataframe signatures with an ETH/USDT sentinel:

| Cache entries | Before | After |
| --- | ---: | ---: |
| BTC threshold | 1 | 1 |
| BTC deviation | 1,000 | 1 |
| Total threshold | 2 | 2 |
| Total deviation | 1,001 | 2 |

Counter-review mutation evidence on an unchanged dataframe signature:

| Mutation | Stale cached value | Correct value after invalidation |
| --- | ---: | ---: |
| label NATR multiplier 1.0 → 2.0 | 104.53310766963853 | 104.56621533927706 |
| label period 5 → 2 | 0.0003168198051533946 | 0.00029625 |

## Interaction with #140

PR #140 validates the configured reversal NATR fractions at the configuration boundary. This PR does not duplicate those bounds: the min/max fractions are already dimensions of both cache keys, while this change only governs cache lifecycle and dynamic pair-local label state.

## Validation

- rebased directly onto current `upstream/main` (`b41a0aed9f6b9711f98103c96f43b4684f16a25b`)
- external, uncommitted adversarial test covering 1,000 signature changes, alternating pairs, long/short directions, threshold/deviation key dimensions, direct-deviation-first ordering, unchanged/invalid setters, live/HPO period and multiplier mutations, and pair isolation
- QuickAdapter strategy load through Freqtrade 2026.6: `OK`
- `ruff check quickadapter`
- `ruff format --check quickadapter`
- `python -m compileall -q -f quickadapter`
- `git diff --check`

Fixes #133