### PR TITLE
refactor(quickadapter): group related constants

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -222,13 +222,14 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     version = "3.12.4"
 
     _TEST_SIZE: Final[float] = 0.1
+    _SKLEARN_TRAIN_TEST_SPLIT_KEYS: Final[frozenset[str]] = frozenset(
+        {"test_size", "train_size", "random_state", "shuffle", "stratify"}
+    )
+
     # Substituted whenever the Weibull DI cutoff (``weibull_min.ppf``) is
     # non-finite (cold start or degenerate fit). Preserves the prior
     # pre-warm-up heuristic for the outlier-quantile cutoff scale.
     _DI_CUTOFF_DEFAULT: Final[float] = 2.0
-    _SKLEARN_TRAIN_TEST_SPLIT_KEYS: Final[frozenset[str]] = frozenset(
-        {"test_size", "train_size", "random_state", "shuffle", "stratify"}
-    )
 
     _SQRT_2: Final[float] = np.sqrt(2.0)
 
@@ -237,6 +238,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         optuna.study.StudyDirection.MAXIMIZE,
     ) * _OPTUNA_LABEL_N_OBJECTIVES
     _OPTUNA_STORAGE_BACKENDS: Final[tuple[str, ...]] = ("file", "sqlite")
+    _STORAGE_FILE: Final[str] = _OPTUNA_STORAGE_BACKENDS[0]
+    _STORAGE_SQLITE: Final[str] = _OPTUNA_STORAGE_BACKENDS[1]
+
     _OPTUNA_JOURNAL_QUARANTINE_TAG: Final[str] = "corrupt"
     _OPTUNA_JOURNAL_RECOVERABLE_ERRORS: Final[tuple[type[Exception], ...]] = (
         KeyError,
@@ -265,15 +269,20 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "standard",
         "robust",
     )
+    SCALER_DEFAULT: Final[ScalerType] = _SCALER_TYPES[0]  # "minmax"
+    _SCALER_MAXABS: Final[str] = _SCALER_TYPES[1]
+    _SCALER_STANDARD: Final[str] = _SCALER_TYPES[2]
+    _SCALER_ROBUST: Final[str] = _SCALER_TYPES[3]
     _SCALER_TYPES_SET: Final[frozenset[ScalerType]] = frozenset(_SCALER_TYPES)
 
-    SCALER_DEFAULT: Final[ScalerType] = _SCALER_TYPES[0]  # "minmax"
     RANGE_DEFAULT: Final[tuple[float, float]] = (-1.0, 1.0)
 
     _DISTANCE_METHODS: Final[tuple[DistanceMethod, ...]] = (
         "compromise_programming",
         "topsis",
     )
+    _METHOD_COMPROMISE_PROGRAMMING: Final[str] = _DISTANCE_METHODS[0]
+    _METHOD_TOPSIS: Final[str] = _DISTANCE_METHODS[1]
     _DISTANCE_METHODS_SET: Final[frozenset[DistanceMethod]] = frozenset(
         _DISTANCE_METHODS
     )
@@ -282,7 +291,13 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "kmeans2",
         "kmedoids",
     )
+    _CLUSTER_KMEANS: Final[str] = _CLUSTER_METHODS[0]
+    _CLUSTER_KMEANS2: Final[str] = _CLUSTER_METHODS[1]
+    _CLUSTER_KMEDOIDS: Final[str] = _CLUSTER_METHODS[2]
+
     _DENSITY_METHODS: Final[tuple[DensityMethod, ...]] = ("knn", "medoid")
+    _DENSITY_KNN: Final[str] = _DENSITY_METHODS[0]
+    _DENSITY_MEDOID: Final[str] = _DENSITY_METHODS[1]
 
     _SELECTION_CATEGORIES: Final[dict[str, tuple[SelectionMethod, ...]]] = {
         "distance": _DISTANCE_METHODS,
@@ -295,6 +310,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         *_CLUSTER_METHODS,
         *_DENSITY_METHODS,
     )
+    _SELECTION_KMEANS: Final[str] = _SELECTION_METHODS[2]
+    _SELECTION_KMEANS2: Final[str] = _SELECTION_METHODS[3]
+    _SELECTION_KMEDOIDS: Final[str] = _SELECTION_METHODS[4]
+    _SELECTION_KNN: Final[str] = _SELECTION_METHODS[5]
+    _SELECTION_MEDOID: Final[str] = _SELECTION_METHODS[6]
     _SELECTION_METHODS_SET: Final[frozenset[SelectionMethod]] = frozenset(
         _SELECTION_METHODS
     )
@@ -318,6 +338,12 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "power_mean",
         "weighted_sum",
     )
+    _METRIC_EUCLIDEAN: Final[str] = _DISTANCE_METRICS[0]
+    _METRIC_MINKOWSKI: Final[str] = _DISTANCE_METRICS[1]
+    _METRIC_HELLINGER: Final[str] = _DISTANCE_METRICS[8]
+    _METRIC_SHELLINGER: Final[str] = _DISTANCE_METRICS[9]
+    _METRIC_POWER_MEAN: Final[str] = _DISTANCE_METRICS[15]
+    _METRIC_WEIGHTED_SUM: Final[str] = _DISTANCE_METRICS[16]
     _DISTANCE_METRICS_SET: Final[frozenset[str]] = frozenset(_DISTANCE_METRICS)
     # SciPy-compatible distance metrics: the first 8 entries of
     # ``_DISTANCE_METRICS`` route to ``scipy.spatial.distance.cdist``.
@@ -331,22 +357,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     _UNSUPPORTED_WEIGHTS_METRICS_SET: Final[frozenset[str]] = frozenset(
         _UNSUPPORTED_WEIGHTS_METRICS
     )
-
-    _METHOD_COMPROMISE_PROGRAMMING: Final[str] = _DISTANCE_METHODS[0]
-    _METHOD_TOPSIS: Final[str] = _DISTANCE_METHODS[1]
-    _METRIC_EUCLIDEAN: Final[str] = _DISTANCE_METRICS[0]
-    _METRIC_MINKOWSKI: Final[str] = _DISTANCE_METRICS[1]
-    _METRIC_HELLINGER: Final[str] = _DISTANCE_METRICS[8]
-    _METRIC_SHELLINGER: Final[str] = _DISTANCE_METRICS[9]
-    _METRIC_POWER_MEAN: Final[str] = _DISTANCE_METRICS[15]
-    _METRIC_WEIGHTED_SUM: Final[str] = _DISTANCE_METRICS[16]
-    _CLUSTER_KMEANS: Final[str] = _CLUSTER_METHODS[0]
-    _CLUSTER_KMEANS2: Final[str] = _CLUSTER_METHODS[1]
-    _SELECTION_KMEANS: Final[str] = _SELECTION_METHODS[2]
-    _SELECTION_KMEANS2: Final[str] = _SELECTION_METHODS[3]
-    _SELECTION_KMEDOIDS: Final[str] = _SELECTION_METHODS[4]
-    _SELECTION_KNN: Final[str] = _SELECTION_METHODS[5]
-    _SELECTION_MEDOID: Final[str] = _SELECTION_METHODS[6]
 
     _PROBABILITY_DISTANCE_METRICS: Final[tuple[str, ...]] = (
         "jensenshannon",
@@ -380,6 +390,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         "min",
         "max",
     )
+    _DENSITY_AGG_POWER_MEAN: Final[str] = _DENSITY_AGGREGATIONS[0]
+    _DENSITY_AGG_QUANTILE: Final[str] = _DENSITY_AGGREGATIONS[1]
+    _DENSITY_AGG_MIN: Final[str] = _DENSITY_AGGREGATIONS[2]
+    _DENSITY_AGG_MAX: Final[str] = _DENSITY_AGGREGATIONS[3]
     _DENSITY_AGGREGATIONS_SET: Final[frozenset[DensityAggregation]] = frozenset(
         _DENSITY_AGGREGATIONS
     )
@@ -443,18 +457,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     )
     DATA_SPLIT_METHOD_DEFAULT: Final[str] = _DATA_SPLIT_METHODS[0]
     _DATA_SPLIT_TIMESERIES: Final[str] = _DATA_SPLIT_METHODS[1]
-    _CLUSTER_KMEDOIDS: Final[str] = _CLUSTER_METHODS[2]
-    _DENSITY_KNN: Final[str] = _DENSITY_METHODS[0]
-    _DENSITY_MEDOID: Final[str] = _DENSITY_METHODS[1]
-    _DENSITY_AGG_POWER_MEAN: Final[str] = _DENSITY_AGGREGATIONS[0]
-    _DENSITY_AGG_QUANTILE: Final[str] = _DENSITY_AGGREGATIONS[1]
-    _DENSITY_AGG_MIN: Final[str] = _DENSITY_AGGREGATIONS[2]
-    _DENSITY_AGG_MAX: Final[str] = _DENSITY_AGGREGATIONS[3]
-    _SCALER_MAXABS: Final[str] = _SCALER_TYPES[1]
-    _SCALER_STANDARD: Final[str] = _SCALER_TYPES[2]
-    _SCALER_ROBUST: Final[str] = _SCALER_TYPES[3]
-    _STORAGE_FILE: Final[str] = _OPTUNA_STORAGE_BACKENDS[0]
-    _STORAGE_SQLITE: Final[str] = _OPTUNA_STORAGE_BACKENDS[1]
     TIMESERIES_N_SPLITS_DEFAULT: Final[int] = 5
     TIMESERIES_GAP_DEFAULT: Final[int] = 0
     TIMESERIES_MAX_TRAIN_SIZE_DEFAULT: Final[int | None] = None

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -131,6 +131,8 @@ class QuickAdapterV3(IStrategy):
     INTERFACE_VERSION = 3
 
     _TRADE_DIRECTIONS: Final[tuple[TradeDirection, ...]] = ("long", "short")
+    _TRADE_LONG: Final[str] = _TRADE_DIRECTIONS[0]
+    _TRADE_SHORT: Final[str] = _TRADE_DIRECTIONS[1]
     _TRADE_DIRECTIONS_SET: Final[frozenset[TradeDirection]] = frozenset(
         _TRADE_DIRECTIONS
     )
@@ -138,15 +140,13 @@ class QuickAdapterV3(IStrategy):
         "direct",
         "inverse",
     )
+    _INTERPOLATION_DIRECT: Final[str] = _INTERPOLATION_DIRECTIONS[0]
+    _INTERPOLATION_INVERSE: Final[str] = _INTERPOLATION_DIRECTIONS[1]
     _ORDER_TYPES: Final[tuple[OrderType, ...]] = ("entry", "exit")
-    _TRADE_LONG: Final[str] = _TRADE_DIRECTIONS[0]
-    _TRADE_SHORT: Final[str] = _TRADE_DIRECTIONS[1]
     _ORDER_ENTRY: Final[str] = _ORDER_TYPES[0]
     _ORDER_EXIT: Final[str] = _ORDER_TYPES[1]
     _ORDER_TYPES_SET: Final[frozenset[OrderType]] = frozenset(_ORDER_TYPES)
     _TRADING_MODES: Final[tuple[TradingMode, ...]] = ("spot", "margin", "futures")
-    _INTERPOLATION_DIRECT: Final[str] = _INTERPOLATION_DIRECTIONS[0]
-    _INTERPOLATION_INVERSE: Final[str] = _INTERPOLATION_DIRECTIONS[1]
     _TRADING_MODE_SPOT: Final[str] = _TRADING_MODES[0]
     _TRADING_MODE_MARGIN: Final[str] = _TRADING_MODES[1]
     _TRADING_MODE_FUTURES: Final[str] = _TRADING_MODES[2]


### PR DESCRIPTION
## Summary

- keep every strict QuickAdapter constant family contiguous in
  `QuickAdapterV3` and `QuickAdapterRegressorV3`
- order canonical sources before their derived aliases, sets, maps, and
  related defaults
- preserve role-staged blocks where the established design intentionally
  groups sibling option sources before defaults or validator maps
- preserve every constant value and consumer without alphabetical churn

## Rationale

PR #126 replaced magic tuple indexes with named constants and explicitly
described those constants as defined next to their tuples. In practice, several
regressor aliases were added in two remote blocks: one interrupted distance
metric contracts and another interrupted the data-split family. The same
partial grouping affected the strategy's trade/interpolation/order/mode block.

An exhaustive follow-up also found one older interleaving:
`_DI_CUTOFF_DEFAULT` separated `_TEST_SIZE` from
`_SKLEARN_TRAIN_TEST_SPLIT_KEYS`.

This change applies one dependency-topology rule only:

1. canonical source
2. aliases derived from that source
3. derived set/map/default contracts

Each related family remains contiguous. Independent constants and valid
role-staged blocks retain their existing order.

## Exhaustive audit

- 4 of 4 QuickAdapter Python modules
- 219 of 219 module/class constants and every `Name` / qualified-attribute
  consumer
- exact scope counts:
  - `QuickAdapterRegressorV3.py`: 107
  - `LabelTransformer.py`: 22
  - `QuickAdapterV3.py`: 32
  - `Utils.py`: 58
- classification: 40 semantic blocks, 66 families, and 16 roles
- pre-fix findings: 7 strict-family interleavings, all in
  `QuickAdapterRegressorV3`
- post-fix findings:
  - late dependencies: 0
  - strict-family interleavings: 0
  - semantic-policy violations: 0
  - default/validator key-order mismatches: 0

The complete 219-row Markdown/TSV classification and decision log were
generated externally under `/tmp`; no audit artifacts or tests are committed.

## Deliberate exclusions

- `LabelTransformer` keeps its role-staged option/type sources before the
  weighting and pipeline defaults maps.
- `Utils` keeps defaults before validator maps and localizes sentinels, warning
  guards, registries, numeric bounds, and resource constants beside their
  consumers.
- independent singleton constants are not alphabetized or moved.
- no documentation, configuration, tunable, type, key, sentinel, cache,
  registry, runtime behavior, or public API changes.

## Validation

- constant-definition AST and values identical to `upstream/main`
- complete non-constant AST, including every consumer, identical to
  `upstream/main`
- Freqtrade 2026.6 Docker snapshot: all 219 runtime values identical between
  `upstream/main` and this head
- imports of all four QuickAdapter modules in the Freqtrade 2026.6 image
- `ruff check --no-cache quickadapter`
- `ruff format --check --no-cache .` (39 files)
- `python -m compileall -q quickadapter ReforceXY` with bytecode redirected
  outside the repository
- `git diff --check`

Repository-wide `ruff check --no-cache .` still reports the same four
pre-existing Unicode ambiguity diagnostics in unchanged ReforceXY files; this
PR does not touch them.

Fixes #160
