### PR TITLE
fix(reforcexy): guard live risk promotion

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,7 +173,11 @@ docker compose up -d --build
 
 ### Supported models
 
-PPO, MaskablePPO, RecurrentPPO, DQN, QRDQN
+PPO, MaskablePPO, RecurrentPPO, DQN, QRDQN.
+
+`RecurrentPPO` is restricted to offline workflows. ReforceXY rejects it in
+Freqtrade dry-run and live modes because it does not maintain complete causal
+observation history or durable episode state across process restarts.
 
 ### Configuration tunables
 
@@ -248,6 +252,12 @@ The ReforceXY template is a research configuration. It uses `dry_run=true`, the
 startup before the trading loop and rejects entry callbacks unless the profile
 is explicitly `live`.
 
+Both profiles use RL exit actions through Freqtrade's native signal path. The
+resolved strategy attributes must therefore keep `use_exit_signal=true` and
+`exit_profit_only=false`. Otherwise ReforceXY stops startup and rejects new
+entries: disabling exit signals suppresses RL exits, while profit-only exits
+would suppress an RL exit from a losing trade.
+
 A live candidate must be defined in a separate, versioned configuration overlay.
 Before any final validation, preregister its Freqtrade `stoploss` and every
 protection method and parameter under
@@ -257,6 +267,14 @@ in dry-run. The `live` profile rejects the research stoploss sentinel in every
 run mode, including dry-run. Do not choose or revise stoploss, protection
 windows, trade limits, lock durations, or drawdown limits from final holdout
 results; the holdout only accepts or rejects the frozen candidate.
+
+`MaskablePPO` requires `freqai.rl_config.inference_masking=true`. Training,
+evaluation, and inference continue to use ReforceXY's shared action-mask
+mechanism. Other supported model types do not receive action masks and are not
+affected by this requirement. ReforceXY refuses `RecurrentPPO` in dry-run and
+live modes until complete causal observation history and episode state can be
+persisted across process restarts. The existing in-memory LSTM cache reuses state
+within one process but does not provide that guarantee.
 
 `reforcexy_execution.protections` is passed to Freqtrade's native
 `ProtectionManager`. An empty list is the only threshold-free default.
@@ -287,7 +305,8 @@ Use the Trade database fields (`exit_reason`, order status, filled amount and
 prices), Freqtrade RPC messages and logs, and exchange order history as the
 authoritative execution diagnostics. The strategy adds
 `freqai_model_expired` as the exit tag when FreqAI returns `do_predict == 2`,
-so that this safety exit remains attributable without changing its execution.
+so that this `EXIT_SIGNAL` remains attributable without changing its execution.
+It is not converted into a Freqtrade `force_exit`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
   - [Configuration tunables](#configuration-tunables-1)
 - [Development](#development)
 - [Common workflows](#common-workflows)
+- [ReforceXY execution profiles](#reforcexy-execution-profiles)
 - [Note](#note)
 
 ## QuickAdapter
@@ -553,6 +554,55 @@ _Cronjob setup (daily check at 3:00 AM):_
 ```cron
 0 3 * * * cd /path/to/freqai-strategies/ReforceXY && ./docker-upgrade.sh >> user_data/logs/docker-upgrade.log 2>&1
 ```
+
+## ReforceXY execution profiles
+
+The ReforceXY template is a research configuration. It uses `dry_run=true`, the
+`research` execution profile, and `stoploss=-0.99` as a sentinel. Changing only
+`dry_run` to `false` does not promote this configuration: the strategy stops
+startup before the trading loop and rejects entry callbacks unless the profile
+is explicitly `live`.
+
+A live candidate must be defined in a separate, versioned configuration overlay.
+Before any final validation, preregister its Freqtrade `stoploss` and every
+protection method and parameter under
+`reforcexy_execution.protections`. Then set
+`reforcexy_execution.profile=live` and rehearse that exact merged configuration
+in dry-run. The `live` profile rejects the research stoploss sentinel in every
+run mode, including dry-run. Do not choose or revise stoploss, protection
+windows, trade limits, lock durations, or drawdown limits from final holdout
+results; the holdout only accepts or rejects the frozen candidate.
+
+`reforcexy_execution.protections` is passed to Freqtrade's native
+`ProtectionManager`. An empty list is the only threshold-free default.
+`CooldownPeriod`, `StoplossGuard`, and `MaxDrawdown` can be configured there,
+using Freqtrade's documented parameter names. Their order in the list is their
+evaluation order. Historical validation must use `--enable-protections`;
+live and dry-run trading load them automatically.
+
+Protections create pair locks that prevent new entries after observed outcomes.
+They do not close an open position or cap its current loss and therefore never
+replace a real stoploss. Wallet allocation, stakes, exposure, order placement,
+fills, stoploss-on-exchange, forced exits, and emergency exits remain owned by
+Freqtrade. ReforceXY does not copy the wallet or order engine and does not pass
+wallet state into the model policy.
+
+The strategy emits only the diagnostics required by the startup guard, without
+applying an economic decision threshold:
+
+| Event                          | Meaning                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `ReforceXY execution contract` | Resolved profile, run mode, stoploss, and protection count at startup. |
+| `ReforceXY entry blocked`      | A fail-closed entry rejection when the execution contract is invalid.  |
+
+ReforceXY does not override Freqtrade's exit-confirmation or order-fill
+callbacks. This keeps stoploss, `force_exit`, `emergency_exit`, partial-exit,
+stoploss-on-exchange, and liquidation handling on the native execution path.
+Use the Trade database fields (`exit_reason`, order status, filled amount and
+prices), Freqtrade RPC messages and logs, and exchange order history as the
+authoritative execution diagnostics. The strategy adds
+`freqai_model_expired` as the exit tag when FreqAI returns `do_predict == 2`,
+so that this safety exit remains attributable without changing its execution.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -425,7 +425,11 @@ docker compose up -d --build
 
 ### Supported models
 
-PPO, MaskablePPO, RecurrentPPO, DQN, QRDQN
+PPO, MaskablePPO, RecurrentPPO, DQN, QRDQN.
+
+`RecurrentPPO` is restricted to offline workflows. ReforceXY rejects it in
+Freqtrade dry-run and live modes because it does not maintain complete causal
+observation history or durable episode state across process restarts.
 
 ### Configuration tunables
 
@@ -563,6 +567,12 @@ The ReforceXY template is a research configuration. It uses `dry_run=true`, the
 startup before the trading loop and rejects entry callbacks unless the profile
 is explicitly `live`.
 
+Both profiles use RL exit actions through Freqtrade's native signal path. The
+resolved strategy attributes must therefore keep `use_exit_signal=true` and
+`exit_profit_only=false`. Otherwise ReforceXY stops startup and rejects new
+entries: disabling exit signals suppresses RL exits, while profit-only exits
+would suppress an RL exit from a losing trade.
+
 A live candidate must be defined in a separate, versioned configuration overlay.
 Before any final validation, preregister its Freqtrade `stoploss` and every
 protection method and parameter under
@@ -572,6 +582,14 @@ in dry-run. The `live` profile rejects the research stoploss sentinel in every
 run mode, including dry-run. Do not choose or revise stoploss, protection
 windows, trade limits, lock durations, or drawdown limits from final holdout
 results; the holdout only accepts or rejects the frozen candidate.
+
+`MaskablePPO` requires `freqai.rl_config.inference_masking=true`. Training,
+evaluation, and inference continue to use ReforceXY's shared action-mask
+mechanism. Other supported model types do not receive action masks and are not
+affected by this requirement. ReforceXY refuses `RecurrentPPO` in dry-run and
+live modes until complete causal observation history and episode state can be
+persisted across process restarts. The existing in-memory LSTM cache reuses state
+within one process but does not provide that guarantee.
 
 `reforcexy_execution.protections` is passed to Freqtrade's native
 `ProtectionManager`. An empty list is the only threshold-free default.
@@ -602,7 +620,8 @@ Use the Trade database fields (`exit_reason`, order status, filled amount and
 prices), Freqtrade RPC messages and logs, and exchange order history as the
 authoritative execution diagnostics. The strategy adds
 `freqai_model_expired` as the exit tag when FreqAI returns `do_predict == 2`,
-so that this safety exit remains attributable without changing its execution.
+so that this `EXIT_SIGNAL` remains attributable without changing its execution.
+It is not converted into a Freqtrade `force_exit`.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@
   - [Supported models](#supported-models)
   - [Configuration tunables](#configuration-tunables-1)
 - [Common workflows](#common-workflows)
+- [ReforceXY execution profiles](#reforcexy-execution-profiles)
 - [Note](#note)
 
 ## QuickAdapter
@@ -238,6 +239,55 @@ _Cronjob setup (daily check at 3:00 AM):_
 ```cron
 0 3 * * * cd /path/to/freqai-strategies/ReforceXY && ./docker-upgrade.sh >> user_data/logs/docker-upgrade.log 2>&1
 ```
+
+## ReforceXY execution profiles
+
+The ReforceXY template is a research configuration. It uses `dry_run=true`, the
+`research` execution profile, and `stoploss=-0.99` as a sentinel. Changing only
+`dry_run` to `false` does not promote this configuration: the strategy stops
+startup before the trading loop and rejects entry callbacks unless the profile
+is explicitly `live`.
+
+A live candidate must be defined in a separate, versioned configuration overlay.
+Before any final validation, preregister its Freqtrade `stoploss` and every
+protection method and parameter under
+`reforcexy_execution.protections`. Then set
+`reforcexy_execution.profile=live` and rehearse that exact merged configuration
+in dry-run. The `live` profile rejects the research stoploss sentinel in every
+run mode, including dry-run. Do not choose or revise stoploss, protection
+windows, trade limits, lock durations, or drawdown limits from final holdout
+results; the holdout only accepts or rejects the frozen candidate.
+
+`reforcexy_execution.protections` is passed to Freqtrade's native
+`ProtectionManager`. An empty list is the only threshold-free default.
+`CooldownPeriod`, `StoplossGuard`, and `MaxDrawdown` can be configured there,
+using Freqtrade's documented parameter names. Their order in the list is their
+evaluation order. Historical validation must use `--enable-protections`;
+live and dry-run trading load them automatically.
+
+Protections create pair locks that prevent new entries after observed outcomes.
+They do not close an open position or cap its current loss and therefore never
+replace a real stoploss. Wallet allocation, stakes, exposure, order placement,
+fills, stoploss-on-exchange, forced exits, and emergency exits remain owned by
+Freqtrade. ReforceXY does not copy the wallet or order engine and does not pass
+wallet state into the model policy.
+
+The strategy emits only the diagnostics required by the startup guard, without
+applying an economic decision threshold:
+
+| Event                          | Meaning                                                                |
+| ------------------------------ | ---------------------------------------------------------------------- |
+| `ReforceXY execution contract` | Resolved profile, run mode, stoploss, and protection count at startup. |
+| `ReforceXY entry blocked`      | A fail-closed entry rejection when the execution contract is invalid.  |
+
+ReforceXY does not override Freqtrade's exit-confirmation or order-fill
+callbacks. This keeps stoploss, `force_exit`, `emergency_exit`, partial-exit,
+stoploss-on-exchange, and liquidation handling on the native execution path.
+Use the Trade database fields (`exit_reason`, order status, filled amount and
+prices), Freqtrade RPC messages and logs, and exchange order history as the
+authoritative execution diagnostics. The strategy adds
+`freqai_model_expired` as the exit tag when FreqAI returns `do_predict == 2`,
+so that this safety exit remains attributable without changing its execution.
 
 ---
 

--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -553,1043 +553,1043 @@
     },
     {
       "endCharacter": 51,
-      "endLine": 612,
+      "endLine": 645,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 26,
-      "startLine": 612
+      "startLine": 645
     },
     {
       "endCharacter": 51,
-      "endLine": 612,
+      "endLine": 645,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 26,
-      "startLine": 612
+      "startLine": 645
     },
     {
       "endCharacter": 60,
-      "endLine": 616,
+      "endLine": 649,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 616
+      "startLine": 649
     },
     {
       "endCharacter": 60,
-      "endLine": 616,
+      "endLine": 649,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 616
+      "startLine": 649
     },
     {
       "endCharacter": 22,
-      "endLine": 687,
+      "endLine": 720,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"train_env\" for class \"ReforceXY*\"\n  Expression of type \"VecEnv\" cannot be assigned to attribute \"train_env\" of class \"ReforceXY\"\n    Type \"VecEnv\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n      \"VecEnv\" is not assignable to \"VecMonitor\"\n      \"VecEnv\" is not assignable to \"SubprocVecEnv\"\n      \"VecEnv\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 687
+      "startLine": 720
     },
     {
       "endCharacter": 37,
-      "endLine": 687,
+      "endLine": 720,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"eval_env\" for class \"ReforceXY*\"\n  Expression of type \"VecEnv\" cannot be assigned to attribute \"eval_env\" of class \"ReforceXY\"\n    Type \"VecEnv\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n      \"VecEnv\" is not assignable to \"VecMonitor\"\n      \"VecEnv\" is not assignable to \"SubprocVecEnv\"\n      \"VecEnv\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 29,
-      "startLine": 687
+      "startLine": 720
     },
     {
       "endCharacter": 38,
-      "endLine": 962,
+      "endLine": 995,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"obj\" of type \"Sized\" in function \"len\"\n  Type \"Any | None\" is not assignable to type \"Sized\"\n    \"None\" is incompatible with protocol \"Sized\"\n      \"__len__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 962
+      "startLine": 995
     },
     {
       "endCharacter": 36,
-      "endLine": 966,
+      "endLine": 999,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"obj\" of type \"Sized\" in function \"len\"\n  Type \"Any | None\" is not assignable to type \"Sized\"\n    \"None\" is incompatible with protocol \"Sized\"\n      \"__len__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 29,
-      "startLine": 966
+      "startLine": 999
     },
     {
       "endCharacter": 80,
-      "endLine": 969,
+      "endLine": 1002,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 52,
-      "startLine": 969
+      "startLine": 1002
     },
     {
       "endCharacter": 78,
-      "endLine": 970,
+      "endLine": 1003,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 50,
-      "startLine": 970
+      "startLine": 1003
     },
     {
       "endCharacter": 80,
-      "endLine": 971,
+      "endLine": 1004,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 52,
-      "startLine": 971
+      "startLine": 1004
     },
     {
       "endCharacter": 83,
-      "endLine": 1039,
+      "endLine": 1072,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 55,
-      "startLine": 1039
+      "startLine": 1072
     },
     {
       "endCharacter": 52,
-      "endLine": 1070,
+      "endLine": 1103,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\" cannot be assigned to parameter \"eval_env\" of type \"BaseEnvironment\" in function \"get_callbacks\"\n  Type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\" is not assignable to type \"BaseEnvironment\"\n    \"SubprocVecEnv\" is not assignable to \"BaseEnvironment\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 1070
+      "startLine": 1103
     },
     {
       "endCharacter": 50,
-      "endLine": 1231,
+      "endLine": 1264,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"NDArray[float32]\" cannot be assigned to parameter \"x\" of type \"float32\" in function \"append\"\n  \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"floating[_32Bit]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 1231
+      "startLine": 1264
     },
     {
       "endCharacter": 32,
-      "endLine": 1956,
+      "endLine": 1989,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"best_trial_params\" is possibly unbound",
       "rule": "reportPossiblyUnboundVariable",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 1956
+      "startLine": 1989
     },
     {
       "endCharacter": 12,
-      "endLine": 1965,
+      "endLine": 1998,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Parameter declaration \"seed\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1965
+      "startLine": 1998
     },
     {
       "endCharacter": 16,
-      "endLine": 1966,
+      "endLine": 1999,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Parameter declaration \"env_info\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1966
+      "startLine": 1999
     },
     {
       "endCharacter": 47,
-      "endLine": 2011,
+      "endLine": 2044,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2011
+      "startLine": 2044
     },
     {
       "endCharacter": 45,
-      "endLine": 2013,
+      "endLine": 2046,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 2013
+      "startLine": 2046
     },
     {
       "endCharacter": 45,
-      "endLine": 2015,
+      "endLine": 2048,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2015
+      "startLine": 2048
     },
     {
       "endCharacter": 43,
-      "endLine": 2017,
+      "endLine": 2050,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2017
+      "startLine": 2050
     },
     {
       "endCharacter": 22,
-      "endLine": 2058,
+      "endLine": 2091,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 2058
+      "startLine": 2091
     },
     {
       "endCharacter": 96,
-      "endLine": 2060,
+      "endLine": 2093,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 89,
-      "startLine": 2060
+      "startLine": 2093
     },
     {
       "endCharacter": 23,
-      "endLine": 2063,
+      "endLine": 2096,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 16,
-      "startLine": 2063
+      "startLine": 2096
     },
     {
       "endCharacter": 98,
-      "endLine": 2065,
+      "endLine": 2098,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 91,
-      "startLine": 2065
+      "startLine": 2098
     },
     {
       "endCharacter": 44,
-      "endLine": 2077,
+      "endLine": 2110,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for types \"Any | None\" and \"Any | int | None\"\n  Operator \"*\" not supported for types \"None\" and \"None\"\n  Operator \"*\" not supported for types \"None\" and \"int\"",
       "rule": "reportOperatorIssue",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 2077
+      "startLine": 2110
     },
     {
       "endCharacter": 133,
-      "endLine": 2079,
+      "endLine": 2112,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for types \"Any | None\" and \"Any | int | None\"\n  Operator \"*\" not supported for types \"None\" and \"None\"\n  Operator \"*\" not supported for types \"None\" and \"int\"",
       "rule": "reportOperatorIssue",
       "severity": "error",
       "startCharacter": 106,
-      "startLine": 2079
+      "startLine": 2112
     },
     {
       "endCharacter": 30,
-      "endLine": 2082,
+      "endLine": 2115,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \">\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 2082
+      "startLine": 2115
     },
     {
       "endCharacter": 47,
-      "endLine": 2126,
+      "endLine": 2159,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"VecEnv\" cannot be assigned to parameter \"eval_env\" of type \"BaseEnvironment\" in function \"get_callbacks\"\n  \"VecEnv\" is not assignable to \"BaseEnvironment\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2126
+      "startLine": 2159
     },
     {
       "endCharacter": 46,
-      "endLine": 2183,
+      "endLine": 2216,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"is_pruned\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2183
+      "startLine": 2216
     },
     {
       "endCharacter": 57,
-      "endLine": 2186,
+      "endLine": 2219,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"best_mean_reward\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 41,
-      "startLine": 2186
+      "startLine": 2219
     },
     {
       "endCharacter": 37,
-      "endLine": 2196,
+      "endLine": 2229,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"train_env\" for class \"ReforceXY*\"\n  Type \"None\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n    \"None\" is not assignable to \"VecMonitor\"\n    \"None\" is not assignable to \"SubprocVecEnv\"\n    \"None\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 33,
-      "startLine": 2196
+      "startLine": 2229
     },
     {
       "endCharacter": 36,
-      "endLine": 2201,
+      "endLine": 2234,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"eval_env\" for class \"ReforceXY*\"\n  Type \"None\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n    \"None\" is not assignable to \"VecMonitor\"\n    \"None\" is not assignable to \"SubprocVecEnv\"\n    \"None\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 2201
+      "startLine": 2234
     },
     {
       "endCharacter": 7,
-      "endLine": 2233,
+      "endLine": 2266,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Declaration \"MyRLEnv\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 0,
-      "startLine": 2233
+      "startLine": 2266
     },
     {
       "endCharacter": 34,
-      "endLine": 2245,
+      "endLine": 2278,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Declaration \"_last_closed_position\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 2245
+      "startLine": 2278
     },
     {
       "endCharacter": 36,
-      "endLine": 2246,
+      "endLine": 2279,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Declaration \"_last_closed_trade_tick\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 2246
+      "startLine": 2279
     },
     {
       "endCharacter": 13,
-      "endLine": 3082,
+      "endLine": 3115,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"reset\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"tuple[DataFrame, dict[Unknown, Unknown]]\", override returns type \"tuple[NDArray[float32], dict[str, Any]]\"\n    \"tuple[NDArray[float32], dict[str, Any]]\" is not assignable to \"tuple[DataFrame, dict[Unknown, Unknown]]\"\n      Tuple entry 1 is incorrect type\n        \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3082
+      "startLine": 3115
     },
     {
       "endCharacter": 26,
-      "endLine": 3104,
+      "endLine": 3137,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Type \"tuple[DataFrame, dict[Unknown, Unknown]]\" is not assignable to return type \"tuple[NDArray[float32], dict[str, Any]]\"\n  \"DataFrame\" is not assignable to \"ndarray[_AnyShape, dtype[float32]]\"",
       "rule": "reportReturnType",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 3104
+      "startLine": 3137
     },
     {
       "endCharacter": 55,
-      "endLine": 3433,
+      "endLine": 3466,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 3433
+      "startLine": 3466
     },
     {
       "endCharacter": 55,
-      "endLine": 3433,
+      "endLine": 3466,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 3433
+      "startLine": 3466
     },
     {
       "endCharacter": 59,
-      "endLine": 3457,
+      "endLine": 3490,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 48,
-      "startLine": 3457
+      "startLine": 3490
     },
     {
       "endCharacter": 59,
-      "endLine": 3457,
+      "endLine": 3490,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 48,
-      "startLine": 3457
+      "startLine": 3490
     },
     {
       "endCharacter": 24,
-      "endLine": 3502,
+      "endLine": 3535,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"_get_observation\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"DataFrame\", override returns type \"NDArray[float32]\"\n    \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3502
+      "startLine": 3535
     },
     {
       "endCharacter": 53,
-      "endLine": 3570,
+      "endLine": 3603,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"name\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 3570
+      "startLine": 3603
     },
     {
       "endCharacter": 12,
-      "endLine": 3604,
+      "endLine": 3637,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"step\" overrides class \"Base5ActionRLEnv\" in an incompatible manner\n  Return type mismatch: base method returns type \"tuple[DataFrame, float, bool, Literal[False], dict[str, Unknown]]\", override returns type \"tuple[NDArray[float32], float, bool, bool, dict[str, Any]]\"\n    \"tuple[NDArray[float32], float, bool, bool, dict[str, Any]]\" is not assignable to \"tuple[DataFrame, float, bool, Literal[False], dict[str, Unknown]]\"\n      Tuple entry 1 is incorrect type\n        \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3604
+      "startLine": 3637
     },
     {
       "endCharacter": 20,
-      "endLine": 3717,
+      "endLine": 3750,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"action_masks\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"list[bool]\", override returns type \"NDArray[bool_]\"\n    \"ndarray[_AnyShape, dtype[bool_]]\" is not assignable to \"list[bool]\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3717
+      "startLine": 3750
     },
     {
       "endCharacter": 65,
-      "endLine": 3910,
+      "endLine": 3943,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Type \"Any | None\" is not assignable to return type \"float\"\n  Type \"Any | None\" is not assignable to type \"float\"\n    \"None\" is not assignable to \"float\"",
       "rule": "reportReturnType",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 3910
+      "startLine": 3943
     },
     {
       "endCharacter": 40,
-      "endLine": 3949,
+      "endLine": 3982,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"Figure\" is not exported from module \"matplotlib.pyplot\"",
       "rule": "reportPrivateImportUsage",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3949
+      "startLine": 3982
     },
     {
       "endCharacter": 54,
-      "endLine": 4447,
+      "endLine": 4480,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 4447
+      "startLine": 4480
     },
     {
       "endCharacter": 54,
-      "endLine": 4447,
+      "endLine": 4480,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 4447
+      "startLine": 4480
     },
     {
       "endCharacter": 50,
-      "endLine": 4459,
+      "endLine": 4492,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"object\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"object\" is not assignable to type \"ConvertibleToFloat\"\n    \"object\" is not assignable to \"str\"\n    \"object\" is incompatible with protocol \"Buffer\"\n      \"__buffer__\" is not present\n    \"object\" is incompatible with protocol \"SupportsFloat\"\n      \"__float__\" is not present\n    \"object\" is incompatible with protocol \"SupportsIndex\"\n      \"__index__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 4459
+      "startLine": 4492
     },
     {
       "endCharacter": 72,
-      "endLine": 4470,
+      "endLine": 4503,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 70,
-      "startLine": 4470
+      "startLine": 4503
     },
     {
       "endCharacter": 72,
-      "endLine": 4470,
+      "endLine": 4503,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 70,
-      "startLine": 4470
+      "startLine": 4503
     },
     {
       "endCharacter": 73,
-      "endLine": 4479,
+      "endLine": 4512,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 71,
-      "startLine": 4479
+      "startLine": 4512
     },
     {
       "endCharacter": 73,
-      "endLine": 4479,
+      "endLine": 4512,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 71,
-      "startLine": 4479
+      "startLine": 4512
     },
     {
       "endCharacter": 58,
-      "endLine": 4488,
+      "endLine": 4521,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 4488
+      "startLine": 4521
     },
     {
       "endCharacter": 58,
-      "endLine": 4488,
+      "endLine": 4521,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 4488
+      "startLine": 4521
     },
     {
       "endCharacter": 50,
-      "endLine": 4712,
+      "endLine": 4745,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Mapping[Unknown, Unknown]\" cannot be assigned to parameter \"src\" of type \"dict[str, Any]\" in function \"deepmerge\"\n  \"Mapping[Unknown, Unknown]\" is not assignable to \"dict[str, Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4712
+      "startLine": 4745
     },
     {
       "endCharacter": 20,
-      "endLine": 4889,
+      "endLine": 4922,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 4889
+      "startLine": 4922
     },
     {
       "endCharacter": 20,
-      "endLine": 4889,
+      "endLine": 4922,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 4889
+      "startLine": 4922
     },
     {
       "endCharacter": 59,
-      "endLine": 4894,
+      "endLine": 4927,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4894
+      "startLine": 4927
     },
     {
       "endCharacter": 59,
-      "endLine": 4894,
+      "endLine": 4927,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4894
+      "startLine": 4927
     },
     {
       "endCharacter": 65,
-      "endLine": 4895,
+      "endLine": 4928,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4895
+      "startLine": 4928
     },
     {
       "endCharacter": 65,
-      "endLine": 4895,
+      "endLine": 4928,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4895
+      "startLine": 4928
     },
     {
       "endCharacter": 57,
-      "endLine": 4896,
+      "endLine": 4929,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4896
+      "startLine": 4929
     },
     {
       "endCharacter": 57,
-      "endLine": 4896,
+      "endLine": 4929,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4896
+      "startLine": 4929
     },
     {
       "endCharacter": 63,
-      "endLine": 4898,
+      "endLine": 4931,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4898
+      "startLine": 4931
     },
     {
       "endCharacter": 63,
-      "endLine": 4898,
+      "endLine": 4931,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4898
+      "startLine": 4931
     },
     {
       "endCharacter": 61,
-      "endLine": 4900,
+      "endLine": 4933,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 4900
+      "startLine": 4933
     },
     {
       "endCharacter": 61,
-      "endLine": 4900,
+      "endLine": 4933,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 4900
+      "startLine": 4933
     },
     {
       "endCharacter": 67,
-      "endLine": 4901,
+      "endLine": 4934,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 4901
+      "startLine": 4934
     },
     {
       "endCharacter": 67,
-      "endLine": 4901,
+      "endLine": 4934,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 4901
+      "startLine": 4934
     },
     {
       "endCharacter": 73,
-      "endLine": 4902,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 39,
-      "startLine": 4902
-    },
-    {
-      "endCharacter": 73,
-      "endLine": 4902,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 39,
-      "startLine": 4902
-    },
-    {
-      "endCharacter": 61,
-      "endLine": 4903,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 33,
-      "startLine": 4903
-    },
-    {
-      "endCharacter": 61,
-      "endLine": 4903,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 33,
-      "startLine": 4903
-    },
-    {
-      "endCharacter": 76,
-      "endLine": 4907,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 46,
-      "startLine": 4907
-    },
-    {
-      "endCharacter": 76,
-      "endLine": 4907,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 46,
-      "startLine": 4907
-    },
-    {
-      "endCharacter": 89,
-      "endLine": 4909,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 52,
-      "startLine": 4909
-    },
-    {
-      "endCharacter": 89,
-      "endLine": 4909,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 52,
-      "startLine": 4909
-    },
-    {
-      "endCharacter": 83,
-      "endLine": 4910,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 49,
-      "startLine": 4910
-    },
-    {
-      "endCharacter": 83,
-      "endLine": 4910,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 49,
-      "startLine": 4910
-    },
-    {
-      "endCharacter": 57,
       "endLine": 4935,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
-      "startCharacter": 31,
+      "startCharacter": 39,
       "startLine": 4935
     },
     {
-      "endCharacter": 57,
+      "endCharacter": 73,
       "endLine": 4935,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
-      "startCharacter": 31,
+      "startCharacter": 39,
       "startLine": 4935
     },
     {
-      "endCharacter": 65,
+      "endCharacter": 61,
       "endLine": 4936,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 33,
+      "startLine": 4936
+    },
+    {
+      "endCharacter": 61,
+      "endLine": 4936,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 33,
+      "startLine": 4936
+    },
+    {
+      "endCharacter": 76,
+      "endLine": 4940,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 46,
+      "startLine": 4940
+    },
+    {
+      "endCharacter": 76,
+      "endLine": 4940,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 46,
+      "startLine": 4940
+    },
+    {
+      "endCharacter": 89,
+      "endLine": 4942,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 52,
+      "startLine": 4942
+    },
+    {
+      "endCharacter": 89,
+      "endLine": 4942,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 52,
+      "startLine": 4942
+    },
+    {
+      "endCharacter": 83,
+      "endLine": 4943,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 49,
+      "startLine": 4943
+    },
+    {
+      "endCharacter": 83,
+      "endLine": 4943,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 49,
+      "startLine": 4943
+    },
+    {
+      "endCharacter": 57,
+      "endLine": 4968,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 31,
+      "startLine": 4968
+    },
+    {
+      "endCharacter": 57,
+      "endLine": 4968,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 31,
+      "startLine": 4968
+    },
+    {
+      "endCharacter": 65,
+      "endLine": 4969,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4936
+      "startLine": 4969
     },
     {
       "endCharacter": 65,
-      "endLine": 4936,
+      "endLine": 4969,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4936
+      "startLine": 4969
     },
     {
       "endCharacter": 67,
-      "endLine": 4938,
+      "endLine": 4971,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 4938
+      "startLine": 4971
     },
     {
       "endCharacter": 67,
-      "endLine": 4938,
+      "endLine": 4971,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 4938
+      "startLine": 4971
     },
     {
       "endCharacter": 87,
-      "endLine": 4941,
+      "endLine": 4974,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4941
+      "startLine": 4974
     },
     {
       "endCharacter": 87,
-      "endLine": 4941,
+      "endLine": 4974,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4941
+      "startLine": 4974
     },
     {
       "endCharacter": 93,
-      "endLine": 4942,
+      "endLine": 4975,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4942
+      "startLine": 4975
     },
     {
       "endCharacter": 93,
-      "endLine": 4942,
+      "endLine": 4975,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4942
+      "startLine": 4975
     },
     {
       "endCharacter": 89,
-      "endLine": 4943,
+      "endLine": 4976,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 47,
-      "startLine": 4943
+      "startLine": 4976
     },
     {
       "endCharacter": 89,
-      "endLine": 4943,
+      "endLine": 4976,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 47,
-      "startLine": 4943
+      "startLine": 4976
     },
     {
       "endCharacter": 89,
-      "endLine": 4944,
+      "endLine": 4977,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4944
+      "startLine": 4977
     },
     {
       "endCharacter": 89,
-      "endLine": 4944,
+      "endLine": 4977,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4944
+      "startLine": 4977
     },
     {
       "endCharacter": 75,
-      "endLine": 4945,
+      "endLine": 4978,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4945
+      "startLine": 4978
     },
     {
       "endCharacter": 75,
-      "endLine": 4945,
+      "endLine": 4978,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4945
+      "startLine": 4978
     },
     {
       "endCharacter": 33,
-      "endLine": 36,
+      "endLine": 39,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "Argument of type \"Scalar\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Scalar\" is not assignable to type \"ConvertibleToInt\"\n    Type \"complex\" is not assignable to type \"ConvertibleToInt\"\n      \"complex\" is not assignable to \"str\"\n      \"complex\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"complex\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"complex\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 20,
-      "startLine": 36
+      "startLine": 39
     },
     {
       "endCharacter": 33,
-      "endLine": 36,
+      "endLine": 39,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "Argument of type \"Scalar\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Scalar\" is not assignable to type \"ConvertibleToInt\"\n    Type \"complex\" is not assignable to type \"ConvertibleToInt\"\n      \"complex\" is not assignable to \"str\"\n      \"complex\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"complex\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"complex\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 20,
-      "startLine": 36
+      "startLine": 39
     },
     {
       "endCharacter": 17,
-      "endLine": 62,
+      "endLine": 68,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "\"can_short\" overrides symbol of same name in class \"IStrategy\"\n  \"property\" is not assignable to \"bool\"",
       "rule": "reportIncompatibleVariableOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 62
+      "startLine": 68
     },
     {
       "endCharacter": 19,
-      "endLine": 66,
+      "endLine": 161,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "\"protections\" overrides symbol of same name in class \"IStrategy\"\n  \"property\" is not assignable to \"list[Unknown]\"",
       "rule": "reportIncompatibleVariableOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 66
+      "startLine": 161
     },
     {
       "endCharacter": 72,
-      "endLine": 88,
+      "endLine": 183,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "No overloads for \"__call__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 88
+      "startLine": 183
     },
     {
       "endCharacter": 71,
-      "endLine": 88,
+      "endLine": 183,
       "file": "ReforceXY/user_data/strategies/RLAgentStrategy.py",
       "message": "Argument of type \"Series[Any] | None\" cannot be assigned to parameter \"x1\" of type \"_SupportsArrayUFunc\" in function \"__call__\"\n  Type \"Series[Any] | None\" is not assignable to type \"_SupportsArrayUFunc\"\n    \"None\" is incompatible with protocol \"_SupportsArrayUFunc\"\n      \"__array_ufunc__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 88
+      "startLine": 183
     }
   ],
   "filesAnalyzed": 3,

--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -9,14 +9,14 @@
   "stake_amount": "unlimited",
   "tradable_balance_ratio": 0.99,
   "fiat_display_currency": "USD",
-  "dry_run": true,
+  "dry_run": true, // Research profile default; live requires an explicit promotion overlay
   "dry_run_wallet": 1000,
   "cancel_open_orders_on_exit": false,
   // "trading_mode": "futures",
   // "margin_mode": "isolated",
   // "leverage": 2.0,
   "trading_mode": "spot",
-  "stoploss": -0.99,
+  "stoploss": -0.99, // Research sentinel; the live profile must override it
   "unfilledtimeout": {
     "entry": 10,
     "exit": 10,
@@ -89,6 +89,10 @@
       "method": "StaticPairList"
     }
   ],
+  "reforcexy_execution": {
+    "profile": "research",
+    "protections": []
+  },
   "telegram": {
     "enabled": false,
     "token": "",

--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -9,14 +9,14 @@
   "stake_amount": "unlimited",
   "tradable_balance_ratio": 0.99,
   "fiat_display_currency": "USD",
-  "dry_run": true,
+  "dry_run": true, // Research profile default; live requires an explicit promotion overlay
   "dry_run_wallet": 1000,
   "cancel_open_orders_on_exit": false,
   // "trading_mode": "futures",
   // "margin_mode": "isolated",
   // "leverage": 2.0,
   "trading_mode": "spot",
-  "stoploss": -0.99,
+  "stoploss": -0.99, // Research sentinel; the live profile must override it
   "unfilledtimeout": {
     "entry": 10,
     "exit": 10,
@@ -90,6 +90,9 @@
     }
   ],
   "custom_protections": [],
+  "reforcexy_execution": {
+    "profile": "research"
+  },
   "telegram": {
     "enabled": false,
     "token": "",

--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -17,6 +17,8 @@
   // "leverage": 2.0,
   "trading_mode": "spot",
   "stoploss": -0.99,
+  "use_exit_signal": true,
+  "exit_profit_only": false,
   "unfilledtimeout": {
     "entry": 10,
     "exit": 10,
@@ -176,6 +178,7 @@
       "n_envs": 8, // Number of DummyVecEnv or SubProcVecEnv training environments
       "multiprocessing": true, // Use SubprocVecEnv if n_envs>1 (otherwise DummyVecEnv)
       "frame_stacking": 2, // Number of VecFrameStack stacks (set > 1 to use)
+      "inference_masking": true, // Required for MaskablePPO inference
       "lr_schedule": false, // Enable learning rate linear schedule
       "cr_schedule": false, // Enable clip range linear schedule
       "max_no_improvement_evals": 0, // Maximum consecutive evaluations without a new best model

--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -9,14 +9,14 @@
   "stake_amount": "unlimited",
   "tradable_balance_ratio": 0.99,
   "fiat_display_currency": "USD",
-  "dry_run": true, // Research profile default; live requires an explicit promotion overlay
+  "dry_run": true,
   "dry_run_wallet": 1000,
   "cancel_open_orders_on_exit": false,
   // "trading_mode": "futures",
   // "margin_mode": "isolated",
   // "leverage": 2.0,
   "trading_mode": "spot",
-  "stoploss": -0.99, // Research sentinel; the live profile must override it
+  "stoploss": -0.99,
   "unfilledtimeout": {
     "entry": 10,
     "exit": 10,

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -31,8 +31,8 @@ import numpy as np
 import optunahub
 import pandas as pd
 import torch as th
-from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.enums import RunMode
+from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.RL.Base5ActionRLEnv import Actions, Base5ActionRLEnv, Positions
 from freqtrade.freqai.RL.BaseEnvironment import BaseEnvironment
@@ -392,10 +392,7 @@ class ReforceXY(BaseReinforcementLearningModel):
         inference_masking = self.rl_config.get(
             "inference_masking", ReforceXY.DEFAULT_INFERENCE_MASKING
         )
-        if (
-            self.model_type == ReforceXY._MODEL_TYPES[2]
-            and inference_masking is not True
-        ):
+        if self.model_type == ReforceXY._MODEL_TYPES[2] and inference_masking is not True:
             raise ValueError(
                 "Config [global]: MaskablePPO requires inference_masking=true "
                 "so inference uses the same ReforceXY action-mask mechanism as "
@@ -404,10 +401,7 @@ class ReforceXY(BaseReinforcementLearningModel):
 
         action_masking = self.model_type == ReforceXY._MODEL_TYPES[2]
         configured_action_masking = self.rl_config.get("action_masking")
-        if (
-            "action_masking" in self.rl_config
-            and configured_action_masking is not action_masking
-        ):
+        if "action_masking" in self.rl_config and configured_action_masking is not action_masking:
             raise ValueError(
                 "Config [global]: action_masking="
                 f"{configured_action_masking!r} conflicts with "
@@ -424,9 +418,7 @@ class ReforceXY(BaseReinforcementLearningModel):
             )
 
         self.inference_masking: bool = inference_masking
-        self.recurrent: bool = (
-            self.model_type == ReforceXY._MODEL_TYPES[1]
-        )  # "RecurrentPPO"
+        self.recurrent: bool = self.model_type == ReforceXY._MODEL_TYPES[1]  # "RecurrentPPO"
         self.lr_schedule: bool = self.rl_config.get("lr_schedule", False)
         self.cr_schedule: bool = self.rl_config.get("cr_schedule", False)
         self.n_envs: int = self.rl_config.get("n_envs", 1)

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -402,14 +402,27 @@ class ReforceXY(BaseReinforcementLearningModel):
                 "training and evaluation."
             )
 
+        action_masking = self.model_type == ReforceXY._MODEL_TYPES[2]
+        configured_action_masking = self.rl_config.get("action_masking")
+        if (
+            "action_masking" in self.rl_config
+            and configured_action_masking is not action_masking
+        ):
+            raise ValueError(
+                "Config [global]: action_masking="
+                f"{configured_action_masking!r} conflicts with "
+                f"model_type={self.model_type!r}; expected {action_masking!r}."
+            )
+        self.action_masking: bool = action_masking
+        self.rl_config["action_masking"] = action_masking
+
         self.pairs: list[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
                 "Config [global]: missing 'pair_whitelist' in exchange section "
                 "or StaticPairList method not defined in pairlists configuration"
             )
-        self.action_masking: bool = self.model_type == ReforceXY._MODEL_TYPES[2]  # "MaskablePPO"
-        self.rl_config.setdefault("action_masking", self.action_masking)
+
         self.inference_masking: bool = inference_masking
         self.recurrent: bool = (
             self.model_type == ReforceXY._MODEL_TYPES[1]

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -32,6 +32,7 @@ import matplotlib.transforms as mtransforms
 import numpy as np
 import optunahub
 import torch as th
+from freqtrade.enums import RunMode
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.RL.Base5ActionRLEnv import Actions, Base5ActionRLEnv, Positions
 from freqtrade.freqai.RL.BaseEnvironment import BaseEnvironment
@@ -202,6 +203,7 @@ class ReforceXY(BaseReinforcementLearningModel):
 
     DEFAULT_EFFICIENCY_MIN_RANGE_EPSILON: Final[float] = 1e-6
     DEFAULT_EFFICIENCY_MIN_RANGE_FRACTION: Final[float] = 0.01
+    DEFAULT_INFERENCE_MASKING: Final[bool] = True
 
     _MODEL_TYPES: Final[Tuple[ModelType, ...]] = (
         "PPO",
@@ -290,6 +292,30 @@ class ReforceXY(BaseReinforcementLearningModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        runmode = self.config.get("runmode")
+        if self.model_type == ReforceXY._MODEL_TYPES[1] and runmode in (
+            RunMode.DRY_RUN,
+            RunMode.LIVE,
+        ):
+            raise ValueError(
+                "Config [global]: RecurrentPPO is disabled in dry-run and live "
+                "because ReforceXY does not maintain complete causal observation "
+                "history or durable episode state across process restarts."
+            )
+
+        inference_masking = self.rl_config.get(
+            "inference_masking", ReforceXY.DEFAULT_INFERENCE_MASKING
+        )
+        if (
+            self.model_type == ReforceXY._MODEL_TYPES[2]
+            and inference_masking is not True
+        ):
+            raise ValueError(
+                "Config [global]: MaskablePPO requires inference_masking=true "
+                "so inference uses the same ReforceXY action-mask mechanism as "
+                "training and evaluation."
+            )
+
         self.pairs: List[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
@@ -300,7 +326,7 @@ class ReforceXY(BaseReinforcementLearningModel):
             self.model_type == ReforceXY._MODEL_TYPES[2]
         )  # "MaskablePPO"
         self.rl_config.setdefault("action_masking", self.action_masking)
-        self.inference_masking: bool = self.rl_config.get("inference_masking", True)
+        self.inference_masking: bool = inference_masking
         self.recurrent: bool = (
             self.model_type == ReforceXY._MODEL_TYPES[1]
         )  # "RecurrentPPO"

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -32,6 +32,7 @@ import optunahub
 import pandas as pd
 import torch as th
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
+from freqtrade.enums import RunMode
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.RL.Base5ActionRLEnv import Actions, Base5ActionRLEnv, Positions
 from freqtrade.freqai.RL.BaseEnvironment import BaseEnvironment
@@ -291,6 +292,7 @@ class ReforceXY(BaseReinforcementLearningModel):
 
     DEFAULT_EFFICIENCY_MIN_RANGE_EPSILON: Final[float] = 1e-6
     DEFAULT_EFFICIENCY_MIN_RANGE_FRACTION: Final[float] = 0.01
+    DEFAULT_INFERENCE_MASKING: Final[bool] = True
 
     _MODEL_TYPES: Final[tuple[ModelType, ...]] = (
         "PPO",
@@ -376,6 +378,30 @@ class ReforceXY(BaseReinforcementLearningModel):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
+        runmode = self.config.get("runmode")
+        if self.model_type == ReforceXY._MODEL_TYPES[1] and runmode in (
+            RunMode.DRY_RUN,
+            RunMode.LIVE,
+        ):
+            raise ValueError(
+                "Config [global]: RecurrentPPO is disabled in dry-run and live "
+                "because ReforceXY does not maintain complete causal observation "
+                "history or durable episode state across process restarts."
+            )
+
+        inference_masking = self.rl_config.get(
+            "inference_masking", ReforceXY.DEFAULT_INFERENCE_MASKING
+        )
+        if (
+            self.model_type == ReforceXY._MODEL_TYPES[2]
+            and inference_masking is not True
+        ):
+            raise ValueError(
+                "Config [global]: MaskablePPO requires inference_masking=true "
+                "so inference uses the same ReforceXY action-mask mechanism as "
+                "training and evaluation."
+            )
+
         self.pairs: list[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
@@ -384,8 +410,10 @@ class ReforceXY(BaseReinforcementLearningModel):
             )
         self.action_masking: bool = self.model_type == ReforceXY._MODEL_TYPES[2]  # "MaskablePPO"
         self.rl_config.setdefault("action_masking", self.action_masking)
-        self.inference_masking: bool = self.rl_config.get("inference_masking", True)
-        self.recurrent: bool = self.model_type == ReforceXY._MODEL_TYPES[1]  # "RecurrentPPO"
+        self.inference_masking: bool = inference_masking
+        self.recurrent: bool = (
+            self.model_type == ReforceXY._MODEL_TYPES[1]
+        )  # "RecurrentPPO"
         self.lr_schedule: bool = self.rl_config.get("lr_schedule", False)
         self.cr_schedule: bool = self.rl_config.get("cr_schedule", False)
         self.n_envs: int = self.rl_config.get("n_envs", 1)

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -316,16 +316,26 @@ class ReforceXY(BaseReinforcementLearningModel):
                 "training and evaluation."
             )
 
+        action_masking = self.model_type == ReforceXY._MODEL_TYPES[2]
+        configured_action_masking = self.rl_config.get("action_masking")
+        if (
+            "action_masking" in self.rl_config
+            and configured_action_masking is not action_masking
+        ):
+            raise ValueError(
+                "Config [global]: action_masking="
+                f"{configured_action_masking!r} conflicts with "
+                f"model_type={self.model_type!r}; expected {action_masking!r}."
+            )
+        self.action_masking: bool = action_masking
+        self.rl_config["action_masking"] = action_masking
+
         self.pairs: List[str] = self.config.get("exchange", {}).get("pair_whitelist")
         if not self.pairs:
             raise ValueError(
                 "Config [global]: missing 'pair_whitelist' in exchange section "
                 "or StaticPairList method not defined in pairlists configuration"
             )
-        self.action_masking: bool = (
-            self.model_type == ReforceXY._MODEL_TYPES[2]
-        )  # "MaskablePPO"
-        self.rl_config.setdefault("action_masking", self.action_masking)
         self.inference_masking: bool = inference_masking
         self.recurrent: bool = (
             self.model_type == ReforceXY._MODEL_TYPES[1]

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -69,14 +69,12 @@ class RLAgentStrategy(IStrategy):
     def can_short(self) -> bool:
         return self.is_short_allowed()
 
-    def _execution_contract_error(self) -> Optional[str]:
+    def _execution_contract_error(self) -> str | None:
         execution_config = self.config.get("reforcexy_execution", {})
         if not isinstance(execution_config, Mapping):
             return "Config: 'reforcexy_execution' must be an object."
 
-        profile = execution_config.get(
-            "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
-        )
+        profile = execution_config.get("profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE)
         if profile not in RLAgentStrategy._EXECUTION_PROFILES:
             return (
                 f"Config: invalid ReforceXY execution profile {profile!r}. "
@@ -84,19 +82,12 @@ class RLAgentStrategy(IStrategy):
             )
 
         if getattr(self, "use_exit_signal", None) is not True:
-            return (
-                "Config: ReforceXY RL actions require Freqtrade use_exit_signal=true."
-            )
+            return "Config: ReforceXY RL actions require Freqtrade use_exit_signal=true."
         if getattr(self, "exit_profit_only", None) is not False:
-            return (
-                "Config: ReforceXY RL actions require Freqtrade exit_profit_only=false."
-            )
+            return "Config: ReforceXY RL actions require Freqtrade exit_profit_only=false."
 
         runmode = self.config.get("runmode")
-        if (
-            runmode == RunMode.LIVE
-            and profile != RLAgentStrategy._EXECUTION_PROFILES[1]
-        ):
+        if runmode == RunMode.LIVE and profile != RLAgentStrategy._EXECUTION_PROFILES[1]:
             return (
                 "Config: ReforceXY refuses live trading under the 'research' "
                 "execution profile. Set profile='live' only after preregistering "
@@ -119,18 +110,6 @@ class RLAgentStrategy(IStrategy):
 
         return None
 
-    @property
-    def protections(self) -> list[dict[str, Any]]:
-        execution_config = self.config.get("reforcexy_execution", {})
-        if not isinstance(execution_config, Mapping):
-            raise ValueError("Config: 'reforcexy_execution' must be an object.")
-        protections = execution_config.get("protections", [])
-        if not isinstance(protections, list):
-            raise ValueError(
-                "Config: 'reforcexy_execution.protections' must be a list."
-            )
-        return protections
-
     def bot_start(self, **kwargs: Any) -> None:
         contract_error = self._execution_contract_error()
         if contract_error is not None:
@@ -138,8 +117,7 @@ class RLAgentStrategy(IStrategy):
 
         runmode = self.config.get("runmode")
         logger.info(
-            "ReforceXY execution contract: profile=%s runmode=%s stoploss=%s "
-            "protections=%d",
+            "ReforceXY execution contract: profile=%s runmode=%s stoploss=%s protections=%d",
             self.config.get("reforcexy_execution", {}).get(
                 "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
             ),
@@ -156,7 +134,7 @@ class RLAgentStrategy(IStrategy):
         rate: float,
         time_in_force: str,
         current_time: datetime.datetime,
-        entry_tag: Optional[str],
+        entry_tag: str | None,
         side: str,
         **kwargs: Any,
     ) -> bool:

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -83,6 +83,15 @@ class RLAgentStrategy(IStrategy):
                 f"Expected one of: {list(RLAgentStrategy._EXECUTION_PROFILES)}."
             )
 
+        if getattr(self, "use_exit_signal", None) is not True:
+            return (
+                "Config: ReforceXY RL actions require Freqtrade use_exit_signal=true."
+            )
+        if getattr(self, "exit_profit_only", None) is not False:
+            return (
+                "Config: ReforceXY RL actions require Freqtrade exit_profit_only=false."
+            )
+
         runmode = self.config.get("runmode")
         if (
             runmode == RunMode.LIVE

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+import math
+from collections.abc import Mapping
 from functools import reduce
 from typing import Any, Final, Literal, Optional
 
@@ -7,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 # import talib.abstract as ta
+from freqtrade.enums import RunMode
 from freqtrade.persistence import Trade
 from freqtrade.strategy import IStrategy
 from pandas import DataFrame
@@ -58,10 +61,115 @@ class RLAgentStrategy(IStrategy):
     _ACTION_EXIT_LONG: Final[int] = 2
     _ACTION_ENTER_SHORT: Final[int] = 3
     _ACTION_EXIT_SHORT: Final[int] = 4
+    _EXECUTION_PROFILES: Final[tuple[str, ...]] = ("research", "live")
+    _DEFAULT_EXECUTION_PROFILE: Final[str] = "research"
+    _RESEARCH_STOPLOSS_SENTINEL: Final[float] = -0.99
 
     @property
     def can_short(self) -> bool:
         return self.is_short_allowed()
+
+    def _execution_contract_error(self) -> Optional[str]:
+        execution_config = self.config.get("reforcexy_execution", {})
+        if not isinstance(execution_config, Mapping):
+            return "Config: 'reforcexy_execution' must be an object."
+
+        profile = execution_config.get(
+            "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
+        )
+        if profile not in RLAgentStrategy._EXECUTION_PROFILES:
+            return (
+                f"Config: invalid ReforceXY execution profile {profile!r}. "
+                f"Expected one of: {list(RLAgentStrategy._EXECUTION_PROFILES)}."
+            )
+
+        runmode = self.config.get("runmode")
+        if (
+            runmode == RunMode.LIVE
+            and profile != RLAgentStrategy._EXECUTION_PROFILES[1]
+        ):
+            return (
+                "Config: ReforceXY refuses live trading under the 'research' "
+                "execution profile. Set profile='live' only after preregistering "
+                "and dry-running the live risk controls."
+            )
+
+        if profile == RLAgentStrategy._EXECUTION_PROFILES[1]:
+            try:
+                stoploss = float(self.stoploss)
+            except (TypeError, ValueError):
+                return "Config: the ReforceXY live stoploss must be a finite number."
+            if (
+                not math.isfinite(stoploss)
+                or stoploss <= RLAgentStrategy._RESEARCH_STOPLOSS_SENTINEL
+            ):
+                return (
+                    "Config: the ReforceXY 'live' execution profile requires a "
+                    "finite Freqtrade stoploss above the research sentinel -0.99."
+                )
+
+        return None
+
+    @property
+    def protections(self) -> list[dict[str, Any]]:
+        execution_config = self.config.get("reforcexy_execution", {})
+        if not isinstance(execution_config, Mapping):
+            raise ValueError("Config: 'reforcexy_execution' must be an object.")
+        protections = execution_config.get("protections", [])
+        if not isinstance(protections, list):
+            raise ValueError(
+                "Config: 'reforcexy_execution.protections' must be a list."
+            )
+        return protections
+
+    def bot_start(self, **kwargs: Any) -> None:
+        contract_error = self._execution_contract_error()
+        if contract_error is not None:
+            raise ValueError(contract_error)
+
+        runmode = self.config.get("runmode")
+        logger.info(
+            "ReforceXY execution contract: profile=%s runmode=%s stoploss=%s "
+            "protections=%d",
+            self.config.get("reforcexy_execution", {}).get(
+                "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
+            ),
+            getattr(runmode, "value", runmode),
+            self.stoploss,
+            len(self.protections),
+        )
+
+    def confirm_trade_entry(
+        self,
+        pair: str,
+        order_type: str,
+        amount: float,
+        rate: float,
+        time_in_force: str,
+        current_time: datetime.datetime,
+        entry_tag: Optional[str],
+        side: str,
+        **kwargs: Any,
+    ) -> bool:
+        try:
+            contract_error = self._execution_contract_error()
+        except Exception as error:
+            logger.critical(
+                "ReforceXY entry blocked: pair=%s side=%s contract_check_error=%r",
+                pair,
+                side,
+                error,
+            )
+            return False
+        if contract_error is not None:
+            logger.critical(
+                "ReforceXY entry blocked: pair=%s side=%s reason=%s",
+                pair,
+                side,
+                contract_error,
+            )
+            return False
+        return True
 
     # def feature_engineering_expand_all(
     #     self, dataframe: DataFrame, period: int, metadata: dict[str, Any], **kwargs
@@ -155,6 +263,7 @@ class RLAgentStrategy(IStrategy):
                     dataframe.at[last_index, "exit_short"] = 1
                 else:
                     dataframe.at[last_index, "exit_long"] = 1
+                dataframe.at[last_index, "exit_tag"] = "freqai_model_expired"
 
         return dataframe
 

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -1,5 +1,7 @@
 import datetime
 import logging
+import math
+from collections.abc import Mapping
 from functools import reduce
 from typing import Any, Final, Literal
 
@@ -7,6 +9,7 @@ import numpy as np
 import pandas as pd
 
 # import talib.abstract as ta
+from freqtrade.enums import RunMode
 from freqtrade.persistence import Trade
 from freqtrade.strategy import IStrategy
 from pandas import DataFrame
@@ -58,10 +61,115 @@ class RLAgentStrategy(IStrategy):
     _ACTION_EXIT_LONG: Final[int] = 2
     _ACTION_ENTER_SHORT: Final[int] = 3
     _ACTION_EXIT_SHORT: Final[int] = 4
+    _EXECUTION_PROFILES: Final[tuple[str, ...]] = ("research", "live")
+    _DEFAULT_EXECUTION_PROFILE: Final[str] = "research"
+    _RESEARCH_STOPLOSS_SENTINEL: Final[float] = -0.99
 
     @property
     def can_short(self) -> bool:
         return self.is_short_allowed()
+
+    def _execution_contract_error(self) -> Optional[str]:
+        execution_config = self.config.get("reforcexy_execution", {})
+        if not isinstance(execution_config, Mapping):
+            return "Config: 'reforcexy_execution' must be an object."
+
+        profile = execution_config.get(
+            "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
+        )
+        if profile not in RLAgentStrategy._EXECUTION_PROFILES:
+            return (
+                f"Config: invalid ReforceXY execution profile {profile!r}. "
+                f"Expected one of: {list(RLAgentStrategy._EXECUTION_PROFILES)}."
+            )
+
+        runmode = self.config.get("runmode")
+        if (
+            runmode == RunMode.LIVE
+            and profile != RLAgentStrategy._EXECUTION_PROFILES[1]
+        ):
+            return (
+                "Config: ReforceXY refuses live trading under the 'research' "
+                "execution profile. Set profile='live' only after preregistering "
+                "and dry-running the live risk controls."
+            )
+
+        if profile == RLAgentStrategy._EXECUTION_PROFILES[1]:
+            try:
+                stoploss = float(self.stoploss)
+            except (TypeError, ValueError):
+                return "Config: the ReforceXY live stoploss must be a finite number."
+            if (
+                not math.isfinite(stoploss)
+                or stoploss <= RLAgentStrategy._RESEARCH_STOPLOSS_SENTINEL
+            ):
+                return (
+                    "Config: the ReforceXY 'live' execution profile requires a "
+                    "finite Freqtrade stoploss above the research sentinel -0.99."
+                )
+
+        return None
+
+    @property
+    def protections(self) -> list[dict[str, Any]]:
+        execution_config = self.config.get("reforcexy_execution", {})
+        if not isinstance(execution_config, Mapping):
+            raise ValueError("Config: 'reforcexy_execution' must be an object.")
+        protections = execution_config.get("protections", [])
+        if not isinstance(protections, list):
+            raise ValueError(
+                "Config: 'reforcexy_execution.protections' must be a list."
+            )
+        return protections
+
+    def bot_start(self, **kwargs: Any) -> None:
+        contract_error = self._execution_contract_error()
+        if contract_error is not None:
+            raise ValueError(contract_error)
+
+        runmode = self.config.get("runmode")
+        logger.info(
+            "ReforceXY execution contract: profile=%s runmode=%s stoploss=%s "
+            "protections=%d",
+            self.config.get("reforcexy_execution", {}).get(
+                "profile", RLAgentStrategy._DEFAULT_EXECUTION_PROFILE
+            ),
+            getattr(runmode, "value", runmode),
+            self.stoploss,
+            len(self.protections),
+        )
+
+    def confirm_trade_entry(
+        self,
+        pair: str,
+        order_type: str,
+        amount: float,
+        rate: float,
+        time_in_force: str,
+        current_time: datetime.datetime,
+        entry_tag: Optional[str],
+        side: str,
+        **kwargs: Any,
+    ) -> bool:
+        try:
+            contract_error = self._execution_contract_error()
+        except Exception as error:
+            logger.critical(
+                "ReforceXY entry blocked: pair=%s side=%s contract_check_error=%r",
+                pair,
+                side,
+                error,
+            )
+            return False
+        if contract_error is not None:
+            logger.critical(
+                "ReforceXY entry blocked: pair=%s side=%s reason=%s",
+                pair,
+                side,
+                contract_error,
+            )
+            return False
+        return True
 
     @property
     def protections(self) -> list[dict[str, Any]]:
@@ -160,6 +268,7 @@ class RLAgentStrategy(IStrategy):
                     dataframe.at[last_index, "exit_short"] = 1
                 else:
                     dataframe.at[last_index, "exit_long"] = 1
+                dataframe.at[last_index, "exit_tag"] = "freqai_model_expired"
 
         return dataframe
 


### PR DESCRIPTION
## Summary

- add explicit `research` and `live` ReforceXY execution profiles
- fail closed at `bot_start()` and `confirm_trade_entry()` when live trading is not explicitly promoted or still uses the `-0.99` research stoploss sentinel
- require the resolved native Freqtrade exit settings `use_exit_signal=true` and `exit_profit_only=false` for RL action profiles
- require `inference_masking=true` for MaskablePPO while preserving ReforceXY's shared action-mask mechanism
- derive `action_masking` from `model_type`, reject contradictory or non-boolean explicit values, and write the canonical value back to `rl_config`
- reject RecurrentPPO in dry-run and live before the local LSTM cache is initialized; ReforceXY does not yet maintain complete causal history or durable episode state across restarts
- pass preregistered protection definitions to Freqtrade's native `ProtectionManager`, with an empty threshold-free default
- keep `do_predict == 2` on the native tagged `EXIT_SIGNAL` path as `freqai_model_expired`, never as `force_exit`
- document promotion, model, protection, holdout, and native execution-diagnostic boundaries

## Risk and ownership boundaries

Freqtrade remains authoritative for wallets, stakes, exposure, orders, fills, `should_exit`, stoploss-on-exchange, forced exits, emergency exits, liquidations, and protections. This change does not clone the wallet, order engine, protection manager, or exit engine; inject wallet state into the policy; add a custom stoploss; or override exit/fill callbacks.

Economic stoploss and protection thresholds must be versioned and preregistered before final validation. Holdout results may accept or reject the frozen candidate, but must not select or revise those thresholds.

No ReforceXY test is committed. Validation uses an external harness against the real runtime.

## Validation

Scoped static checks:

- `ruff check ReforceXY/user_data/strategies/RLAgentStrategy.py ReforceXY/user_data/freqaimodels/ReforceXY.py`
- `ruff format --check ReforceXY/user_data/strategies/RLAgentStrategy.py ReforceXY/user_data/freqaimodels/ReforceXY.py`
- `python -m compileall -q ReforceXY/user_data/strategies/RLAgentStrategy.py ReforceXY/user_data/freqaimodels/ReforceXY.py`
- `git diff --check`
- Freqtrade config-template parsing and `StrategyResolver` loading

Wave 1 external harness:

- project image `reforcexy-freqtrade@sha256:cd78d9984dfc170228d77bb9a201599e08f05bea84309ebfd314cd4da8553238`
- built on `freqtradeorg/freqtrade@sha256:9caa7cb0a8a13f9639ad3980114f3af0ffbd896d43736eeb65f8d0db8c009093`
- Freqtrade 2026.6, Python 3.14.6, Gymnasium 1.2.3, Stable-Baselines3/SB3-Contrib 2.8.0, Optuna 4.9.0
- all four `use_exit_signal` / `exit_profit_only` combinations exercised through real `IStrategy.should_exit`; only `true/false` produced an `EXIT_SIGNAL` for a losing trade
- losing RL action persisted native `exit_reason=exit_signal`
- `do_predict == 2` persisted `exit_reason=freqai_model_expired` and the same order tag through native `FreqtradeBot` / `Trade`
- PPO with `action_masking` absent or `false` produced canonical `false` in the environment; explicit `true` failed closed
- MaskablePPO with `action_masking` absent or `true` produced canonical `true` in the environment; explicit `false` failed closed
- non-boolean explicit `action_masking` values failed closed, and MaskablePPO with `inference_masking=false` remained rejected
- MaskablePPO training/evaluation/inference probes used masks (4 training calls, 40 evaluation calls, 3 inference calls, 10/10 valid masked predictions); PPO remained unmasked (0 training mask calls, evaluation masking disabled, 3 inference calls without masks)
- RecurrentPPO dry-run and live failed before `_lstm_states_cache` initialization
- research/live/stoploss cases and native `ProtectionManager` loading passed
- repository mounted read-only; SQLite was in memory and exchange/wallet boundaries were local harness doubles around native Freqtrade methods

Previous contract harness:

- Freqtrade 2026.4 and 2026.6: 11/11 research/live/profile/stoploss cases
- verified `bot_start()` failure propagation through `StrategyError`
- fail-closed `confirm_trade_entry()` behavior
- native `ProtectionManager` loading
- real `Trade` persistence confirming `freqai_model_expired` propagation from `exit_tag` to `exit_reason`
- no wallet reference and no added exit/fill callback

Three independent external reviews converged with no P0, P1, or P2 finding on the published commit.

## Residual limits

- The guard does not cancel exchange orders that already exist before startup; exchange-order reconciliation remains on Freqtrade's native path.
- A finite stoploss such as `-0.98` passes the structural sentinel barrier. Its economic adequacy remains a preregistered external promotion gate rather than a hardcoded threshold or holdout-selected value.
- Position adjustment is not enabled or introduced by this change.
- The in-memory RecurrentPPO cache can reuse state within one process, but it does not reconstruct complete causal observation history or persist episode state across process restarts. RecurrentPPO therefore remains unavailable in dry-run and live; this change does not claim to solve the POMDP/state-reconstruction problem.
- `do_predict == 2` remains an ordinary tagged `EXIT_SIGNAL`; it is not a privileged force-exit and still follows Freqtrade's native signal and order path.

## Scope

Independent draft based on `main` at `371435f2f79dc5b956d8960f2f2d0cb960c4054e`. Current reviewed head: `fe37720c4f2013fdad68006320b579e9c51903cb`. The diff is limited to the ReforceXY strategy, model, canonical template, and root documentation. No merge, rebase, force-push, QuickAdapter change, or tracked ReforceXY test is included.