### PR TITLE
refactor(quickadapter): deduplicate regressor (min,max) finite fallback

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3561,6 +3561,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return float(reduced)
         return fallback
 
+    # ±2.0 fallbacks are out-of-[-1, 1] normalized-range sentinels.
     @staticmethod
     def safe_min_pred(pred_label: pd.Series) -> float:
         return QuickAdapterRegressorV3._safe_pred(
@@ -3579,10 +3580,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         max_candidate: float,
         pred_label: pd.Series,
     ) -> tuple[float, float]:
-        # Finite candidates are returned unchanged (no ``float()`` coercion) to
-        # keep the pre-refactor behavior bit-for-bit; only non-finite candidates
-        # fall back to the explicit ±2.0 sentinels, which sit outside the default
-        # [-1, 1] normalized label range.
         if not np.isfinite(min_candidate):
             min_candidate = QuickAdapterRegressorV3.safe_min_pred(pred_label)
         if not np.isfinite(max_candidate):

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3579,6 +3579,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         max_candidate: float,
         pred_label: pd.Series,
     ) -> tuple[float, float]:
+        # Finite candidates are returned unchanged (no float() coercion) to
+        # preserve their dtype; only non-finite candidates fall back to the
+        # explicit ±2.0 out-of-domain sentinels of normalized labels.
         if not np.isfinite(min_candidate):
             min_candidate = QuickAdapterRegressorV3.safe_min_pred(pred_label)
         if not np.isfinite(max_candidate):

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3579,9 +3579,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         max_candidate: float,
         pred_label: pd.Series,
     ) -> tuple[float, float]:
-        # Finite candidates are returned unchanged (no float() coercion) to keep
-        # the pre-refactor behavior bit-for-bit; only non-finite candidates fall
-        # back to the explicit ±2.0 sentinels, which sit outside the default
+        # Finite candidates are returned unchanged (no ``float()`` coercion) to
+        # keep the pre-refactor behavior bit-for-bit; only non-finite candidates
+        # fall back to the explicit ±2.0 sentinels, which sit outside the default
         # [-1, 1] normalized label range.
         if not np.isfinite(min_candidate):
             min_candidate = QuickAdapterRegressorV3.safe_min_pred(pred_label)

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3544,32 +3544,46 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return pred_label_minima, pred_label_maxima
 
     @staticmethod
-    def safe_min_pred(pred_label: pd.Series) -> float:
+    def _safe_pred(
+        pred_label: pd.Series,
+        reducer: Callable[[pd.Series], float],
+        fallback: float,
+    ) -> float:
         try:
-            pred_label_minimum = pred_label.min()
+            reduced = reducer(pred_label)
         except Exception:
-            pred_label_minimum = None
+            reduced = None
         if (
-            pred_label_minimum is not None
-            and isinstance(pred_label_minimum, (int, float, np.number))
-            and np.isfinite(pred_label_minimum)
+            reduced is not None
+            and isinstance(reduced, (int, float, np.number))
+            and np.isfinite(reduced)
         ):
-            return float(pred_label_minimum)
-        return -2.0
+            return float(reduced)
+        return fallback
+
+    @staticmethod
+    def safe_min_pred(pred_label: pd.Series) -> float:
+        return QuickAdapterRegressorV3._safe_pred(
+            pred_label, lambda series: series.min(), -2.0
+        )
 
     @staticmethod
     def safe_max_pred(pred_label: pd.Series) -> float:
-        try:
-            pred_label_maximum = pred_label.max()
-        except Exception:
-            pred_label_maximum = None
-        if (
-            pred_label_maximum is not None
-            and isinstance(pred_label_maximum, (int, float, np.number))
-            and np.isfinite(pred_label_maximum)
-        ):
-            return float(pred_label_maximum)
-        return 2.0
+        return QuickAdapterRegressorV3._safe_pred(
+            pred_label, lambda series: series.max(), 2.0
+        )
+
+    @staticmethod
+    def _resolve_min_max(
+        min_candidate: float,
+        max_candidate: float,
+        pred_label: pd.Series,
+    ) -> tuple[float, float]:
+        if not np.isfinite(min_candidate):
+            min_candidate = QuickAdapterRegressorV3.safe_min_pred(pred_label)
+        if not np.isfinite(max_candidate):
+            max_candidate = QuickAdapterRegressorV3.safe_max_pred(pred_label)
+        return min_candidate, max_candidate
 
     @staticmethod
     def soft_extremum_min_max(
@@ -3584,12 +3598,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             pred_label, selection_method, keep_fraction
         )
         soft_minimum = soft_extremum(pred_label_minima, alpha=-alpha)
-        if not np.isfinite(soft_minimum):
-            soft_minimum = QuickAdapterRegressorV3.safe_min_pred(pred_label)
         soft_maximum = soft_extremum(pred_label_maxima, alpha=alpha)
-        if not np.isfinite(soft_maximum):
-            soft_maximum = QuickAdapterRegressorV3.safe_max_pred(pred_label)
-        return soft_minimum, soft_maximum
+        return QuickAdapterRegressorV3._resolve_min_max(
+            soft_minimum, soft_maximum, pred_label
+        )
 
     @staticmethod
     def median_min_max(
@@ -3605,17 +3617,13 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             min_val = np.nan
         else:
             min_val = np.nanmedian(pred_label_minima.to_numpy())
-        if not np.isfinite(min_val):
-            min_val = QuickAdapterRegressorV3.safe_min_pred(pred_label)
 
         if pred_label_maxima.empty:
             max_val = np.nan
         else:
             max_val = np.nanmedian(pred_label_maxima.to_numpy())
-        if not np.isfinite(max_val):
-            max_val = QuickAdapterRegressorV3.safe_max_pred(pred_label)
 
-        return min_val, max_val
+        return QuickAdapterRegressorV3._resolve_min_max(min_val, max_val, pred_label)
 
     @staticmethod
     def skimage_min_max(
@@ -3640,14 +3648,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         max_func = QuickAdapterRegressorV3.apply_skimage_threshold
 
         min_val = min_func(pred_label_minima, threshold_func)
-        if not np.isfinite(min_val):
-            min_val = QuickAdapterRegressorV3.safe_min_pred(pred_label)
-
         max_val = max_func(pred_label_maxima, threshold_func)
-        if not np.isfinite(max_val):
-            max_val = QuickAdapterRegressorV3.safe_max_pred(pred_label)
 
-        return min_val, max_val
+        return QuickAdapterRegressorV3._resolve_min_max(min_val, max_val, pred_label)
 
     @staticmethod
     def apply_skimage_threshold(

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -3579,9 +3579,10 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         max_candidate: float,
         pred_label: pd.Series,
     ) -> tuple[float, float]:
-        # Finite candidates are returned unchanged (no float() coercion) to
-        # preserve their dtype; only non-finite candidates fall back to the
-        # explicit ±2.0 out-of-domain sentinels of normalized labels.
+        # Finite candidates are returned unchanged (no float() coercion) to keep
+        # the pre-refactor behavior bit-for-bit; only non-finite candidates fall
+        # back to the explicit ±2.0 sentinels, which sit outside the default
+        # [-1, 1] normalized label range.
         if not np.isfinite(min_candidate):
             min_candidate = QuickAdapterRegressorV3.safe_min_pred(pred_label)
         if not np.isfinite(max_candidate):


### PR DESCRIPTION
## Summary

Deduplicates the repeated "resolve (min, max) with a finite fallback" tail shared by the three `QuickAdapterRegressorV3` prediction-threshold methods, per #173.

- Extract `_resolve_min_max(min_candidate, max_candidate, pred_label)` applying the finite fallback once; reused by `soft_extremum_min_max`, `median_min_max`, and `skimage_min_max`.
- Fold the `safe_min_pred`/`safe_max_pred` twins into a `_safe_pred(pred_label, reducer, fallback)` core with two thin wrappers. The load-bearing `±2.0` out-of-domain sentinels stay explicit as the `fallback` argument at each wrapper.

## Non-goals honored

- Per-method extrema computation (`get_pred_min_max`, soft-extremum, median, skimage) left untouched — only the shared fallback tail is deduplicated.
- `±2.0` sentinels remain explicit parameters, not hidden.

## Bit-for-bit equivalence

The finite branch returns the candidate **unchanged** (no `float()` coercion), preserving the exact pre-refactor dtype (`np.float64` from `np.nanmedian`/`soft_extremum`, native `float` from skimage); only the non-finite branch routes through the unchanged `safe_*_pred` fallback. Coercing a finite candidate with `float()` would change its dtype (e.g. `np.float32` → Python `float`; the numeric value is preserved under `==`, but strict bit-for-bit type equivalence would break), so it is deliberately avoided.

Verified in `quickadapter-freqtrade:latest` (numpy 2.4.6 / pandas 3.0.3 / skimage 0.26.0): an OLD-vs-NEW harness comparing value **and** type across finite/non-finite edge cases (empty/all-NaN/single/all-equal/±inf/int64/float32/bool/object/overflow series; mixed finite/non-finite candidate pairs; signed zero) reported 0 divergences.

## Quality gates

- `ruff check` — clean
- `ruff format --check` — clean
- `python -m py_compile` — clean

## Acceptance criteria

- [x] The finite-fallback tail exists once and is reused by the three threshold methods.
- [x] Outputs bit-for-bit unchanged for finite and non-finite candidate extrema.
- [x] Sentinels remain explicit parameters.

Closes #173