### PR TITLE
refactor(quickadapter): consolidate causal epsilon-fill idioms (#171)

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2221,7 +2221,7 @@ def _impute_weights(
 
 
 def _segment_ends(a: NDArray[np.integer]) -> NDArray[np.intp]:
-    """Indices of the last element of each run of equal values in ``a``."""
+    """Indices of the last element of each consecutive run of equal values in ``a``."""
     return np.flatnonzero(np.r_[a[1:] != a[:-1], True])
 
 

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2220,6 +2220,11 @@ def _impute_weights(
     return weights
 
 
+def _segment_ends(a: NDArray[np.integer]) -> NDArray[np.intp]:
+    """Indices of the last element of each run of equal values in ``a``."""
+    return np.flatnonzero(np.r_[a[1:] != a[:-1], True])
+
+
 def _causal_impute_weights(
     weights: NDArray[np.floating],
     *,
@@ -2239,7 +2244,7 @@ def _causal_impute_weights(
         .fillna(default_weight)
         .to_numpy(dtype=float)
     )
-    event_ends = np.flatnonzero(np.r_[availability[1:] != availability[:-1], True])
+    event_ends = _segment_ends(availability)
     event_medians = np.repeat(
         running_median[event_ends],
         np.diff(np.r_[-1, event_ends]),
@@ -2745,8 +2750,9 @@ def _compute_epsilon_floor(
         b = float(np.nanmedian(pivot_values))
     else:
         raise ValueError(
-            f"Invalid fill_epsilon_baseline value {baseline!r}: "
-            f"supported values are {', '.join(FILL_EPSILON_BASELINES)}"
+            enum_error_message(
+                "fill_epsilon_baseline", baseline, FILL_EPSILON_BASELINES
+            )
         )
     if not np.isfinite(b):
         b = 0.0
@@ -2845,13 +2851,12 @@ def _compute_causal_epsilon_fill(
         )
     else:
         raise ValueError(
-            f"Invalid fill_epsilon_baseline value {baseline!r}: "
-            f"supported values are {', '.join(FILL_EPSILON_BASELINES)}"
+            enum_error_message(
+                "fill_epsilon_baseline", baseline, FILL_EPSILON_BASELINES
+            )
         )
 
-    event_ends = np.flatnonzero(
-        np.r_[pivot_available_at[1:] != pivot_available_at[:-1], True]
-    )
+    event_ends = _segment_ends(pivot_available_at)
     availability_events = pivot_available_at[event_ends]
     event_floors = float(label_weighting["fill_epsilon"]) * running_baseline[event_ends]
 
@@ -3085,9 +3090,7 @@ def _compute_knn_pivot_sigma_availability(
 
     pivot_positions = pivot_indices.astype(np.int64, copy=False)
     pivot_confirmations = known_at_positions[pivot_positions]
-    confirmation_group_ends = np.flatnonzero(
-        np.r_[pivot_confirmations[:-1] != pivot_confirmations[1:], True]
-    )
+    confirmation_group_ends = _segment_ends(pivot_confirmations)
     pivot_spacing = _ZIGZAG_MIN_CONFIRMATION_SLOPES + 1
     last_future_pivot_position = n - pivot_spacing
     kth_distances = (


### PR DESCRIPTION
## Summary

Behavior-preserving internal deduplication in `quickadapter/user_data/strategies/Utils.py`, addressing both findings of #171.

**Finding 1 (primary).** Extract the duplicated segment-ends idiom `np.flatnonzero(np.r_[a[1:] != a[:-1], True])` into a pure helper `_segment_ends(a: NDArray[np.integer]) -> NDArray[np.intp]`, placed just before its first caller. Call it from all three sites:
- `_causal_impute_weights` (on `availability`)
- `_compute_causal_epsilon_fill` (on `pivot_available_at`)
- `_compute_knn_pivot_sigma_availability` (on `pivot_confirmations`; the flipped operand order is equivalent by symmetry of `!=` on integer arrays)

No empty guard is added: all three sites guarantee non-empty input upstream, and the raw idiom's edge-case output is preserved unchanged.

**Finding 2 (optional).** Route the two verbatim-duplicated `fill_epsilon_baseline` `ValueError` messages (`_compute_epsilon_floor`, `_compute_causal_epsilon_fill`) through the existing `enum_error_message` factory. The produced string is byte-identical, and the scalar (`np.nanmean`/`np.nanmedian`) vs expanding (`pd.Series.expanding().mean()/.median()`) baseline computations are left untouched.

## Non-goals

No behavior change. The scalar and expanding baseline computations are not unified.

## Verification

- `ruff check` clean; `ruff format --check` clean; `python -m py_compile Utils.py` clean.
- Bit-for-bit equivalence of the four affected functions (`_causal_impute_weights`, `_compute_epsilon_floor`, `_compute_causal_epsilon_fill`, `_compute_knn_pivot_sigma_availability`) verified against the prior revision by randomized fuzzing in the `quickadapter-freqtrade:latest` container, plus `_segment_ends` vs both inline forms over 309 cases (including size-1/2 edges and the flipped operand order), and the invalid-baseline error message. All checks pass.

Closes #171