### PR TITLE
refactor(quickadapter): consolidate Utils numeric-helper twins

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2090,10 +2090,10 @@ def zero_phase_filter(
 
 
 # Zero-phase filter dispatch: method -> (kernel, window_selector). Module-level
-# Final table (_*_SPECS family), consumed via .get(method, default). Only the
-# window parity varies per method (std stays odd-window-derived in smooth); the
-# .get default reproduces the legacy "gaussian"/odd else-branch for unknown methods.
-_SMOOTHING_FILTER_SPECS: Final[
+# Final dispatch table consumed via .get(method, default). Both the kernel and
+# the window parity vary per method, while std stays odd-window-derived in smooth;
+# the .get default reproduces the legacy "gaussian"/odd else-branch for unknown methods.
+_ZERO_PHASE_FILTER_DISPATCH: Final[
     dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]
 ] = {
     SMOOTHING_METHODS[1]: (SMOOTHING_KERNELS[0], get_odd_window),  # "gaussian"
@@ -2158,7 +2158,7 @@ def smooth(
             index=series.index,
         )
 
-    win_type, window_selector = _SMOOTHING_FILTER_SPECS.get(
+    win_type, window_selector = _ZERO_PHASE_FILTER_DISPATCH.get(
         method,
         (SMOOTHING_KERNELS[0], get_odd_window),  # "gaussian"/odd default
     )

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2089,10 +2089,10 @@ def zero_phase_filter(
     return pd.Series(filtered_values, index=series.index)
 
 
-# Zero-phase filter dispatch: method -> (kernel, window_selector), mirroring the
-# get_ma_fn/get_price_fn table idiom. Only the window parity varies per method
-# (std stays odd-window-derived in smooth); unknown methods fall back to the
-# "gaussian"/odd default, preserving the legacy else-branch.
+# Zero-phase filter dispatch: method -> (kernel, window_selector). Module-level
+# Final table (_*_SPECS family), consumed via .get(method, default). Only the
+# window parity varies per method (std stays odd-window-derived in smooth); the
+# .get default reproduces the legacy "gaussian"/odd else-branch for unknown methods.
 _SMOOTHING_FILTER_SPECS: Final[
     dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]
 ] = {
@@ -6119,7 +6119,7 @@ def _step_round(
     value: float | int,
     step: int,
     int_op: Callable[[int, int], int],
-    float_op: Callable[[float], float],
+    float_op: Callable[[float], int],
 ) -> int:
     _validate_step_args(value, step)
     if isinstance(value, (int, np.integer)):

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2089,10 +2089,9 @@ def zero_phase_filter(
     return pd.Series(filtered_values, index=series.index)
 
 
-# Zero-phase filter dispatch: method -> (kernel, window_selector). Module-level
-# Final dispatch table consumed via .get(method, default). The kernel varies per
-# method; the window is odd except for kaiser_bessel_derived (even). std stays
-# odd-window-derived in smooth; the .get default reproduces the legacy
+# Zero-phase filter dispatch: method -> (kernel, window_selector). The kernel
+# varies per method; the window is odd except for kaiser_bessel_derived (even).
+# std stays odd-window-derived in smooth; the .get default reproduces the legacy
 # "gaussian"/odd else-branch for unknown methods.
 _ZERO_PHASE_FILTER_DISPATCH: Final[
     dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2089,10 +2089,6 @@ def zero_phase_filter(
     return pd.Series(filtered_values, index=series.index)
 
 
-# Zero-phase filter dispatch: method -> (kernel, window_selector). The kernel
-# varies per method; the window is odd except for kaiser_bessel_derived (even).
-# std stays odd-window-derived in smooth; the .get default reproduces the legacy
-# "gaussian"/odd else-branch for unknown methods.
 _ZERO_PHASE_FILTER_DISPATCH: Final[
     dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]
 ] = {

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2161,7 +2161,7 @@ def smooth(
 
     win_type, window_selector = _ZERO_PHASE_FILTER_DISPATCH.get(
         method,
-        (SMOOTHING_KERNELS[0], get_odd_window),  # "gaussian"/odd default
+        _ZERO_PHASE_FILTER_DISPATCH[SMOOTHING_METHODS[1]],  # "gaussian"/odd default
     )
     return zero_phase_filter(
         series=series,

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2089,6 +2089,23 @@ def zero_phase_filter(
     return pd.Series(filtered_values, index=series.index)
 
 
+# Zero-phase filter dispatch: method -> (kernel, window_selector), mirroring the
+# get_ma_fn/get_price_fn table idiom. Only the window parity varies per method
+# (std stays odd-window-derived in smooth); unknown methods fall back to the
+# "gaussian"/odd default, preserving the legacy else-branch.
+_SMOOTHING_FILTER_SPECS: Final[
+    dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]
+] = {
+    SMOOTHING_METHODS[1]: (SMOOTHING_KERNELS[0], get_odd_window),  # "gaussian"
+    SMOOTHING_METHODS[2]: (SMOOTHING_KERNELS[1], get_odd_window),  # "kaiser"
+    SMOOTHING_METHODS[3]: (
+        SMOOTHING_KERNELS[2],
+        get_even_window,
+    ),  # "kaiser_bessel_derived"
+    SMOOTHING_METHODS[4]: (SMOOTHING_KERNELS[3], get_odd_window),  # "triang"
+}
+
+
 def smooth(
     series: pd.Series,
     method: SmoothingMethod = DEFAULTS_LABEL_SMOOTHING["method"],
@@ -2114,39 +2131,6 @@ def smooth(
 
     if method == SMOOTHING_METHODS[0]:  # "none"
         return series
-    elif method == SMOOTHING_METHODS[1]:  # "gaussian"
-        return zero_phase_filter(
-            series=series,
-            window=odd_window,
-            win_type=SMOOTHING_KERNELS[0],  # "gaussian"
-            std=std,
-            beta=beta,
-        )
-    elif method == SMOOTHING_METHODS[2]:  # "kaiser"
-        return zero_phase_filter(
-            series=series,
-            window=odd_window,
-            win_type=SMOOTHING_KERNELS[1],  # "kaiser"
-            std=std,
-            beta=beta,
-        )
-    elif method == SMOOTHING_METHODS[3]:  # "kaiser_bessel_derived"
-        even_window = get_even_window(window_candles)
-        return zero_phase_filter(
-            series=series,
-            window=even_window,
-            win_type=SMOOTHING_KERNELS[2],  # "kaiser_bessel_derived"
-            std=std,
-            beta=beta,
-        )
-    elif method == SMOOTHING_METHODS[4]:  # "triang"
-        return zero_phase_filter(
-            series=series,
-            window=odd_window,
-            win_type=SMOOTHING_KERNELS[3],  # "triang"
-            std=std,
-            beta=beta,
-        )
     elif method == SMOOTHING_METHODS[5]:  # "smm" (Simple Moving Median)
         return series.rolling(window=odd_window, center=True, min_periods=1).median()
     elif method == SMOOTHING_METHODS[6]:  # "sma" (Simple Moving Average)
@@ -2173,14 +2157,18 @@ def smooth(
             ),
             index=series.index,
         )
-    else:
-        return zero_phase_filter(
-            series=series,
-            window=odd_window,
-            win_type=SMOOTHING_KERNELS[0],  # "gaussian"
-            std=std,
-            beta=beta,
-        )
+
+    win_type, window_selector = _SMOOTHING_FILTER_SPECS.get(
+        method,
+        (SMOOTHING_KERNELS[0], get_odd_window),  # "gaussian"/odd default
+    )
+    return zero_phase_filter(
+        series=series,
+        window=window_selector(window_candles),
+        win_type=win_type,
+        std=std,
+        beta=beta,
+    )
 
 
 def _impute_weights(
@@ -6127,24 +6115,28 @@ def round_to_step(value: float | int, step: int) -> int:
     return int(round(float(value) / step) * step)
 
 
-@lru_cache(maxsize=_CACHE_MAXSIZE_LARGE)
-def ceil_to_step(value: float | int, step: int) -> int:
+def _step_round(
+    value: float | int,
+    step: int,
+    int_op: Callable[[int, int], int],
+    float_op: Callable[[float], float],
+) -> int:
     _validate_step_args(value, step)
     if isinstance(value, (int, np.integer)):
-        return int(-(-int(value) // step) * step)
+        return int(int_op(int(value), step) * step)
     if not np.isfinite(value):
         raise ValueError(f"Invalid value {value!r}: must be finite")
-    return int(math.ceil(float(value) / step) * step)
+    return int(float_op(float(value) / step) * step)
+
+
+@lru_cache(maxsize=_CACHE_MAXSIZE_LARGE)
+def ceil_to_step(value: float | int, step: int) -> int:
+    return _step_round(value, step, lambda v, s: -(-v // s), math.ceil)
 
 
 @lru_cache(maxsize=_CACHE_MAXSIZE_LARGE)
 def floor_to_step(value: float | int, step: int) -> int:
-    _validate_step_args(value, step)
-    if isinstance(value, (int, np.integer)):
-        return int((int(value) // step) * step)
-    if not np.isfinite(value):
-        raise ValueError(f"Invalid value {value!r}: must be finite")
-    return int(math.floor(float(value) / step) * step)
+    return _step_round(value, step, lambda v, s: v // s, math.floor)
 
 
 def get_label_defaults(

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2090,9 +2090,10 @@ def zero_phase_filter(
 
 
 # Zero-phase filter dispatch: method -> (kernel, window_selector). Module-level
-# Final dispatch table consumed via .get(method, default). Both the kernel and
-# the window parity vary per method, while std stays odd-window-derived in smooth;
-# the .get default reproduces the legacy "gaussian"/odd else-branch for unknown methods.
+# Final dispatch table consumed via .get(method, default). The kernel varies per
+# method; the window is odd except for kaiser_bessel_derived (even). std stays
+# odd-window-derived in smooth; the .get default reproduces the legacy
+# "gaussian"/odd else-branch for unknown methods.
 _ZERO_PHASE_FILTER_DISPATCH: Final[
     dict[SmoothingMethod, tuple[SmoothingKernel, Callable[[int], int]]]
 ] = {


### PR DESCRIPTION
## Summary

Behavior-preserving deduplication of three numeric-helper twins in `quickadapter/user_data/strategies/Utils.py`, per #174. Net −8 lines, single file.

- **F4 — `smooth` dispatch.** The four near-identical zero-phase filter branches (`gaussian`, `kaiser`, `kaiser_bessel_derived`, `triang`) and the `gaussian` `else`-fallback are replaced with a module-level `Final` table-driven dispatch `_ZERO_PHASE_FILTER_DISPATCH: method -> (kernel, window_selector)`, consumed via the same `.get(key, default)` dispatch idiom as `get_ma_fn`/`get_price_fn` (which build the dict locally). The `else`-fallback is folded into the `.get` default (`gaussian`/odd), which is bit-for-bit safe since methods are a closed enum matched by string equality (branch reordering is output-invariant). `std` stays derived from the odd window for every kernel; the window is odd for every method except `kaiser_bessel_derived` (even).
- **F5 — `ceil_to_step`/`floor_to_step`.** Extracted a shared `_step_round(value, step, int_op, float_op)` core carrying the `_validate_step_args` call, integer fast-path, finiteness guard, and float path. The integer ops (`-(-v // s)` vs `v // s`) and float ops (`math.ceil` vs `math.floor`) are passed verbatim; `int(value)` cast, `* step` placement, and branch order are preserved. `lru_cache` stays on the public wrappers only (keyed on `(value, step)`); the shared core is intentionally uncached because each wrapper passes a freshly built lambda whose distinct per-call identity would prevent any cache hit — lambdas are hashable, so this is about identity, not hashability. **`round_to_step` is left untouched** (distinct banker's/half-step tie-breaking, per non-goals).
- **F6 — odd/even window merge: intentionally skipped.** `get_odd_window`/`get_even_window` are used as first-class callables in the F4 dispatch table; merging into `get_window(window, parity)` would force `partial`/lambda wrappers at the call site, churn a stable public API (AGENTS.md), and split `lru_cache` capacity across parities for no functional gain. The issue marks F6 optional and "skip if it reduces clarity".

## Verification

- `ruff check` clean; `ruff format --check` clean; `python -m py_compile` clean on the modified file.
- **Bit-for-bit equivalence proven** by capturing pre- vs post-refactor outputs inside `quickadapter-freqtrade:latest` across a broad input grid — all 9 `smooth` methods × 8 series (empty/short/long/NaN/negative/constant) × window/beta/polyorder/mode/sigma combinations (16,128 cases), `ceil`/`floor`/`round_to_step` over int/np.integer/float/non-finite/invalid inputs (196 cases each), and odd/even windows (34 cases). Baseline and refactored dumps are identical (matching SHA-256).

## Acceptance criteria

- [x] `smooth` dispatch is table-driven; outputs bit-for-bit unchanged for every method.
- [x] `ceil_to_step`/`floor_to_step` share the float path + finiteness guard; `round_to_step` untouched; all three bit-for-bit unchanged.
- [x] (Optional) odd/even window merge — evaluated and deliberately skipped (rationale above).

Closes #174