### PR TITLE
refactor(quickadapter): consolidate LabelTransformer scaler tail and direction core

### DIFF
--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -306,8 +306,8 @@ class _LabelTransformerConfig:
         return get_label_column_config(column_name, self.default, self.columns)
 
 
-# eq=False: default eq=True on a frozen dataclass would synthesize a
-# __hash__ that raises TypeError on the unhashable ``registry`` mapping.
+# eq=False keeps identity hashing: with the frozen default eq=True the
+# synthesized __hash__ raises TypeError when called, as ``registry`` is unhashable.
 @dataclass(frozen=True, eq=False, slots=True)
 class _ScalerFamily:
     registry: Mapping[str, str]

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -306,6 +306,8 @@ class _LabelTransformerConfig:
         return get_label_column_config(column_name, self.default, self.columns)
 
 
+# eq=False: default eq=True on a frozen dataclass would synthesize a
+# __hash__ that raises TypeError on the unhashable ``registry`` mapping.
 @dataclass(frozen=True, eq=False, slots=True)
 class _ScalerFamily:
     registry: Mapping[str, str]

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -396,6 +396,28 @@ class LabelTransformer(BaseTransform):
         out[mask] = np.sign(values[mask]) * np.power(np.abs(values[mask]), exp)
         return out
 
+    @staticmethod
+    def _apply_registered_scaler(
+        values: NDArray[np.floating],
+        mask: NDArray[np.bool_],
+        state: _ColumnState,
+        method: str,
+        registry: dict[str, str],
+        type_names: tuple[str, ...],
+        kind: str,
+        inverse: bool = False,
+    ) -> NDArray[np.floating]:
+        scaler_attr = registry.get(method)
+        if scaler_attr is None:
+            raise ValueError(
+                f"Invalid {kind} value {method!r}: "
+                f"supported values are {', '.join(type_names)}"
+            )
+        scaler = getattr(state, scaler_attr, None)
+        if scaler is None:
+            raise RuntimeError(f"{scaler_attr} not fitted")
+        return LabelTransformer._apply_scaler(values, mask, scaler, inverse=inverse)
+
     def _standardize(
         self,
         values: NDArray[np.floating],
@@ -416,16 +438,16 @@ class LabelTransformer(BaseTransform):
                 inverse=inverse,
             )
 
-        scaler_attr = self._STANDARDIZATION_SCALERS.get(method)
-        if scaler_attr is None:
-            raise ValueError(
-                f"Invalid standardization value {method!r}: "
-                f"supported values are {', '.join(STANDARDIZATION_TYPES)}"
-            )
-        scaler = getattr(state, scaler_attr, None)
-        if scaler is None:
-            raise RuntimeError(f"{scaler_attr} not fitted")
-        return LabelTransformer._apply_scaler(values, mask, scaler, inverse=inverse)
+        return LabelTransformer._apply_registered_scaler(
+            values,
+            mask,
+            state,
+            method,
+            self._STANDARDIZATION_SCALERS,
+            STANDARDIZATION_TYPES,
+            "standardization",
+            inverse=inverse,
+        )
 
     def _normalize(
         self,
@@ -442,16 +464,16 @@ class LabelTransformer(BaseTransform):
         if method == NORMALIZATION_TYPES[3]:  # none
             return values
 
-        scaler_attr = self._NORMALIZATION_SCALERS.get(method)
-        if scaler_attr is None:
-            raise ValueError(
-                f"Invalid normalization value {method!r}: "
-                f"supported values are {', '.join(NORMALIZATION_TYPES)}"
-            )
-        scaler = getattr(state, scaler_attr, None)
-        if scaler is None:
-            raise RuntimeError(f"{scaler_attr} not fitted")
-        return LabelTransformer._apply_scaler(values, mask, scaler, inverse=inverse)
+        return LabelTransformer._apply_registered_scaler(
+            values,
+            mask,
+            state,
+            method,
+            self._NORMALIZATION_SCALERS,
+            NORMALIZATION_TYPES,
+            "normalization",
+            inverse=inverse,
+        )
 
     def _fit_standardization(
         self, values: NDArray[np.floating], state: _ColumnState
@@ -584,17 +606,18 @@ class LabelTransformer(BaseTransform):
 
         return X, y, sample_weight, feature_list
 
-    def transform(
+    def _apply_columns(
         self,
         X: ArrayLike,
-        y: ArrayOrNone = None,
-        sample_weight: ArrayOrNone = None,
-        feature_list: ListOrNone = None,
-        outlier_check: bool = False,
-        **kwargs,
+        y: ArrayOrNone,
+        sample_weight: ArrayOrNone,
+        feature_list: ListOrNone,
+        *,
+        inverse: bool,
     ) -> tuple[ArrayLike, ArrayOrNone, ArrayOrNone, ListOrNone]:
         if not self._fitted:
-            raise RuntimeError("LabelTransformer must be fitted before transform")
+            verb = "inverse_transform" if inverse else "transform"
+            raise RuntimeError(f"LabelTransformer must be fitted before {verb}")
 
         arr = np.asarray(X, dtype=float)
         was_1d = arr.ndim == 1
@@ -619,13 +642,24 @@ class LabelTransformer(BaseTransform):
             if col_name not in self._column_states:
                 raise ValueError(f"Column {col_name!r} was not present during fitting")
             result[:, i] = self._transform_column(
-                arr[:, i], self._column_states[col_name]
+                arr[:, i], self._column_states[col_name], inverse=inverse
             )
 
         if was_1d:
             result = result.flatten()
 
         return result, y, sample_weight, feature_list
+
+    def transform(
+        self,
+        X: ArrayLike,
+        y: ArrayOrNone = None,
+        sample_weight: ArrayOrNone = None,
+        feature_list: ListOrNone = None,
+        outlier_check: bool = False,
+        **kwargs,
+    ) -> tuple[ArrayLike, ArrayOrNone, ArrayOrNone, ListOrNone]:
+        return self._apply_columns(X, y, sample_weight, feature_list, inverse=False)
 
     def fit_transform(
         self,
@@ -646,38 +680,4 @@ class LabelTransformer(BaseTransform):
         feature_list: ListOrNone = None,
         **kwargs,
     ) -> tuple[ArrayLike, ArrayOrNone, ArrayOrNone, ListOrNone]:
-        if not self._fitted:
-            raise RuntimeError(
-                "LabelTransformer must be fitted before inverse_transform"
-            )
-
-        arr = np.asarray(X, dtype=float)
-        was_1d = arr.ndim == 1
-        if was_1d:
-            arr = arr.reshape(-1, 1)
-
-        n_columns = arr.shape[1]
-
-        if feature_list is not None and len(feature_list) == n_columns:
-            column_names = list(feature_list)
-        else:
-            column_names = self._fitted_columns
-
-        if len(column_names) != n_columns:
-            raise ValueError(
-                f"Column count mismatch: fitted on {len(self._fitted_columns)} columns, "
-                f"got {n_columns}"
-            )
-
-        result = np.empty_like(arr)
-        for i, col_name in enumerate(column_names):
-            if col_name not in self._column_states:
-                raise ValueError(f"Column {col_name!r} was not present during fitting")
-            result[:, i] = self._transform_column(
-                arr[:, i], self._column_states[col_name], inverse=True
-            )
-
-        if was_1d:
-            result = result.flatten()
-
-        return result, y, sample_weight, feature_list
+        return self._apply_columns(X, y, sample_weight, feature_list, inverse=True)

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -305,6 +305,13 @@ class _LabelTransformerConfig:
         return get_label_column_config(column_name, self.default, self.columns)
 
 
+@dataclass(frozen=True, slots=True)
+class _ScalerFamily:
+    registry: dict[str, str]
+    type_names: tuple[str, ...]
+    kind: Literal["standardization", "normalization"]
+
+
 class LabelTransformer(BaseTransform):
     _STANDARDIZATION_SCALERS: dict[str, str] = {
         STANDARDIZATION_TYPES[1]: "standard_scaler",  # zscore
@@ -315,6 +322,12 @@ class LabelTransformer(BaseTransform):
         NORMALIZATION_TYPES[0]: "maxabs_scaler",  # maxabs
         NORMALIZATION_TYPES[1]: "minmax_scaler",  # minmax
     }
+    _STANDARDIZATION_FAMILY: Final[_ScalerFamily] = _ScalerFamily(
+        _STANDARDIZATION_SCALERS, STANDARDIZATION_TYPES, "standardization"
+    )
+    _NORMALIZATION_FAMILY: Final[_ScalerFamily] = _ScalerFamily(
+        _NORMALIZATION_SCALERS, NORMALIZATION_TYPES, "normalization"
+    )
 
     def __init__(self, *, label_transformer: dict[str, Any]) -> None:
         super().__init__(name="LabelTransformer")
@@ -402,16 +415,14 @@ class LabelTransformer(BaseTransform):
         mask: NDArray[np.bool_],
         state: _ColumnState,
         method: str,
-        registry: dict[str, str],
-        type_names: tuple[str, ...],
-        kind: str,
+        family: _ScalerFamily,
         inverse: bool = False,
     ) -> NDArray[np.floating]:
-        scaler_attr = registry.get(method)
+        scaler_attr = family.registry.get(method)
         if scaler_attr is None:
             raise ValueError(
-                f"Invalid {kind} value {method!r}: "
-                f"supported values are {', '.join(type_names)}"
+                f"Invalid {family.kind} value {method!r}: "
+                f"supported values are {', '.join(family.type_names)}"
             )
         scaler = getattr(state, scaler_attr, None)
         if scaler is None:
@@ -443,9 +454,7 @@ class LabelTransformer(BaseTransform):
             mask,
             state,
             method,
-            self._STANDARDIZATION_SCALERS,
-            STANDARDIZATION_TYPES,
-            "standardization",
+            self._STANDARDIZATION_FAMILY,
             inverse=inverse,
         )
 
@@ -469,9 +478,7 @@ class LabelTransformer(BaseTransform):
             mask,
             state,
             method,
-            self._NORMALIZATION_SCALERS,
-            NORMALIZATION_TYPES,
-            "normalization",
+            self._NORMALIZATION_FAMILY,
             inverse=inverse,
         )
 
@@ -606,7 +613,7 @@ class LabelTransformer(BaseTransform):
 
         return X, y, sample_weight, feature_list
 
-    def _apply_columns(
+    def _transform_columns(
         self,
         X: ArrayLike,
         y: ArrayOrNone,
@@ -659,7 +666,7 @@ class LabelTransformer(BaseTransform):
         outlier_check: bool = False,
         **kwargs,
     ) -> tuple[ArrayLike, ArrayOrNone, ArrayOrNone, ListOrNone]:
-        return self._apply_columns(X, y, sample_weight, feature_list, inverse=False)
+        return self._transform_columns(X, y, sample_weight, feature_list, inverse=False)
 
     def fit_transform(
         self,
@@ -680,4 +687,4 @@ class LabelTransformer(BaseTransform):
         feature_list: ListOrNone = None,
         **kwargs,
     ) -> tuple[ArrayLike, ArrayOrNone, ArrayOrNone, ListOrNone]:
-        return self._apply_columns(X, y, sample_weight, feature_list, inverse=True)
+        return self._transform_columns(X, y, sample_weight, feature_list, inverse=True)

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -306,8 +306,7 @@ class _LabelTransformerConfig:
         return get_label_column_config(column_name, self.default, self.columns)
 
 
-# eq=False keeps identity hashing: with the frozen default eq=True the
-# synthesized __hash__ raises TypeError when called, as ``registry`` is unhashable.
+# registry is an unhashable Mapping -> eq=False
 @dataclass(frozen=True, eq=False, slots=True)
 class _ScalerFamily:
     registry: Mapping[str, str]

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -1,6 +1,7 @@
 import copy
 import fnmatch
 import logging
+from collections.abc import Mapping
 from dataclasses import dataclass, field
 from typing import Any, Final, Literal
 
@@ -305,20 +306,20 @@ class _LabelTransformerConfig:
         return get_label_column_config(column_name, self.default, self.columns)
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, eq=False, slots=True)
 class _ScalerFamily:
-    registry: dict[str, str]
+    registry: Mapping[str, str]
     type_names: tuple[str, ...]
     kind: Literal["standardization", "normalization"]
 
 
 class LabelTransformer(BaseTransform):
-    _STANDARDIZATION_SCALERS: dict[str, str] = {
+    _STANDARDIZATION_SCALERS: Final[dict[str, str]] = {
         STANDARDIZATION_TYPES[1]: "standard_scaler",  # zscore
         STANDARDIZATION_TYPES[2]: "robust_scaler",  # robust
         STANDARDIZATION_TYPES[4]: "power_transformer",  # power_yj
     }
-    _NORMALIZATION_SCALERS: dict[str, str] = {
+    _NORMALIZATION_SCALERS: Final[dict[str, str]] = {
         NORMALIZATION_TYPES[0]: "maxabs_scaler",  # maxabs
         NORMALIZATION_TYPES[1]: "minmax_scaler",  # minmax
     }


### PR DESCRIPTION
## Summary

Consolidates the parallel structure in `LabelTransformer.py` per #175, with no behavior change.

- **Scaler tail (primary).** `_standardize` and `_normalize` shared an identical tail (registry lookup → `ValueError` on unknown method → `getattr` → `RuntimeError` on unfitted scaler → `_apply_scaler`). Extracted into a static `_apply_registered_scaler(values, mask, state, method, family, inverse=...)`, where `family` is a frozen `_ScalerFamily(registry, type_names, kind)` descriptor. The method-specific preambles (`mmad`, `sigmoid`, `none`) and the two registries stay separate.
- **transform / inverse_transform.** Folded onto a shared direction-parametrized core `_transform_columns(..., *, inverse)`. The public `transform`/`inverse_transform` wrappers keep their exact signatures, including the currently-unused `outlier_check` and `**kwargs`.
- **Descriptor.** The co-varying `(registry, type_names, kind)` triple is bundled into a per-family `_ScalerFamily` constant (`_STANDARDIZATION_FAMILY`, `_NORMALIZATION_FAMILY`); `kind` is `Literal["standardization", "normalization"]`. The descriptor is `frozen=True, eq=False, slots=True` (identity semantics; no synthesized `__hash__` over the mapping), `registry` typed `Mapping[str, str]`, and the two registries are `Final`.

## Non-goals respected

- Registries `_STANDARDIZATION_SCALERS`/`_NORMALIZATION_SCALERS` kept separate; per-method special cases kept distinct.
- `_fit_standardization` / `_fit_normalization` untouched (out of scope).
- No `enum_error_message` import from `Utils` (would create an import cycle). Error messages are built locally and kept byte-identical to the previous strings.
- No instance-attribute or `_ColumnState` field renames (freqtrade joblib-serializes the fitted pipeline).

## Verification

- `ruff check` and `ruff format --check`: clean.
- `python -m py_compile`: clean.
- **Bit-for-bit equivalence**: container run (`quickadapter-freqtrade:latest`) comparing the branch against `main` yields identical SHA-256 outputs across every `standardization` × `normalization` × `gamma` combination, 1D/2D inputs, multi-column config, NaN/±inf, and all error paths (unfitted, column-count mismatch, unknown column, invalid method).

Closes #175