### PR TITLE
fix(quickadapter): honor unlimited trade sentinel

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -271,7 +271,7 @@ class QuickAdapterV3(IStrategy):
         return get_fit_live_predictions_candles(self.config.get("freqai"), logger)
 
     @staticmethod
-    def _is_unlimited_open_trades(max_open_trades: float) -> bool:
+    def _is_unlimited_max_open_trades(max_open_trades: int | float) -> bool:
         return max_open_trades == -1 or max_open_trades == math.inf
 
     @cached_property
@@ -297,14 +297,14 @@ class QuickAdapterV3(IStrategy):
             fit_live_predictions_candles,
         )
         max_open_trades = self.config.get("max_open_trades", 0)
-        unlimited_open_trades = QuickAdapterV3._is_unlimited_open_trades(
+        unlimited_max_open_trades = QuickAdapterV3._is_unlimited_max_open_trades(
             max_open_trades
         )
         estimated_trade_limit = max(
             2,
             int(round(lookback_period_candles / max(1, trade_duration_candles))),
         )
-        if unlimited_open_trades:
+        if unlimited_max_open_trades:
             stoploss_trade_limit = estimated_trade_limit
             drawdown_trade_limit = 2 * estimated_trade_limit
         else:
@@ -361,7 +361,7 @@ class QuickAdapterV3(IStrategy):
     @property
     def max_open_trades_per_side(self) -> int:
         max_open_trades = self.config.get("max_open_trades", 0)
-        if QuickAdapterV3._is_unlimited_open_trades(max_open_trades):
+        if QuickAdapterV3._is_unlimited_max_open_trades(max_open_trades):
             return -1
         if self.is_short_allowed():
             if max_open_trades % 2 == 1:
@@ -2288,7 +2288,7 @@ class QuickAdapterV3(IStrategy):
             return False
         max_open_trades = self.config.get("max_open_trades", 0)
         if (
-            not QuickAdapterV3._is_unlimited_open_trades(max_open_trades)
+            not QuickAdapterV3._is_unlimited_max_open_trades(max_open_trades)
             and Trade.get_open_trade_count() >= max_open_trades
         ):
             return False

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -270,6 +270,10 @@ class QuickAdapterV3(IStrategy):
     def _fit_live_predictions_candles(self) -> int:
         return get_fit_live_predictions_candles(self.config.get("freqai"), logger)
 
+    @staticmethod
+    def _is_unlimited_open_trades(max_open_trades: float) -> bool:
+        return max_open_trades == -1 or max_open_trades == math.inf
+
     @cached_property
     def protections(self) -> list[dict[str, Any]]:
         fit_live_predictions_candles = self._fit_live_predictions_candles
@@ -293,7 +297,9 @@ class QuickAdapterV3(IStrategy):
             fit_live_predictions_candles,
         )
         max_open_trades = self.config.get("max_open_trades", 0)
-        unlimited_open_trades = max_open_trades == -1 or max_open_trades == math.inf
+        unlimited_open_trades = QuickAdapterV3._is_unlimited_open_trades(
+            max_open_trades
+        )
         estimated_trade_limit = max(
             2,
             int(round(lookback_period_candles / max(1, trade_duration_candles))),
@@ -355,7 +361,7 @@ class QuickAdapterV3(IStrategy):
     @property
     def max_open_trades_per_side(self) -> int:
         max_open_trades = self.config.get("max_open_trades", 0)
-        if max_open_trades < 0 or max_open_trades == math.inf:
+        if QuickAdapterV3._is_unlimited_open_trades(max_open_trades):
             return -1
         if self.is_short_allowed():
             if max_open_trades % 2 == 1:
@@ -2281,7 +2287,10 @@ class QuickAdapterV3(IStrategy):
             )
             return False
         max_open_trades = self.config.get("max_open_trades", 0)
-        if max_open_trades != -1 and Trade.get_open_trade_count() >= max_open_trades:
+        if (
+            not QuickAdapterV3._is_unlimited_open_trades(max_open_trades)
+            and Trade.get_open_trade_count() >= max_open_trades
+        ):
             return False
         max_open_trades_per_side = self.max_open_trades_per_side
         if max_open_trades_per_side >= 0:

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -292,14 +292,22 @@ class QuickAdapterV3(IStrategy):
             stoploss_stop_duration_candles,
             fit_live_predictions_candles,
         )
-        max_open_trades = int(self.config.get("max_open_trades", 0))
-        stoploss_trade_limit = min(
-            max(
-                2,
-                int(round(lookback_period_candles / max(1, trade_duration_candles))),
-            ),
-            max(2, int(round(max_open_trades * 0.75))),
+        max_open_trades = self.config.get("max_open_trades", 0)
+        unlimited_open_trades = max_open_trades == -1 or max_open_trades == math.inf
+        estimated_trade_limit = max(
+            2,
+            int(round(lookback_period_candles / max(1, trade_duration_candles))),
         )
+        if unlimited_open_trades:
+            stoploss_trade_limit = estimated_trade_limit
+            drawdown_trade_limit = 2 * estimated_trade_limit
+        else:
+            max_open_trades = int(max_open_trades)
+            stoploss_trade_limit = min(
+                estimated_trade_limit,
+                max(2, int(round(max_open_trades * 0.75))),
+            )
+            drawdown_trade_limit = 2 * max_open_trades
 
         protections_list = []
 
@@ -317,7 +325,7 @@ class QuickAdapterV3(IStrategy):
                 {
                     "method": "MaxDrawdown",
                     "lookback_period_candles": lookback_period_candles,
-                    "trade_limit": 2 * max_open_trades,
+                    "trade_limit": drawdown_trade_limit,
                     "stop_duration_candles": drawdown_stop_duration_candles,
                     "max_allowed_drawdown": drawdown["max_allowed_drawdown"],
                 }
@@ -347,7 +355,7 @@ class QuickAdapterV3(IStrategy):
     @property
     def max_open_trades_per_side(self) -> int:
         max_open_trades = self.config.get("max_open_trades", 0)
-        if max_open_trades < 0:
+        if max_open_trades < 0 or max_open_trades == math.inf:
             return -1
         if self.is_short_allowed():
             if max_open_trades % 2 == 1:
@@ -2272,7 +2280,8 @@ class QuickAdapterV3(IStrategy):
                 f"[{pair}] Denied short {QuickAdapterV3._ORDER_ENTRY}: shorting not allowed"
             )
             return False
-        if Trade.get_open_trade_count() >= self.config.get("max_open_trades", 0):
+        max_open_trades = self.config.get("max_open_trades", 0)
+        if max_open_trades != -1 and Trade.get_open_trade_count() >= max_open_trades:
             return False
         max_open_trades_per_side = self.max_open_trades_per_side
         if max_open_trades_per_side >= 0:


### PR DESCRIPTION
## Summary

- honor Freqtrade's raw `max_open_trades = -1` sentinel and its runtime-normalized `+inf` form
- preserve finite-limit entry boundaries and per-side behavior
- derive finite, positive protection thresholds from the existing lookback/trade-duration estimate when trades are unlimited

## Root cause

QuickAdapter compared the open-trade count directly with the raw `-1` sentinel and derived `MaxDrawdown.trade_limit = -2`. Freqtrade 2026.6 also normalizes `-1` to `float("inf")`, which made the existing `int(max_open_trades)` protection calculation raise `OverflowError`.

## Validation

Validated with an external, untracked harness in Freqtrade 2026.6 using local image `sha256:a41cc6823deb4a1bdf5982f77f8a4f9c8d7d7d6ee5756c484862f4ea62586bde`:

- finite limit 3: accepted at 2 open trades; rejected at 3 and 4
- zero: rejected at 0, preserving existing behavior
- raw `-1` and normalized `+inf`: entry accepted at 0 when all other callback gates pass
- raw `-1` and normalized `+inf`: `MaxDrawdown.trade_limit = 12`, `StoplossGuard.trade_limit = 6`; real protection classes do not lock on an empty history
- real schema: `-1`, `0`, positive integers, and positive numbers accepted; `-2`, booleans, strings, and null rejected
- `ruff check` and `ruff format --check` pass for `QuickAdapterV3.py`
- `python -m compileall` and `git diff --check` pass

The repository-wide Ruff run still reports four pre-existing RUF002/RUF003 findings in ReforceXY files untouched by this PR. Regression coverage remains external as required; no test or audit artifact is committed.

Fixes #181