### PR TITLE
fix(quickadapter): make best-params persistence atomic

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -8,7 +8,6 @@ import math
 import os
 import re
 import stat
-import tempfile
 from collections.abc import Iterator, Sequence
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -30,6 +29,7 @@ from typing import (
     cast,
     get_args,
 )
+from uuid import uuid4
 
 import numpy as np
 import optuna
@@ -5377,6 +5377,8 @@ def optuna_load_best_params(
     best_params_path = (
         base_path / f"optuna-{namespace}-best-params-{pair.split('/')[0]}.json"
     )
+    if not best_params_path.parent.is_dir():
+        return None
     with _locked_optuna_best_params_directory(best_params_path):
         _reject_optuna_best_params_symlink(best_params_path)
         if not best_params_path.is_file():
@@ -5453,15 +5455,18 @@ def optuna_save_best_params(
                 existing_mode = stat.S_IMODE(best_params_path.stat().st_mode)
             except FileNotFoundError:
                 existing_mode = None
-            with tempfile.NamedTemporaryFile(
+            temporary_path = best_params_path.with_name(
+                f".{best_params_path.name}.{uuid4().hex}.tmp"
+            )
+            with os.fdopen(
+                os.open(
+                    temporary_path,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                    0o666,
+                ),
                 mode="w",
                 encoding="utf-8",
-                dir=best_params_path.parent,
-                prefix=f".{best_params_path.name}.",
-                suffix=".tmp",
-                delete=False,
             ) as write_file:
-                temporary_path = Path(write_file.name)
                 if existing_mode is not None:
                     os.fchmod(write_file.fileno(), existing_mode)
                 json.dump(best_params, write_file, indent=4)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5345,18 +5345,23 @@ def _quarantine_corrupt_optuna_best_params(
 @contextmanager
 def _locked_optuna_best_params(
     best_params_path: Path,
+    *,
+    exclusive: bool,
 ) -> Iterator[None]:
-    """Serialize best-params I/O using a stable, writable lock file."""
+    """Serialize best-params I/O using a stable lock file."""
     lock_path = best_params_path.parent / ".optuna-best-params.lock"
     lock_fd = os.open(
         lock_path,
-        os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+        (os.O_RDWR if exclusive else os.O_RDONLY)
+        | os.O_CREAT
+        | os.O_CLOEXEC
+        | os.O_NOFOLLOW,
         0o666,
     )
     try:
         if not stat.S_ISREG(os.fstat(lock_fd).st_mode):
             raise OSError(f"Optuna best params lock {lock_path} must be a regular file")
-        fcntl.flock(lock_fd, fcntl.LOCK_EX)
+        fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
         yield
     finally:
         os.close(lock_fd)
@@ -5383,24 +5388,35 @@ def optuna_load_best_params(
     )
     if not best_params_path.parent.is_dir():
         return None
-    with _locked_optuna_best_params(best_params_path):
+    malformed = False
+    with _locked_optuna_best_params(best_params_path, exclusive=False):
         _reject_optuna_best_params_symlink(best_params_path)
         if not best_params_path.is_file():
             return None
         try:
             with best_params_path.open("r", encoding="utf-8") as read_file:
                 best_params = json.load(read_file)
-        except (json.JSONDecodeError, UnicodeDecodeError) as decode_error:
-            quarantined = _quarantine_corrupt_optuna_best_params(
-                best_params_path,
-                pair,
-                namespace,
-                decode_error,
-                logger,
-            )
-            if quarantined is None:
-                raise
-            return None
+        except (json.JSONDecodeError, UnicodeDecodeError):
+            malformed = True
+    if malformed:
+        with _locked_optuna_best_params(best_params_path, exclusive=True):
+            _reject_optuna_best_params_symlink(best_params_path)
+            if not best_params_path.is_file():
+                return None
+            try:
+                with best_params_path.open("r", encoding="utf-8") as read_file:
+                    best_params = json.load(read_file)
+            except (json.JSONDecodeError, UnicodeDecodeError) as decode_error:
+                quarantined = _quarantine_corrupt_optuna_best_params(
+                    best_params_path,
+                    pair,
+                    namespace,
+                    decode_error,
+                    logger,
+                )
+                if quarantined is None:
+                    raise
+                return None
     if namespace == _OPTUNA_NAMESPACES.label:
         return _validate_optuna_label_best_params(
             best_params,
@@ -5453,7 +5469,7 @@ def optuna_save_best_params(
             }
         else:
             best_params = params
-        with _locked_optuna_best_params(best_params_path):
+        with _locked_optuna_best_params(best_params_path, exclusive=True):
             _reject_optuna_best_params_symlink(best_params_path)
             try:
                 existing_metadata = best_params_path.stat()

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5154,6 +5154,7 @@ class _OptunaNamespaces(NamedTuple):
 # Exported for cross-module use; consumers may import despite the leading
 # underscore on the instance (the class ``_OptunaNamespaces`` stays private).
 _OPTUNA_NAMESPACES: Final[_OptunaNamespaces] = _OptunaNamespaces()
+_OPTUNA_BEST_PARAMS_QUARANTINE_TAG: Final[str] = "corrupt"
 _OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 8
 
 
@@ -5311,11 +5312,13 @@ def _quarantine_corrupt_optuna_best_params(
     cause: Exception,
     logger: Logger | None,
 ) -> Path | None:
-    """Atomically move malformed persisted best params out of the live path."""
+    """Atomically move corrupt persisted best params out of the live path."""
     if not best_params_path.exists():
         return None
     stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-    quarantine_base = f"{best_params_path.name}.corrupt-{stamp}"
+    quarantine_base = (
+        f"{best_params_path.name}.{_OPTUNA_BEST_PARAMS_QUARANTINE_TAG}-{stamp}"
+    )
     for index in range(_OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT + 1):
         suffix = "" if index == 0 else f"-{index}"
         quarantine_path = best_params_path.with_name(f"{quarantine_base}{suffix}")
@@ -5336,7 +5339,7 @@ def _quarantine_corrupt_optuna_best_params(
     if logger is not None:
         logger.warning(
             f"[{pair}] Optuna {namespace} best params {best_params_path.name} "
-            f"malformed ({cause!r}); quarantined to {quarantine_path.name}; "
+            f"corrupt ({cause!r}); quarantined to {quarantine_path.name}; "
             "no persisted best params recovered"
         )
     return quarantine_path
@@ -5368,6 +5371,7 @@ def _locked_optuna_best_params(
 
 
 def _reject_optuna_best_params_symlink(best_params_path: Path) -> None:
+    """Fail closed when the live best-params path is a symlink."""
     if best_params_path.is_symlink():
         raise OSError(
             f"Optuna best params path {best_params_path} must not be a symlink"

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5343,19 +5343,23 @@ def _quarantine_corrupt_optuna_best_params(
 
 
 @contextmanager
-def _locked_optuna_best_params_directory(
+def _locked_optuna_best_params(
     best_params_path: Path,
 ) -> Iterator[None]:
-    """Serialize best-params I/O across processes sharing the target directory."""
-    directory_fd = os.open(
-        best_params_path.parent,
-        os.O_RDONLY | os.O_DIRECTORY,
+    """Serialize best-params I/O using a stable, writable lock file."""
+    lock_path = best_params_path.parent / ".optuna-best-params.lock"
+    lock_fd = os.open(
+        lock_path,
+        os.O_RDWR | os.O_CREAT | os.O_CLOEXEC | os.O_NOFOLLOW,
+        0o666,
     )
     try:
-        fcntl.flock(directory_fd, fcntl.LOCK_EX)
+        if not stat.S_ISREG(os.fstat(lock_fd).st_mode):
+            raise OSError(f"Optuna best params lock {lock_path} must be a regular file")
+        fcntl.flock(lock_fd, fcntl.LOCK_EX)
         yield
     finally:
-        os.close(directory_fd)
+        os.close(lock_fd)
 
 
 def _reject_optuna_best_params_symlink(best_params_path: Path) -> None:
@@ -5379,7 +5383,7 @@ def optuna_load_best_params(
     )
     if not best_params_path.parent.is_dir():
         return None
-    with _locked_optuna_best_params_directory(best_params_path):
+    with _locked_optuna_best_params(best_params_path):
         _reject_optuna_best_params_symlink(best_params_path)
         if not best_params_path.is_file():
             return None
@@ -5449,12 +5453,12 @@ def optuna_save_best_params(
             }
         else:
             best_params = params
-        with _locked_optuna_best_params_directory(best_params_path):
+        with _locked_optuna_best_params(best_params_path):
             _reject_optuna_best_params_symlink(best_params_path)
             try:
-                existing_mode = stat.S_IMODE(best_params_path.stat().st_mode)
+                existing_metadata = best_params_path.stat()
             except FileNotFoundError:
-                existing_mode = None
+                existing_metadata = None
             temporary_path = best_params_path.with_name(
                 f".{best_params_path.name}.{uuid4().hex}.tmp"
             )
@@ -5467,8 +5471,25 @@ def optuna_save_best_params(
                 mode="w",
                 encoding="utf-8",
             ) as write_file:
-                if existing_mode is not None:
-                    os.fchmod(write_file.fileno(), existing_mode)
+                if existing_metadata is not None:
+                    temporary_metadata = os.fstat(write_file.fileno())
+                    if (
+                        temporary_metadata.st_uid != existing_metadata.st_uid
+                        or temporary_metadata.st_gid != existing_metadata.st_gid
+                    ):
+                        os.fchown(
+                            write_file.fileno(),
+                            existing_metadata.st_uid
+                            if temporary_metadata.st_uid != existing_metadata.st_uid
+                            else -1,
+                            existing_metadata.st_gid
+                            if temporary_metadata.st_gid != existing_metadata.st_gid
+                            else -1,
+                        )
+                    os.fchmod(
+                        write_file.fileno(),
+                        stat.S_IMODE(existing_metadata.st_mode),
+                    )
                 json.dump(best_params, write_file, indent=4)
                 write_file.flush()
                 os.fsync(write_file.fileno())

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -1,12 +1,18 @@
 import copy
+import fcntl
 import functools
 import hashlib
 import inspect
 import json
 import math
+import os
 import re
-from collections.abc import Sequence
+import stat
+import tempfile
+from collections.abc import Iterator, Sequence
+from contextlib import contextmanager
 from dataclasses import dataclass
+from datetime import datetime, timezone
 from enum import IntEnum
 from functools import lru_cache, singledispatch
 from logging import Logger
@@ -5148,6 +5154,7 @@ class _OptunaNamespaces(NamedTuple):
 # Exported for cross-module use; consumers may import despite the leading
 # underscore on the instance (the class ``_OptunaNamespaces`` stays private).
 _OPTUNA_NAMESPACES: Final[_OptunaNamespaces] = _OptunaNamespaces()
+_OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 8
 
 
 _OPTUNA_LABEL_BEST_PARAMS_SCHEMA_VERSION: Final[int] = 2
@@ -5297,6 +5304,67 @@ def _validate_optuna_label_best_params(
     return params
 
 
+def _quarantine_corrupt_optuna_best_params(
+    best_params_path: Path,
+    pair: str,
+    namespace: OptunaNamespace,
+    cause: Exception,
+    logger: Logger | None,
+) -> Path | None:
+    """Atomically move malformed persisted best params out of the live path."""
+    if not best_params_path.exists():
+        return None
+    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+    quarantine_base = f"{best_params_path.name}.corrupt-{stamp}"
+    for index in range(_OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT + 1):
+        suffix = "" if index == 0 else f"-{index}"
+        quarantine_path = best_params_path.with_name(f"{quarantine_base}{suffix}")
+        if not quarantine_path.exists():
+            break
+    else:
+        raise FileExistsError(best_params_path)
+    try:
+        best_params_path.rename(quarantine_path)
+    except OSError as quarantine_error:
+        if logger is not None:
+            logger.error(
+                f"[{pair}] Optuna {namespace} best params "
+                f"{best_params_path.name} quarantine failed: {quarantine_error!r}",
+                exc_info=True,
+            )
+        raise
+    if logger is not None:
+        logger.warning(
+            f"[{pair}] Optuna {namespace} best params {best_params_path.name} "
+            f"malformed ({cause!r}); quarantined to {quarantine_path.name}; "
+            "no persisted best params recovered"
+        )
+    return quarantine_path
+
+
+@contextmanager
+def _locked_optuna_best_params_directory(
+    best_params_path: Path,
+) -> Iterator[None]:
+    """Serialize best-params I/O across processes sharing the target directory."""
+    directory_fd = os.open(
+        best_params_path.parent,
+        os.O_RDONLY | os.O_DIRECTORY,
+    )
+    try:
+        fcntl.flock(directory_fd, fcntl.LOCK_EX)
+        yield
+    finally:
+        os.close(directory_fd)
+
+
+def _reject_optuna_best_params_symlink(best_params_path: Path) -> None:
+    if best_params_path.is_symlink():
+        raise OSError(
+            f"Optuna best params path {best_params_path} must not be a symlink"
+        )
+
+
 def optuna_load_best_params(
     base_path: Path,
     pair: str,
@@ -5309,32 +5377,46 @@ def optuna_load_best_params(
     best_params_path = (
         base_path / f"optuna-{namespace}-best-params-{pair.split('/')[0]}.json"
     )
-    if best_params_path.is_file():
-        with best_params_path.open("r", encoding="utf-8") as read_file:
-            best_params = json.load(read_file)
-        if namespace == _OPTUNA_NAMESPACES.label:
-            return _validate_optuna_label_best_params(
-                best_params,
+    with _locked_optuna_best_params_directory(best_params_path):
+        _reject_optuna_best_params_symlink(best_params_path)
+        if not best_params_path.is_file():
+            return None
+        try:
+            with best_params_path.open("r", encoding="utf-8") as read_file:
+                best_params = json.load(read_file)
+        except (json.JSONDecodeError, UnicodeDecodeError) as decode_error:
+            quarantined = _quarantine_corrupt_optuna_best_params(
+                best_params_path,
                 pair,
+                namespace,
+                decode_error,
                 logger,
-                expected_selection_metadata=expected_selection_metadata,
             )
-        if expected_objective_identity is not None:
-            if (
-                not isinstance(best_params, dict)
-                or best_params.get("objective_identity") != expected_objective_identity
-                or not isinstance(best_params.get("params"), dict)
-            ):
-                if logger is not None:
-                    logger.warning(
-                        f"[{pair}] Ignoring Optuna {namespace} best params: "
-                        f"objective identity does not match "
-                        f"{expected_objective_identity!r}"
-                    )
-                return None
-            return best_params["params"]
-        return best_params
-    return None
+            if quarantined is None:
+                raise
+            return None
+    if namespace == _OPTUNA_NAMESPACES.label:
+        return _validate_optuna_label_best_params(
+            best_params,
+            pair,
+            logger,
+            expected_selection_metadata=expected_selection_metadata,
+        )
+    if expected_objective_identity is not None:
+        if (
+            not isinstance(best_params, dict)
+            or best_params.get("objective_identity") != expected_objective_identity
+            or not isinstance(best_params.get("params"), dict)
+        ):
+            if logger is not None:
+                logger.warning(
+                    f"[{pair}] Ignoring Optuna {namespace} best params: "
+                    f"objective identity does not match "
+                    f"{expected_objective_identity!r}"
+                )
+            return None
+        return best_params["params"]
+    return best_params
 
 
 def optuna_save_best_params(
@@ -5349,6 +5431,7 @@ def optuna_save_best_params(
     best_params_path = (
         base_path / f"optuna-{namespace}-best-params-{pair.split('/')[0]}.json"
     )
+    temporary_path: Path | None = None
     try:
         if namespace == _OPTUNA_NAMESPACES.label:
             best_params: dict[str, Any] = {
@@ -5364,13 +5447,43 @@ def optuna_save_best_params(
             }
         else:
             best_params = params
-        with best_params_path.open("w", encoding="utf-8") as write_file:
-            json.dump(best_params, write_file, indent=4)
-    except Exception as e:
-        logger.error(
-            f"[{pair}] Optuna {namespace} failed to save best params: {e!r}",
-            exc_info=True,
-        )
+        with _locked_optuna_best_params_directory(best_params_path):
+            _reject_optuna_best_params_symlink(best_params_path)
+            try:
+                existing_mode = stat.S_IMODE(best_params_path.stat().st_mode)
+            except FileNotFoundError:
+                existing_mode = None
+            with tempfile.NamedTemporaryFile(
+                mode="w",
+                encoding="utf-8",
+                dir=best_params_path.parent,
+                prefix=f".{best_params_path.name}.",
+                suffix=".tmp",
+                delete=False,
+            ) as write_file:
+                temporary_path = Path(write_file.name)
+                if existing_mode is not None:
+                    os.fchmod(write_file.fileno(), existing_mode)
+                json.dump(best_params, write_file, indent=4)
+                write_file.flush()
+                os.fsync(write_file.fileno())
+            os.replace(temporary_path, best_params_path)
+            temporary_path = None
+    except BaseException as error:
+        if temporary_path is not None:
+            try:
+                temporary_path.unlink(missing_ok=True)
+            except OSError as cleanup_error:
+                logger.error(
+                    f"[{pair}] Optuna {namespace} best params temporary file "
+                    f"{temporary_path.name} cleanup failed: {cleanup_error!r}",
+                    exc_info=True,
+                )
+        if isinstance(error, Exception):
+            logger.error(
+                f"[{pair}] Optuna {namespace} failed to save best params: {error!r}",
+                exc_info=True,
+            )
         raise
 
 


### PR DESCRIPTION
## Summary

- write Optuna best-params JSON through a file-synced temporary file in the destination directory, then publish it with atomic replacement
- serialize valid readers through a shared read-only lock and mutations through an exclusive read-write lock, including on NFS with remote locking enabled
- after malformed input is detected under the shared lock, reacquire the exclusive lock and reparse the current generation before quarantining it
- preserve umask-derived first-write modes and existing numeric UID/GID plus mode on replacement, failing before publication when restoration is not permitted
- fail closed for symlink destinations and symlink or nonregular lock files
- preserve the historical cold-start `None` contract when a model directory does not exist
- quarantine malformed JSON or invalid UTF-8 explicitly without consuming or relabeling it as recovered parameters
- preserve the existing `hp`/`label` payload validation and pair filename construction

## Validation

- external `/tmp` harness on `quickadapter-pr-test-pytest:latest` (`sha256:a41cc6823deb4a1bdf5982f77f8a4f9c8d7d7d6ee5756c484862f4ea62586bde`), Freqtrade 2026.6 / Python 3.14.6: 9 scenarios passed across `hp` and `label`
- covered missing-directory cold start through the utility and real `QuickAdapterV3` wrapper, first-write umasks `002`/`022`/`077`, existing-mode preservation, successful replacement, injected dump/replace failures, byte-identical previous artifact, temp cleanup, malformed/truncated JSON, invalid UTF-8, quarantine failure propagation, semantic rejection, thread/process races, and symlink fail-closed behavior
- separate 5-case external review harness covered a stable global R/W regular lock file, lockfile symlink/nonregular rejection, permitted UID/GID preservation, and ownership-restoration failure before replacement
- cross-UID external harness used writer UID 12345 with umask `022` and reader UID 23456: lock and JSON were `0644`, valid loading passed through both the utility and real `QuickAdapterRegressorV3`, and repaired-between-locks, absent-between-locks, persistent corruption, `hp`/`label`, and pre-replace failure matrices passed
- a bind-mount probe reproduced the prior ownership change under a distinct writer UID/GID; native and POSIX shared locks passed on a read-only descriptor while the equivalent POSIX exclusive lock returned `EBADF`
- separate-container restart/reopen passed, followed by a real `QuickAdapterRegressorV3` reopen
- independent blind review confirmed both original findings; targeted post-diff adversarial reviews found no remaining P0-P3 finding
- `ruff check`, `ruff format --check`, source compilation, and `git diff --check` passed

The file contents are `fsync`ed before replacement. The parent directory is not `fsync`ed, so the guarantee is atomic runtime visibility and preservation before replacement, not power-loss durability of the renamed directory entry. Regression harnesses remain external and no tests are committed.

Valid readers require read access to the lock file; save and quarantine operations require write access to it, and lock bootstrap remains governed by the directory permissions, umask, and ACLs. Cross-UID writers must provide a compatible shared group, ACL, umask, or preprovisioned lock file. Inter-client NFS exclusion requires server-backed locking and excludes `nolock` or client-local `local_lock` modes; no server-backed NFS mount was available for validation. Replacement preserves numeric UID/GID and mode, not ACLs, xattrs, security labels, or hardlinks.

Fixes #182
