### PR TITLE
perf(quickadapter): harmonize causal availability for provably-stable zero-weight imputations

### DIFF
--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1009,16 +1009,12 @@ class QuickAdapterV3(IStrategy):
                         imputation_leading_stable_mask = (
                             imputation_masks.leading_stable_mask
                         )
-                        imputation_trailing_stable_mask = (
-                            imputation_masks.trailing_stable_mask
-                        )
                         imputation_stable_release_index = (
                             imputation_masks.stable_release_index
                         )
                     else:
                         imputation_dependency_mask = None
                         imputation_leading_stable_mask = None
-                        imputation_trailing_stable_mask = None
                         imputation_stable_release_index = -1
                     dataframe[
                         label_weight_known_at_lookahead_column_name(label_col)
@@ -1029,7 +1025,6 @@ class QuickAdapterV3(IStrategy):
                         weighting_config=col_weighting_config,
                         imputation_dependency_mask=imputation_dependency_mask,
                         imputation_leading_stable_mask=imputation_leading_stable_mask,
-                        imputation_trailing_stable_mask=imputation_trailing_stable_mask,
                         imputation_stable_release_index=imputation_stable_release_index,
                     )
 

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -1005,9 +1005,7 @@ class QuickAdapterV3(IStrategy):
                                 col_weighting_config,
                             )
                         )
-                        imputation_dependency_mask = (
-                            imputation_masks.dependency_mask
-                        )
+                        imputation_dependency_mask = imputation_masks.dependency_mask
                         imputation_leading_stable_mask = (
                             imputation_masks.leading_stable_mask
                         )

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -998,17 +998,30 @@ class QuickAdapterV3(IStrategy):
                 )
                 if label_data.known_at_lookahead is not None:
                     if causal_mode:
-                        (
-                            imputation_dependency_mask,
-                            imputation_leading_stable_mask,
-                        ) = compute_label_weight_imputation_dependency_mask(
-                            len(label_data.indices),
-                            label_data.metrics,
-                            col_weighting_config,
+                        imputation_masks = (
+                            compute_label_weight_imputation_dependency_mask(
+                                len(label_data.indices),
+                                label_data.metrics,
+                                col_weighting_config,
+                            )
+                        )
+                        imputation_dependency_mask = (
+                            imputation_masks.dependency_mask
+                        )
+                        imputation_leading_stable_mask = (
+                            imputation_masks.leading_stable_mask
+                        )
+                        imputation_trailing_stable_mask = (
+                            imputation_masks.trailing_stable_mask
+                        )
+                        imputation_stable_release_index = (
+                            imputation_masks.stable_release_index
                         )
                     else:
                         imputation_dependency_mask = None
                         imputation_leading_stable_mask = None
+                        imputation_trailing_stable_mask = None
+                        imputation_stable_release_index = -1
                     dataframe[
                         label_weight_known_at_lookahead_column_name(label_col)
                     ] = compute_label_weight_known_at_lookahead(
@@ -1018,6 +1031,8 @@ class QuickAdapterV3(IStrategy):
                         weighting_config=col_weighting_config,
                         imputation_dependency_mask=imputation_dependency_mask,
                         imputation_leading_stable_mask=imputation_leading_stable_mask,
+                        imputation_trailing_stable_mask=imputation_trailing_stable_mask,
+                        imputation_stable_release_index=imputation_stable_release_index,
                     )
 
             if label_col == EXTREMA_COLUMN:

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2651,15 +2651,15 @@ def _nonfinite_imputation_dependency_mask(
 class LabelWeightImputationMasks:
     """Causal-availability masks for non-finite pivot-weight imputations.
 
-    See :func:`compute_label_weight_imputation_dependency_mask` for the release
-    algorithm.
+    Produced by :func:`compute_label_weight_imputation_dependency_mask` (see it
+    for the release algorithm) and consumed by
+    :func:`compute_label_weight_known_at_lookahead`.
 
-    - ``dependency_mask``: pivots unavailable until the frame boundary
-    - ``leading_stable_mask``: subset of ``dependency_mask`` whose imputation is
-      provably fixed at ``0.0`` on the causal prefix, released over the prefix
-      ``weight_availability[: stable_release_index + 1]``
-    - ``stable_release_index``: pivot index bounding the shared release prefix,
-      or ``-1`` when ``leading_stable_mask`` is empty (no releasable run)
+    - ``dependency_mask``: pivots deferred to the frame boundary ``n``
+    - ``leading_stable_mask``: subset of ``dependency_mask`` provably fixed at
+      ``0.0`` on the causal prefix, hence released early
+    - ``stable_release_index``: pivot index bounding that release prefix, or
+      ``-1`` when ``leading_stable_mask`` is empty
     """
 
     dependency_mask: NDArray[np.bool_]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2758,8 +2758,9 @@ def compute_label_weight_imputation_dependency_mask(
         if component_finite.any():
             first_finite_indices.append(int(np.argmax(component_finite)))
         else:
-            # An all-non-finite component imputes to the nonzero default (1.0),
-            # so the aggregate leading run cannot be a stable zero.
+            # An all-non-finite component never confirms a finite weight
+            # in-frame, so it has no first_finite release candle; block the
+            # leading release and defer these pivots to n conservatively.
             every_component_has_finite = False
 
     if len(imputed_metrics) == 0:

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2654,10 +2654,12 @@ class LabelWeightImputationMasks:
     ``dependency_mask`` pivots remain unavailable until the frame boundary.
     ``leading_stable_mask`` and ``trailing_stable_mask`` (both subsets of
     ``dependency_mask``) mark non-finite runs whose imputation is provably fixed
-    at ``0.0`` given only the causal prefix; they are released at
-    ``weight_availability[stable_release_index]`` rather than the frame boundary.
-    ``stable_release_index`` is the pivot index whose weight confirmation is that
-    shared release candle (``-1`` when both stable masks are empty).
+    at ``0.0`` given only the causal prefix; they are released at the max over
+    the release prefix ``weight_availability[: stable_release_index + 1]`` rather
+    than the frame boundary. ``stable_release_index`` is the pivot index whose
+    weight confirmation is that shared release candle: ``first_finite`` for a
+    single metric, ``max`` over components for ``combined`` (``-1`` when both
+    stable masks are empty).
     """
 
     dependency_mask: NDArray[np.bool_]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2658,8 +2658,8 @@ class LabelWeightImputationMasks:
     - ``leading_stable_mask``: subset of ``dependency_mask`` whose imputation is
       provably fixed at ``0.0`` on the causal prefix, released over the prefix
       ``weight_availability[: stable_release_index + 1]``
-    - ``stable_release_index``: pivot index of the shared release candle, or
-      ``-1`` when no pivot is finite
+    - ``stable_release_index``: pivot index bounding the shared release prefix,
+      or ``-1`` when ``leading_stable_mask`` is empty (no releasable run)
     """
 
     dependency_mask: NDArray[np.bool_]
@@ -2695,13 +2695,11 @@ def compute_label_weight_imputation_dependency_mask(
       component confirmation; unequal run lengths must not leak). Guarded by an
       empirical ``combined_weights[:S] == 0.0`` check.
 
-    ``stable_release_index`` is ``-1`` only when no pivot is finite (``uniform``,
-    empty or all-non-finite metrics, and any ``combined`` case that fails the
-    checks above; those pivots keep the nonzero default and defer to ``n``). A
-    single metric with any finite value always reports ``first_finite`` even
-    when ``leading_stable_mask`` is empty (e.g. all-finite or interior-only-NaN);
-    the consumer additionally gates the release on the mask being non-empty, so
-    such an index is inert.
+    ``stable_release_index`` is ``-1`` whenever ``leading_stable_mask`` is empty
+    (``uniform``, empty or all-non-finite metrics, a single metric with no
+    leading run such as all-finite or interior-only-NaN, and any ``combined``
+    case that fails the checks above); those pivots keep the nonzero default and
+    defer to ``n``. It is ``>= 0`` if and only if a leading run is released.
     """
     label_weighting = {**DEFAULTS_LABEL_WEIGHTING, **weighting_config}
     strategy = label_weighting["strategy"]
@@ -2733,8 +2731,9 @@ def compute_label_weight_imputation_dependency_mask(
         release_index = -1
         if finite.any():
             first_finite = int(np.argmax(finite))
-            leading_stable[:first_finite] = True
-            release_index = first_finite
+            if first_finite > 0:
+                leading_stable[:first_finite] = True
+                release_index = first_finite
         return LabelWeightImputationMasks(dependency, leading_stable, release_index)
     if strategy != WEIGHT_STRATEGIES[8]:  # "combined"
         raise ValueError(_invalid_weight_strategy_message(strategy, metrics))
@@ -3314,7 +3313,7 @@ def compute_label_weight_known_at_lookahead(
 
     A metric-based pivot's weight is backfilled from the adjacent closing pivot,
     so it becomes computable at the next pivot's confirmation
-    ``i_{k+1} == known_at_positions[indices[k+1]]``; the trailing pivot has no
+    ``i_{k+1} == known_at_positions[indices[k+1]]``; the terminal pivot has no
     closing swing (weight 0 via ``_impute_weights``) and never resolves in-frame
     -> ``n``. A uniform pivot instead has a unit weight at its own label
     availability. Off-pivot rows keep their label availability, except that a

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2653,13 +2653,13 @@ class LabelWeightImputationMasks:
 
     ``dependency_mask`` pivots remain unavailable until the frame boundary.
     ``leading_stable_mask`` and ``trailing_stable_mask`` (both subsets of
-    ``dependency_mask``) mark non-finite runs whose imputation is provably fixed
-    at ``0.0`` given only the causal prefix; they are released at the max over
-    the release prefix ``weight_availability[: stable_release_index + 1]`` rather
-    than the frame boundary. ``stable_release_index`` is the pivot index whose
-    weight confirmation is that shared release candle: ``first_finite`` for a
-    single metric, ``max`` over components for ``combined`` (``-1`` when both
-    stable masks are empty).
+    ``dependency_mask``) mark non-finite pivots whose imputation is provably
+    fixed at ``0.0`` given only the causal prefix; they are released at the max
+    over the release prefix ``weight_availability[: stable_release_index + 1]``
+    rather than the frame boundary. ``stable_release_index`` is the pivot index
+    whose weight confirmation is that shared release candle (``first_finite`` for
+    a single metric, ``max`` over components for ``combined``), or ``-1`` when no
+    early release applies (the consumer also gates on the masks being non-empty).
     """
 
     dependency_mask: NDArray[np.bool_]
@@ -2685,9 +2685,11 @@ def compute_label_weight_imputation_dependency_mask(
     provably fixed given only the causal prefix, so they need not defer to the
     frame boundary:
 
-    - single-metric: the leading run ``[0, first_finite)`` and the trailing run
-      ``(last_finite, n)`` both impute to ``0.0`` and stabilize once the first
-      finite pivot's weight is known; ``stable_release_index = first_finite``.
+    - single-metric: the leading run ``[0, first_finite)`` and the terminal
+      pivot (the last pivot, which has no closing swing) both impute to ``0.0``
+      and stabilize once the first finite pivot's weight is known;
+      ``stable_release_index = first_finite``. A non-terminal pivot in a longer
+      trailing run stays deferred to ``n`` (its 0.0 is not causal-prefix stable).
     - ``combined`` with every selected component leading with a non-finite run:
       the aggregate is stably zero over ``[0, min_c first_finite_c)`` (the
       shortest leading run bounds the all-zero prefix), released at the ``max``
@@ -2696,9 +2698,11 @@ def compute_label_weight_imputation_dependency_mask(
       empirical ``combined_weights[:S] == 0.0`` check; ``trailing_stable_mask``
       is unused (empty) for ``combined``.
 
-    Both masks are empty (and ``stable_release_index == -1``) for ``uniform``,
-    all-non-finite metrics, and any ``combined`` case that fails the checks
-    above; those pivots keep the nonzero legacy default and defer to ``n``.
+    ``stable_release_index == -1`` (both stable masks empty, or single-metric
+    with all its finite/non-finite structure yielding no released pivot) for
+    ``uniform``, all-non-finite metrics, and any ``combined`` case that fails the
+    checks above; those pivots keep the nonzero legacy default and defer to
+    ``n``.
     """
     label_weighting = {**DEFAULTS_LABEL_WEIGHTING, **weighting_config}
     strategy = label_weighting["strategy"]
@@ -2733,7 +2737,15 @@ def compute_label_weight_imputation_dependency_mask(
             first_finite = int(np.argmax(finite))
             last_finite = finite.size - 1 - int(np.argmax(finite[::-1]))
             leading_stable[:first_finite] = True
-            trailing_stable[last_finite + 1 :] = True
+            # Only the terminal pivot (no closing swing) is provably 0.0 at
+            # weight_availability[first_finite]: it is always the last pivot, so
+            # its trailing-boundary classification cannot flip. A non-terminal
+            # pivot in a longer trailing run (a degenerate interior swing, e.g.
+            # zero-volume window) could still turn interior (median != 0.0)
+            # until its own later swing is confirmed, so releasing it early
+            # would leak; leave it deferred to n via dependency_mask.
+            if last_finite < n_indices - 1:
+                trailing_stable[n_indices - 1] = True
             release_index = first_finite
         return LabelWeightImputationMasks(
             dependency, leading_stable, trailing_stable, release_index

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2655,9 +2655,8 @@ class LabelWeightImputationMasks:
     algorithm.
 
     - ``dependency_mask``: pivots unavailable until the frame boundary
-    - ``leading_stable_mask``/``trailing_stable_mask``: subsets of
-      ``dependency_mask`` whose imputation is provably fixed at ``0.0`` on the
-      causal prefix, released over the prefix
+    - ``leading_stable_mask``: subset of ``dependency_mask`` whose imputation is
+      provably fixed at ``0.0`` on the causal prefix, released over the prefix
       ``weight_availability[: stable_release_index + 1]``
     - ``stable_release_index``: pivot index of the shared release candle, or
       ``-1`` when no pivot is finite
@@ -2665,7 +2664,6 @@ class LabelWeightImputationMasks:
 
     dependency_mask: NDArray[np.bool_]
     leading_stable_mask: NDArray[np.bool_]
-    trailing_stable_mask: NDArray[np.bool_]
     stable_release_index: int
 
 
@@ -2681,38 +2679,36 @@ def compute_label_weight_imputation_dependency_mask(
     dependency propagates from every selected component and from the aggregate
     before its final imputation.
 
-    ``leading_stable_mask`` and ``trailing_stable_mask`` (subsets of
-    ``dependency_mask``) mark non-finite runs that impute to ``0.0`` and are
-    provably fixed given only the causal prefix, so they need not defer to the
-    frame boundary:
+    ``leading_stable_mask`` (a subset of ``dependency_mask``) marks non-finite
+    runs that impute to ``0.0`` and are provably fixed given only the causal
+    prefix, so they need not defer to the frame boundary:
 
-    - single-metric: the leading run ``[0, first_finite)`` and the terminal
-      pivot (the last pivot, which has no closing swing) both impute to ``0.0``
-      and stabilize once the first finite pivot's weight is known;
-      ``stable_release_index = first_finite``. A non-terminal pivot in a longer
-      trailing run stays deferred to ``n`` (its 0.0 is not causal-prefix stable).
+    - single-metric: the leading run ``[0, first_finite)`` imputes to ``0.0``
+      and stabilizes once the first finite pivot's weight is known;
+      ``stable_release_index = first_finite``. The terminal pivot and any
+      non-terminal trailing run stay deferred to ``n`` (their 0.0 is not
+      causal-prefix stable: a later closing pivot turns the metric finite).
     - ``combined`` with every selected component leading with a non-finite run:
       the aggregate is stably zero over ``[0, min_c first_finite_c)`` (the
       shortest leading run bounds the all-zero prefix), released at the ``max``
       over components ``stable_release_index = max_c first_finite_c`` (the latest
       component confirmation; unequal run lengths must not leak). Guarded by an
-      empirical ``combined_weights[:S] == 0.0`` check; ``trailing_stable_mask``
-      is unused (empty) for ``combined``.
+      empirical ``combined_weights[:S] == 0.0`` check.
 
     ``stable_release_index`` is ``-1`` only when no pivot is finite (``uniform``,
     empty or all-non-finite metrics, and any ``combined`` case that fails the
-    checks above; those pivots keep the nonzero legacy default and defer to
-    ``n``). A single metric with any finite value always reports
-    ``first_finite`` even when both stable masks are empty (e.g. all-finite or
-    interior-only-NaN); the consumer additionally gates the release on the masks
-    being non-empty, so such an index is inert.
+    checks above; those pivots keep the nonzero default and defer to ``n``). A
+    single metric with any finite value always reports ``first_finite`` even
+    when ``leading_stable_mask`` is empty (e.g. all-finite or interior-only-NaN);
+    the consumer additionally gates the release on the mask being non-empty, so
+    such an index is inert.
     """
     label_weighting = {**DEFAULTS_LABEL_WEIGHTING, **weighting_config}
     strategy = label_weighting["strategy"]
 
     def _empty_masks() -> LabelWeightImputationMasks:
         zeros = np.zeros(n_indices, dtype=bool)
-        return LabelWeightImputationMasks(zeros, zeros.copy(), zeros.copy(), -1)
+        return LabelWeightImputationMasks(zeros, zeros.copy(), -1)
 
     if strategy == WEIGHT_STRATEGIES[0]:  # "none"
         raise ValueError(
@@ -2733,23 +2729,13 @@ def compute_label_weight_imputation_dependency_mask(
             )
         dependency = _nonfinite_imputation_dependency_mask(values)
         leading_stable = np.zeros(n_indices, dtype=bool)
-        trailing_stable = np.zeros(n_indices, dtype=bool)
         finite = ~dependency
         release_index = -1
         if finite.any():
             first_finite = int(np.argmax(finite))
-            last_finite = finite.size - 1 - int(np.argmax(finite[::-1]))
             leading_stable[:first_finite] = True
-            # The terminal pivot (always last, no closing swing) is provably
-            # 0.0, so its classification cannot flip. A non-terminal trailing
-            # pivot could still turn interior (nonzero) once its own later swing
-            # confirms, so releasing it early would leak; defer it to n.
-            if last_finite < n_indices - 1:
-                trailing_stable[n_indices - 1] = True
             release_index = first_finite
-        return LabelWeightImputationMasks(
-            dependency, leading_stable, trailing_stable, release_index
-        )
+        return LabelWeightImputationMasks(dependency, leading_stable, release_index)
     if strategy != WEIGHT_STRATEGIES[8]:  # "combined"
         raise ValueError(_invalid_weight_strategy_message(strategy, metrics))
 
@@ -2779,7 +2765,7 @@ def compute_label_weight_imputation_dependency_mask(
 
     if len(imputed_metrics) == 0:
         empty = np.zeros(n_indices, dtype=bool)
-        return LabelWeightImputationMasks(dependency_mask, empty, empty.copy(), -1)
+        return LabelWeightImputationMasks(dependency_mask, empty, -1)
 
     combined_weights = _aggregate_imputed_metrics(
         imputed_metrics,
@@ -2805,9 +2791,7 @@ def compute_label_weight_imputation_dependency_mask(
         if bool(np.all(combined_weights[:stable_length] == 0.0)):
             leading_stable[:stable_length] = True
             release_index = max(first_finite_indices)
-    return LabelWeightImputationMasks(
-        dependency_mask, leading_stable, np.zeros(n_indices, dtype=bool), release_index
-    )
+    return LabelWeightImputationMasks(dependency_mask, leading_stable, release_index)
 
 
 def _compute_epsilon_floor(
@@ -3323,7 +3307,6 @@ def compute_label_weight_known_at_lookahead(
     *,
     imputation_dependency_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
     imputation_leading_stable_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
-    imputation_trailing_stable_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
     imputation_stable_release_index: int = -1,
     weighting_config: dict[str, Any] | None = None,
 ) -> pd.Series:
@@ -3353,14 +3336,14 @@ def compute_label_weight_known_at_lookahead(
     dependencies.
 
     The imputation masks (``imputation_dependency_mask``,
-    ``imputation_leading_stable_mask``, ``imputation_trailing_stable_mask``,
-    ``imputation_stable_release_index``) come from
-    :func:`compute_label_weight_imputation_dependency_mask`. Dependency pivots
-    and their Gaussian bands wait for the frame boundary; stable-mask pivots are
-    released over ``weight_availability[: imputation_stable_release_index + 1]``,
-    folded via ``max`` with each pivot's own label availability, with their
-    zero-weight bands skipped. The release applies only in the identity-order
-    case (no dropped pivot) where the runs are a contiguous prefix/suffix.
+    ``imputation_leading_stable_mask``, ``imputation_stable_release_index``)
+    come from :func:`compute_label_weight_imputation_dependency_mask`.
+    Dependency pivots and their Gaussian bands wait for the frame boundary;
+    leading-stable pivots are released over
+    ``weight_availability[: imputation_stable_release_index + 1]``, folded via
+    ``max`` with each pivot's own label availability, with their zero-weight
+    bands skipped. The release applies only in the identity-order case (no
+    dropped pivot) where the run is a contiguous prefix.
     """
     n = len(known_at_lookahead)
     positions, known_at_lookahead_values = _sanitize_known_at_lookahead(
@@ -3391,16 +3374,12 @@ def compute_label_weight_known_at_lookahead(
     raw_leading_stable_mask = _validate_pivot_mask(
         imputation_leading_stable_mask, "imputation_leading_stable_mask"
     )
-    raw_trailing_stable_mask = _validate_pivot_mask(
-        imputation_trailing_stable_mask, "imputation_trailing_stable_mask"
-    )
     valid_mask = (raw_idx >= 0) & (raw_idx < n)
     idx = raw_idx[valid_mask]
     order = np.argsort(idx, kind="stable")
     idx = idx[order]
     dependency_mask = raw_dependency_mask[valid_mask][order]
     leading_stable_mask = raw_leading_stable_mask[valid_mask][order]
-    trailing_stable_mask = raw_trailing_stable_mask[valid_mask][order]
     base = known_at_positions.copy()
     if idx.size:
         weight_availability = np.empty(idx.size, dtype=np.int64)
@@ -3437,19 +3416,18 @@ def compute_label_weight_known_at_lookahead(
             np.maximum(avail_pivot, sigma_availability, out=avail_pivot)
         avail_pivot[dependency_mask] = n
         if (
-            (leading_stable_mask.any() or trailing_stable_mask.any())
+            leading_stable_mask.any()
             and idx.size == raw_idx.size
             and np.array_equal(order, np.arange(idx.size))
             and 0 <= imputation_stable_release_index < weight_availability.size
         ):
             # Prefix max (not weight_availability[stable_release_index]) stays
             # leak-free if availability is non-monotone, at worst deferring
-            # later; guarded to identity order (contiguous prefix/suffix runs).
+            # later; guarded to identity order (contiguous prefix run).
             release = int(
                 np.max(weight_availability[: imputation_stable_release_index + 1])
             )
             avail_pivot[leading_stable_mask] = release
-            avail_pivot[trailing_stable_mask] = release
         base[idx] = np.maximum(base[idx], avail_pivot)
         if fill_radius > 0:
             for (
@@ -3458,18 +3436,16 @@ def compute_label_weight_known_at_lookahead(
                 weight_avail,
                 pivot_dependency,
                 pivot_leading,
-                pivot_trailing,
             ) in zip(
                 idx.tolist(),
                 avail_pivot.tolist(),
                 band_weight_availability.tolist(),
                 dependency_mask.tolist(),
                 leading_stable_mask.tolist(),
-                trailing_stable_mask.tolist(),
             ):
-                # A leading/trailing-run pivot imputes to 0.0 (zero bump): its own
-                # row is released above; it spreads no band.
-                if pivot_leading or pivot_trailing:
+                # A leading-run pivot imputes to 0.0 (zero bump): its own row is
+                # released above; it spreads no band.
+                if pivot_leading:
                     continue
                 # Skip pivots whose band weight never resolves in-frame
                 # (weight_avail == n): their Gaussian bump is zero. Exception: an

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2743,7 +2743,7 @@ def compute_label_weight_imputation_dependency_mask(
     imputed_metrics: list[NDArray[np.floating]] = []
     coefficients_list: list[float] = []
     first_finite_indices: list[int] = []
-    all_components_finite = True
+    every_component_has_finite = True
     for metric_name, values_array, coefficient in _select_combined_metrics(
         metrics, label_weighting["metric_coefficients"]
     ):
@@ -2761,10 +2761,10 @@ def compute_label_weight_imputation_dependency_mask(
         else:
             # An all-non-finite component imputes to the nonzero legacy default
             # (1.0), so the aggregate leading run cannot be a stable zero.
-            all_components_finite = False
+            every_component_has_finite = False
 
-    empty = np.zeros(n_indices, dtype=bool)
     if len(imputed_metrics) == 0:
+        empty = np.zeros(n_indices, dtype=bool)
         return LabelWeightImputationMasks(dependency_mask, empty, empty.copy(), -1)
 
     combined_weights = _aggregate_imputed_metrics(
@@ -2786,7 +2786,7 @@ def compute_label_weight_imputation_dependency_mask(
     # stable-zero prefix spans [0, min first_finite); the release candle is the
     # max over components (latest confirmation) so unequal run lengths never leak.
     if (
-        all_components_finite
+        every_component_has_finite
         and first_finite_indices
         and min(first_finite_indices) >= 1
     ):
@@ -2795,7 +2795,7 @@ def compute_label_weight_imputation_dependency_mask(
             leading_stable[:stable_length] = True
             release_index = max(first_finite_indices)
     return LabelWeightImputationMasks(
-        dependency_mask, leading_stable, empty.copy(), release_index
+        dependency_mask, leading_stable, np.zeros(n_indices, dtype=bool), release_index
     )
 
 
@@ -3347,11 +3347,12 @@ def compute_label_weight_known_at_lookahead(
     trailing pivot is excluded only when it has no such dependency.
     ``imputation_leading_stable_mask`` and ``imputation_trailing_stable_mask``
     (subsets) mark non-finite runs that impute to 0.0 and are provably fixed
-    given the causal prefix; both are released at
-    ``weight_availability[imputation_stable_release_index]`` (the shared
-    stabilization candle) instead of the frame boundary, and their zero-weight
+    given the causal prefix; both are released at the max over the release
+    prefix ``weight_availability[: imputation_stable_release_index + 1]`` (the
+    shared stabilization candle) instead of the frame boundary, folded via
+    ``max`` with each pivot's own label availability, and their zero-weight
     bands are skipped. The release is applied only in the identity-order case
-    where the runs are a contiguous prefix/suffix.
+    (no dropped pivot) where the runs are a contiguous prefix/suffix.
     """
     n = len(known_at_lookahead)
     positions, known_at_lookahead_values = _sanitize_known_at_lookahead(
@@ -3429,15 +3430,23 @@ def compute_label_weight_known_at_lookahead(
         avail_pivot[dependency_mask] = n
         if (
             (leading_stable_mask.any() or trailing_stable_mask.any())
+            and idx.size == raw_idx.size
             and np.array_equal(order, np.arange(idx.size))
             and 0 <= imputation_stable_release_index < weight_availability.size
         ):
             # Leading/trailing non-finite runs impute to 0.0 and are provably
-            # fixed once the shared release pivot's weight is known
-            # (weight_availability[stable_release_index]), not at the frame
-            # boundary. Guarded to the identity-order case where the runs are a
-            # contiguous prefix/suffix.
-            release = int(weight_availability[imputation_stable_release_index])
+            # fixed once every contributing component's first finite weight is
+            # known. That shared candle is the max over the release prefix
+            # weight_availability[: stable_release_index + 1]; for single-metric
+            # (release index == first_finite) the prefix max equals
+            # weight_availability[first_finite]. Taking the prefix max rather
+            # than a single lookup stays correct without assuming
+            # weight_availability is monotone (combined max-over-components).
+            # Guarded to the identity-order case (no dropped pivot) where the
+            # runs are a contiguous prefix/suffix.
+            release = int(
+                np.max(weight_availability[: imputation_stable_release_index + 1])
+            )
             avail_pivot[leading_stable_mask] = release
             avail_pivot[trailing_stable_mask] = release
         base[idx] = np.maximum(base[idx], avail_pivot)

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2651,17 +2651,16 @@ def _nonfinite_imputation_dependency_mask(
 class LabelWeightImputationMasks:
     """Causal-availability masks for non-finite pivot-weight imputations.
 
-    ``dependency_mask`` pivots remain unavailable until the frame boundary.
-    ``leading_stable_mask`` and ``trailing_stable_mask`` (both subsets of
-    ``dependency_mask``) mark non-finite pivots whose imputation is provably
-    fixed at ``0.0`` given only the causal prefix; they are released at the max
-    over the release prefix ``weight_availability[: stable_release_index + 1]``
-    rather than the frame boundary. ``stable_release_index`` is the pivot index
-    whose weight confirmation is that shared release candle (``first_finite`` for
-    a single metric with any finite value, ``max`` over components for
-    ``combined``), or ``-1`` only when no pivot is finite. The consumer applies
-    it solely when a stable mask is non-empty, so a non-negative index with empty
-    masks is inert.
+    See :func:`compute_label_weight_imputation_dependency_mask` for the release
+    algorithm.
+
+    - ``dependency_mask``: pivots unavailable until the frame boundary
+    - ``leading_stable_mask``/``trailing_stable_mask``: subsets of
+      ``dependency_mask`` whose imputation is provably fixed at ``0.0`` on the
+      causal prefix, released over the prefix
+      ``weight_availability[: stable_release_index + 1]``
+    - ``stable_release_index``: pivot index of the shared release candle, or
+      ``-1`` when no pivot is finite
     """
 
     dependency_mask: NDArray[np.bool_]
@@ -2800,9 +2799,6 @@ def compute_label_weight_imputation_dependency_mask(
 
     leading_stable = np.zeros(n_indices, dtype=bool)
     release_index = -1
-    # Every component must lead with a non-finite run (first_finite >= 1). The
-    # stable-zero prefix spans [0, min first_finite); the release candle is the
-    # max over components (latest confirmation) so unequal run lengths never leak.
     if (
         every_component_has_finite
         and first_finite_indices
@@ -3359,18 +3355,15 @@ def compute_label_weight_known_at_lookahead(
     strategies and additive fills keep their existing competing-band
     dependencies.
 
-    ``imputation_dependency_mask`` marks pivot weights whose non-finite
-    imputation can change as the available prefix grows. Those pivots and their
-    Gaussian bands are unavailable until the frame boundary. An unresolved
-    trailing pivot is excluded only when it has no such dependency.
-    ``imputation_leading_stable_mask`` and ``imputation_trailing_stable_mask``
-    (subsets) mark non-finite runs that impute to 0.0 and are provably fixed
-    given the causal prefix; both are released at the max over the release
-    prefix ``weight_availability[: imputation_stable_release_index + 1]`` (the
-    shared stabilization candle) instead of the frame boundary, folded via
-    ``max`` with each pivot's own label availability, and their zero-weight
-    bands are skipped. The release is applied only in the identity-order case
-    (no dropped pivot) where the runs are a contiguous prefix/suffix.
+    The imputation masks (``imputation_dependency_mask``,
+    ``imputation_leading_stable_mask``, ``imputation_trailing_stable_mask``,
+    ``imputation_stable_release_index``) come from
+    :func:`compute_label_weight_imputation_dependency_mask`. Dependency pivots
+    and their Gaussian bands wait for the frame boundary; stable-mask pivots are
+    released over ``weight_availability[: imputation_stable_release_index + 1]``,
+    folded via ``max`` with each pivot's own label availability, with their
+    zero-weight bands skipped. The release applies only in the identity-order
+    case (no dropped pivot) where the runs are a contiguous prefix/suffix.
     """
     n = len(known_at_lookahead)
     positions, known_at_lookahead_values = _sanitize_known_at_lookahead(
@@ -3452,17 +3445,10 @@ def compute_label_weight_known_at_lookahead(
             and np.array_equal(order, np.arange(idx.size))
             and 0 <= imputation_stable_release_index < weight_availability.size
         ):
-            # Leading/trailing non-finite runs impute to 0.0 and are provably
-            # fixed once every contributing component's first finite weight is
-            # known. That shared candle is the max over the release prefix
-            # weight_availability[: stable_release_index + 1]. Under the
-            # production invariant (zigzag confirmation watermark => monotone
-            # weight_availability) this equals weight_availability[
-            # stable_release_index]; the prefix max also stays leak-free if that
-            # invariant is ever violated (combined max-over-components, or a
-            # non-monotone availability), at worst deferring slightly later.
-            # Guarded to the identity-order case (no dropped pivot) where the
-            # runs are a contiguous prefix/suffix.
+            # Release stable-mask pivots at the prefix max
+            # weight_availability[: stable_release_index + 1]; this stays
+            # leak-free even if availability is non-monotone (at worst defers
+            # later). Guarded to identity order (contiguous prefix/suffix runs).
             release = int(
                 np.max(weight_availability[: imputation_stable_release_index + 1])
             )

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2647,24 +2647,64 @@ def _nonfinite_imputation_dependency_mask(
     return ~np.isfinite(values)
 
 
+@dataclass(frozen=True, slots=True)
+class LabelWeightImputationMasks:
+    """Causal-availability masks for non-finite pivot-weight imputations.
+
+    ``dependency_mask`` pivots remain unavailable until the frame boundary.
+    ``leading_stable_mask`` and ``trailing_stable_mask`` (both subsets of
+    ``dependency_mask``) mark non-finite runs whose imputation is provably fixed
+    at ``0.0`` given only the causal prefix; they are released at
+    ``weight_availability[stable_release_index]`` rather than the frame boundary.
+    ``stable_release_index`` is the pivot index whose weight confirmation is that
+    shared release candle (``-1`` when both stable masks are empty).
+    """
+
+    dependency_mask: NDArray[np.bool_]
+    leading_stable_mask: NDArray[np.bool_]
+    trailing_stable_mask: NDArray[np.bool_]
+    stable_release_index: int
+
+
 def compute_label_weight_imputation_dependency_mask(
     n_indices: int,
     metrics: dict[str, list[float]],
     weighting_config: dict[str, Any],
-) -> tuple[NDArray[np.bool_], NDArray[np.bool_]]:
+) -> LabelWeightImputationMasks:
     """Identify pivot weights whose non-finite imputation can change by prefix.
 
-    Returns ``(dependency_mask, leading_stable_mask)``. A ``dependency_mask``
-    pivot remains causally unavailable until the frame boundary; for
-    ``combined``, dependency propagates from every selected component and from
-    the aggregate before its final imputation. ``leading_stable_mask`` (a subset
-    of ``dependency_mask``) marks the leading non-finite run of a single-metric
-    strategy: those pivots impute to ``0.0`` and stabilize once the first finite
-    pivot's weight is known, so they need not defer to the frame boundary. It is
-    empty for ``uniform``, ``combined``, and all-non-finite metrics.
+    Returns a :class:`LabelWeightImputationMasks`. A ``dependency_mask`` pivot
+    remains causally unavailable until the frame boundary; for ``combined``,
+    dependency propagates from every selected component and from the aggregate
+    before its final imputation.
+
+    ``leading_stable_mask`` and ``trailing_stable_mask`` (subsets of
+    ``dependency_mask``) mark non-finite runs that impute to ``0.0`` and are
+    provably fixed given only the causal prefix, so they need not defer to the
+    frame boundary:
+
+    - single-metric: the leading run ``[0, first_finite)`` and the trailing run
+      ``(last_finite, n)`` both impute to ``0.0`` and stabilize once the first
+      finite pivot's weight is known; ``stable_release_index = first_finite``.
+    - ``combined`` with every selected component leading with a non-finite run:
+      the aggregate is stably zero over ``[0, min_c first_finite_c)`` (the
+      shortest leading run bounds the all-zero prefix), released at the ``max``
+      over components ``stable_release_index = max_c first_finite_c`` (the latest
+      component confirmation; unequal run lengths must not leak). Guarded by an
+      empirical ``combined_weights[:S] == 0.0`` check; ``trailing_stable_mask``
+      is unused (empty) for ``combined``.
+
+    Both masks are empty (and ``stable_release_index == -1``) for ``uniform``,
+    all-non-finite metrics, and any ``combined`` case that fails the checks
+    above; those pivots keep the nonzero legacy default and defer to ``n``.
     """
     label_weighting = {**DEFAULTS_LABEL_WEIGHTING, **weighting_config}
     strategy = label_weighting["strategy"]
+
+    def _empty_masks() -> LabelWeightImputationMasks:
+        zeros = np.zeros(n_indices, dtype=bool)
+        return LabelWeightImputationMasks(zeros, zeros.copy(), zeros.copy(), -1)
+
     if strategy == WEIGHT_STRATEGIES[0]:  # "none"
         raise ValueError(
             "compute_label_weight_imputation_dependency_mask must not be called "
@@ -2672,11 +2712,11 @@ def compute_label_weight_imputation_dependency_mask(
             "weighting is disabled"
         )
     if strategy == WEIGHT_STRATEGIES[1]:  # "uniform"
-        return np.zeros(n_indices, dtype=bool), np.zeros(n_indices, dtype=bool)
+        return _empty_masks()
     if strategy in metrics:
         values = np.asarray(metrics[strategy], dtype=float)
         if values.size == 0:
-            return np.zeros(n_indices, dtype=bool), np.zeros(n_indices, dtype=bool)
+            return _empty_masks()
         if values.shape != (n_indices,):
             raise ValueError(
                 f"Invalid metric {strategy!r} shape {values.shape}: "
@@ -2684,16 +2724,26 @@ def compute_label_weight_imputation_dependency_mask(
             )
         dependency = _nonfinite_imputation_dependency_mask(values)
         leading_stable = np.zeros(n_indices, dtype=bool)
+        trailing_stable = np.zeros(n_indices, dtype=bool)
         finite = ~dependency
+        release_index = -1
         if finite.any():
-            leading_stable[: int(np.argmax(finite))] = True
-        return dependency, leading_stable
+            first_finite = int(np.argmax(finite))
+            last_finite = finite.size - 1 - int(np.argmax(finite[::-1]))
+            leading_stable[:first_finite] = True
+            trailing_stable[last_finite + 1 :] = True
+            release_index = first_finite
+        return LabelWeightImputationMasks(
+            dependency, leading_stable, trailing_stable, release_index
+        )
     if strategy != WEIGHT_STRATEGIES[8]:  # "combined"
         raise ValueError(_invalid_weight_strategy_message(strategy, metrics))
 
     dependency_mask = np.zeros(n_indices, dtype=bool)
     imputed_metrics: list[NDArray[np.floating]] = []
     coefficients_list: list[float] = []
+    first_finite_indices: list[int] = []
+    all_components_finite = True
     for metric_name, values_array, coefficient in _select_combined_metrics(
         metrics, label_weighting["metric_coefficients"]
     ):
@@ -2702,12 +2752,20 @@ def compute_label_weight_imputation_dependency_mask(
                 f"Invalid metric {metric_name!r} shape {values_array.shape}: "
                 f"must be ({n_indices},)"
             )
-        dependency_mask |= _nonfinite_imputation_dependency_mask(values_array)
+        component_finite = np.isfinite(values_array)
+        dependency_mask |= ~component_finite
         imputed_metrics.append(_impute_weights(values_array))
         coefficients_list.append(coefficient)
+        if component_finite.any():
+            first_finite_indices.append(int(np.argmax(component_finite)))
+        else:
+            # An all-non-finite component imputes to the nonzero legacy default
+            # (1.0), so the aggregate leading run cannot be a stable zero.
+            all_components_finite = False
 
+    empty = np.zeros(n_indices, dtype=bool)
     if len(imputed_metrics) == 0:
-        return dependency_mask, np.zeros(n_indices, dtype=bool)
+        return LabelWeightImputationMasks(dependency_mask, empty, empty.copy(), -1)
 
     combined_weights = _aggregate_imputed_metrics(
         imputed_metrics,
@@ -2721,7 +2779,24 @@ def compute_label_weight_imputation_dependency_mask(
             f"must be ({n_indices},)"
         )
     dependency_mask |= _nonfinite_imputation_dependency_mask(combined_weights)
-    return dependency_mask, np.zeros(n_indices, dtype=bool)
+
+    leading_stable = np.zeros(n_indices, dtype=bool)
+    release_index = -1
+    # Every component must lead with a non-finite run (first_finite >= 1). The
+    # stable-zero prefix spans [0, min first_finite); the release candle is the
+    # max over components (latest confirmation) so unequal run lengths never leak.
+    if (
+        all_components_finite
+        and first_finite_indices
+        and min(first_finite_indices) >= 1
+    ):
+        stable_length = min(first_finite_indices)
+        if bool(np.all(combined_weights[:stable_length] == 0.0)):
+            leading_stable[:stable_length] = True
+            release_index = max(first_finite_indices)
+    return LabelWeightImputationMasks(
+        dependency_mask, leading_stable, empty.copy(), release_index
+    )
 
 
 def _compute_epsilon_floor(
@@ -3237,6 +3312,8 @@ def compute_label_weight_known_at_lookahead(
     *,
     imputation_dependency_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
     imputation_leading_stable_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
+    imputation_trailing_stable_mask: Sequence[bool] | NDArray[np.bool_] | None = None,
+    imputation_stable_release_index: int = -1,
     weighting_config: dict[str, Any] | None = None,
 ) -> pd.Series:
     """Per-row causal availability (in candles) of the label WEIGHT column.
@@ -3268,10 +3345,13 @@ def compute_label_weight_known_at_lookahead(
     imputation can change as the available prefix grows. Those pivots and their
     Gaussian bands are unavailable until the frame boundary. An unresolved
     trailing pivot is excluded only when it has no such dependency.
-    ``imputation_leading_stable_mask`` (a subset) marks a leading non-finite run
-    that imputes to 0.0 and stabilizes at the first finite pivot's confirmation;
-    those pivots are released there instead of at the frame boundary and their
-    zero-weight bands are skipped.
+    ``imputation_leading_stable_mask`` and ``imputation_trailing_stable_mask``
+    (subsets) mark non-finite runs that impute to 0.0 and are provably fixed
+    given the causal prefix; both are released at
+    ``weight_availability[imputation_stable_release_index]`` (the shared
+    stabilization candle) instead of the frame boundary, and their zero-weight
+    bands are skipped. The release is applied only in the identity-order case
+    where the runs are a contiguous prefix/suffix.
     """
     n = len(known_at_lookahead)
     positions, known_at_lookahead_values = _sanitize_known_at_lookahead(
@@ -3302,12 +3382,16 @@ def compute_label_weight_known_at_lookahead(
     raw_leading_stable_mask = _validate_pivot_mask(
         imputation_leading_stable_mask, "imputation_leading_stable_mask"
     )
+    raw_trailing_stable_mask = _validate_pivot_mask(
+        imputation_trailing_stable_mask, "imputation_trailing_stable_mask"
+    )
     valid_mask = (raw_idx >= 0) & (raw_idx < n)
     idx = raw_idx[valid_mask]
     order = np.argsort(idx, kind="stable")
     idx = idx[order]
     dependency_mask = raw_dependency_mask[valid_mask][order]
     leading_stable_mask = raw_leading_stable_mask[valid_mask][order]
+    trailing_stable_mask = raw_trailing_stable_mask[valid_mask][order]
     base = known_at_positions.copy()
     if idx.size:
         weight_availability = np.empty(idx.size, dtype=np.int64)
@@ -3343,16 +3427,19 @@ def compute_label_weight_known_at_lookahead(
             )
             np.maximum(avail_pivot, sigma_availability, out=avail_pivot)
         avail_pivot[dependency_mask] = n
-        if leading_stable_mask.any() and np.array_equal(order, np.arange(idx.size)):
-            # Leading non-finite run imputes to 0.0, stable once the first finite
-            # pivot's weight is known (backfilled confirmation weight_availability
-            # [first_finite]), not at the frame boundary. Guarded to the sorted
-            # (identity-order) case where the run is a contiguous prefix.
-            first_finite = int(leading_stable_mask.sum())
-            if first_finite < weight_availability.size:
-                avail_pivot[leading_stable_mask] = int(
-                    weight_availability[first_finite]
-                )
+        if (
+            (leading_stable_mask.any() or trailing_stable_mask.any())
+            and np.array_equal(order, np.arange(idx.size))
+            and 0 <= imputation_stable_release_index < weight_availability.size
+        ):
+            # Leading/trailing non-finite runs impute to 0.0 and are provably
+            # fixed once the shared release pivot's weight is known
+            # (weight_availability[stable_release_index]), not at the frame
+            # boundary. Guarded to the identity-order case where the runs are a
+            # contiguous prefix/suffix.
+            release = int(weight_availability[imputation_stable_release_index])
+            avail_pivot[leading_stable_mask] = release
+            avail_pivot[trailing_stable_mask] = release
         base[idx] = np.maximum(base[idx], avail_pivot)
         if fill_radius > 0:
             for (
@@ -3361,16 +3448,18 @@ def compute_label_weight_known_at_lookahead(
                 weight_avail,
                 pivot_dependency,
                 pivot_leading,
+                pivot_trailing,
             ) in zip(
                 idx.tolist(),
                 avail_pivot.tolist(),
                 band_weight_availability.tolist(),
                 dependency_mask.tolist(),
                 leading_stable_mask.tolist(),
+                trailing_stable_mask.tolist(),
             ):
-                # A leading-run pivot imputes to 0.0 (zero bump): its own row is
-                # released above; it spreads no band.
-                if pivot_leading:
+                # A leading/trailing-run pivot imputes to 0.0 (zero bump): its own
+                # row is released above; it spreads no band.
+                if pivot_leading or pivot_trailing:
                     continue
                 # Skip pivots whose band weight never resolves in-frame
                 # (weight_avail == n): their Gaussian bump is zero. Exception: an

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2740,13 +2740,10 @@ def compute_label_weight_imputation_dependency_mask(
             first_finite = int(np.argmax(finite))
             last_finite = finite.size - 1 - int(np.argmax(finite[::-1]))
             leading_stable[:first_finite] = True
-            # Only the terminal pivot (no closing swing) is provably 0.0 at
-            # weight_availability[first_finite]: it is always the last pivot, so
-            # its trailing-boundary classification cannot flip. A non-terminal
-            # pivot in a longer trailing run (a degenerate interior swing, e.g.
-            # zero-volume window) could still turn interior (median != 0.0)
-            # until its own later swing is confirmed, so releasing it early
-            # would leak; leave it deferred to n via dependency_mask.
+            # The terminal pivot (always last, no closing swing) is provably
+            # 0.0, so its classification cannot flip. A non-terminal trailing
+            # pivot could still turn interior (nonzero) once its own later swing
+            # confirms, so releasing it early would leak; defer it to n.
             if last_finite < n_indices - 1:
                 trailing_stable[n_indices - 1] = True
             release_index = first_finite
@@ -2776,8 +2773,8 @@ def compute_label_weight_imputation_dependency_mask(
         if component_finite.any():
             first_finite_indices.append(int(np.argmax(component_finite)))
         else:
-            # An all-non-finite component imputes to the nonzero legacy default
-            # (1.0), so the aggregate leading run cannot be a stable zero.
+            # An all-non-finite component imputes to the nonzero default (1.0),
+            # so the aggregate leading run cannot be a stable zero.
             every_component_has_finite = False
 
     if len(imputed_metrics) == 0:
@@ -3445,10 +3442,9 @@ def compute_label_weight_known_at_lookahead(
             and np.array_equal(order, np.arange(idx.size))
             and 0 <= imputation_stable_release_index < weight_availability.size
         ):
-            # Release stable-mask pivots at the prefix max
-            # weight_availability[: stable_release_index + 1]; this stays
-            # leak-free even if availability is non-monotone (at worst defers
-            # later). Guarded to identity order (contiguous prefix/suffix runs).
+            # Prefix max (not weight_availability[stable_release_index]) stays
+            # leak-free if availability is non-monotone, at worst deferring
+            # later; guarded to identity order (contiguous prefix/suffix runs).
             release = int(
                 np.max(weight_availability[: imputation_stable_release_index + 1])
             )

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2658,8 +2658,10 @@ class LabelWeightImputationMasks:
     over the release prefix ``weight_availability[: stable_release_index + 1]``
     rather than the frame boundary. ``stable_release_index`` is the pivot index
     whose weight confirmation is that shared release candle (``first_finite`` for
-    a single metric, ``max`` over components for ``combined``), or ``-1`` when no
-    early release applies (the consumer also gates on the masks being non-empty).
+    a single metric with any finite value, ``max`` over components for
+    ``combined``), or ``-1`` only when no pivot is finite. The consumer applies
+    it solely when a stable mask is non-empty, so a non-negative index with empty
+    masks is inert.
     """
 
     dependency_mask: NDArray[np.bool_]
@@ -2698,11 +2700,13 @@ def compute_label_weight_imputation_dependency_mask(
       empirical ``combined_weights[:S] == 0.0`` check; ``trailing_stable_mask``
       is unused (empty) for ``combined``.
 
-    ``stable_release_index == -1`` (both stable masks empty, or single-metric
-    with all its finite/non-finite structure yielding no released pivot) for
-    ``uniform``, all-non-finite metrics, and any ``combined`` case that fails the
+    ``stable_release_index`` is ``-1`` only when no pivot is finite (``uniform``,
+    empty or all-non-finite metrics, and any ``combined`` case that fails the
     checks above; those pivots keep the nonzero legacy default and defer to
-    ``n``.
+    ``n``). A single metric with any finite value always reports
+    ``first_finite`` even when both stable masks are empty (e.g. all-finite or
+    interior-only-NaN); the consumer additionally gates the release on the masks
+    being non-empty, so such an index is inert.
     """
     label_weighting = {**DEFAULTS_LABEL_WEIGHTING, **weighting_config}
     strategy = label_weighting["strategy"]
@@ -3451,11 +3455,12 @@ def compute_label_weight_known_at_lookahead(
             # Leading/trailing non-finite runs impute to 0.0 and are provably
             # fixed once every contributing component's first finite weight is
             # known. That shared candle is the max over the release prefix
-            # weight_availability[: stable_release_index + 1]; for single-metric
-            # (release index == first_finite) the prefix max equals
-            # weight_availability[first_finite]. Taking the prefix max rather
-            # than a single lookup stays correct without assuming
-            # weight_availability is monotone (combined max-over-components).
+            # weight_availability[: stable_release_index + 1]. Under the
+            # production invariant (zigzag confirmation watermark => monotone
+            # weight_availability) this equals weight_availability[
+            # stable_release_index]; the prefix max also stays leak-free if that
+            # invariant is ever violated (combined max-over-components, or a
+            # non-monotone availability), at worst deferring slightly later.
             # Guarded to the identity-order case (no dropped pivot) where the
             # runs are a contiguous prefix/suffix.
             release = int(


### PR DESCRIPTION
## Summary

Harmonizes the causal-availability rule for non-finite pivot-weight imputations that are **provably fixed at `0.0`** given only the causal prefix. Following PR #158 (which released the single-metric **leading** run early), this PR extends the same treatment to the `combined` strategy and hardens the release mechanism. Such over-purges are conservative (no leak) today; releasing a provably-stable `0.0` at its true stabilization candle recovers valid causal training rows.

**Unifying rule:** an imputation provably fixed at `0.0` under the causal prefix is released at its true stabilization candle, not at the frame boundary `n` — and **only** when that value cannot flip as the prefix grows.

## Changes

- **Combined leading-stable release (net-new).** For `strategy="combined"` with **every** selected component leading with a non-finite run, the aggregate is stably zero over `[0, min_c first_finite_c)`. The release candle is the **`max`-over-components** confirmation (`stable_release_index = max_c first_finite_c`), not a single pivot's — unequal run lengths would otherwise leak. Guarded by `min_c first_finite_c >= 1` and an empirical `combined_weights[:S] == 0.0` prefix-stability check.
- **Single-metric leading run** keeps the #158 behavior: the leading run `[0, first_finite)` is released at `first_finite`. `stable_release_index` is `-1` whenever there is no leading run (all-finite / interior-only-NaN), holding the invariant *`index >= 0` iff a leading run is released*.
- **Terminal / trailing pivots stay deferred to `n`.** The terminal pivot (last pivot, no closing swing) and any non-terminal trailing run are **not** released early: `add_pivot` backfills a pivot's swing metric once a later closing pivot arrives, so a terminal non-finite `0.0` can flip to a nonzero interior median when the frame extends — its `0.0` is **not** causal-prefix stable. They remain in `dependency_mask` → deferred to `n` (conservative, no leak).
- **API.** `compute_label_weight_imputation_dependency_mask` returns a frozen `LabelWeightImputationMasks` dataclass (`dependency_mask`, `leading_stable_mask`, `stable_release_index`). The consumer `compute_label_weight_known_at_lookahead` gains `imputation_leading_stable_mask` and `imputation_stable_release_index`; the caller unpacks the dataclass (`None`/`-1` on the non-causal path).
- **Consumer release** is the prefix max `weight_availability[: stable_release_index + 1]`, folded via `max` with each pivot's own label availability, gated on identity pivot order with no dropped pivot. Under the production invariant (zigzag confirmation watermark ⇒ monotone `weight_availability`) this equals `weight_availability[stable_release_index]` and is bit-for-bit with #158 on the leading path; the prefix max stays leak-free (at worst defers later) if that invariant is ever violated.

## Why the API carries an explicit index

For `combined`, the stable run length (`min_c f_c`, i.e. `leading_stable_mask.sum()`) and the release candle (`max_c f_c`) **differ**, and the `max` cannot be recovered from the mask alone, so `stable_release_index` carries it explicitly. For single-metric it equals `first_finite`, preserving bit-for-bit leading behavior.

## Verification

Standalone drivers (external to the repo per its test convention) comparing prior state vs this branch inside the `quickadapter-freqtrade` image:

- Non-causal path and existing single-metric **leading** rows bit-for-bit identical; new availability never below prior (fix only ever defers → leak-free direction).
- Combined leading-stable release proven leak-free (`assigned >= true` stabilization) across `arithmetic`/`geometric`/`harmonic`/`quadratic`/`softmax`/`weighted_median`; the `max`-over-components release fixes a real leak the naive `min` would cause (e.g. `A=[NaN,5,6,NaN]`, `B=[NaN,NaN,2,NaN]`, arithmetic_mean: `min`-candle aggregate `0.5 != 0` would leak, `max`-candle `0.0` stable).
- Terminal / non-terminal trailing pivots and all-non-finite metrics stay deferred to `n`.
- Prefix-max stays `>= ` true stabilization under non-monotone availability.

`ruff check` (no new findings vs base), `ruff format --check`, `python -m py_compile`, and `lsp_diagnostics` clean.

## Acceptance criteria (#169)

- [x] Provably-stable `0.0` leading imputations released at their true stabilization candle (single-metric leading run; combined leading-stable run at the `max`-over-components confirmation).
- [x] Non-causal-prefix-stable `0.0` (terminal pivot, non-terminal trailing runs) and all-non-finite metrics stay deferred to `n`.
- [x] Combined mismatched run lengths handled without leak (empirical prefix-stability check).
- [x] No causal leakage (empirical prefix-stability verification).
- [x] Non-causal path and existing single-metric leading behavior remain bit-for-bit unchanged (under the monotone-availability production invariant).

Closes #169

