### PR TITLE
fix(quickadapter): correct volume rate span

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -4317,7 +4317,9 @@ def _zigzag(
 
         start_pos = min(previous_pos, current_pos)
         end_pos = max(previous_pos, current_pos) + 1
-        avg_volume_per_candle = np.nansum(volumes[start_pos:end_pos]) / duration
+        avg_volume_per_candle = np.nansum(volumes[start_pos:end_pos]) / (
+            end_pos - start_pos
+        )
         median_volume = np.nanmedian(volumes[start_pos:end_pos])
         if (
             np.isfinite(avg_volume_per_candle)


### PR DESCRIPTION
## Summary

- divide the inclusive Zigzag volume span by its actual observation count
- preserve pivot detection, causal availability, price-derived metrics, and downstream weighting semantics

## Root cause

`volume_rate` summed an inclusive interval containing `duration + 1` volume observations but divided by `duration`, so constant volumes produced a rate greater than 1.

## Validation

- external regression harness in Freqtrade 2026.6 covering constant, asymmetric, partially missing, zero, and all-NaN volumes
- direct and `combined` label-weight consumers
- `ruff check` and `ruff format --check`
- targeted runtime compilation and `git diff --check`

No test or harness artifact is committed.

Fixes #188