### PR TITLE
fix(quickadapter): prevent best-params lock hang on FIFO paths

### DIFF
--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5446,12 +5446,15 @@ def _locked_optuna_best_params(
 ) -> Iterator[None]:
     """Serialize best-params I/O using a stable lock file."""
     lock_path = best_params_path.parent / ".optuna-best-params.lock"
+    # O_NONBLOCK so a pre-existing FIFO (unlike a symlink, not caught by
+    # O_NOFOLLOW) cannot hang this open before the S_ISREG guard rejects it.
     lock_fd = os.open(
         lock_path,
         (os.O_RDWR if exclusive else os.O_RDONLY)
         | os.O_CREAT
         | os.O_CLOEXEC
-        | os.O_NOFOLLOW,
+        | os.O_NOFOLLOW
+        | os.O_NONBLOCK,
         0o666,
     )
     try:


### PR DESCRIPTION
## Context

Cross-validation and correction of **unresolved review comments left on already-merged PRs** (#186, #185, #158). Because #186 was squash-merged (`30898b98`), every finding was checked against the **current content of `main`**, not commit ancestry / badges. Each verdict below is backed by source lines and live in-container runs (`quickadapter-freqtrade:latest`), cross-validated by three independent analyses (varied models) reconciled with proof.

Net result: **one real, actionable defect** (the FIFO lock hang, #185). All other findings are already addressed in `main`, false positives, or safe/documented conservatism — no change warranted.

## Change

Open the best-params lock file with `os.O_NONBLOCK` in `_locked_optuna_best_params` ([Utils.py](https://github.com/jerome-benoit/freqai-strategies/blob/main/quickadapter/user_data/strategies/Utils.py#L5449)).

## Verdicts per finding

### VALID — unaddressed → **fixed here**

- **[#185 P2] FIFO deadlock** (`_locked_optuna_best_params`, ~L5451). The shared-load path opened `.optuna-best-params.lock` with `O_RDONLY | O_CREAT | O_CLOEXEC | O_NOFOLLOW` and **no `O_NONBLOCK`**, then checked `S_ISREG`. `O_NOFOLLOW` rejects symlinks but **not** FIFOs, so a pre-existing FIFO makes the `O_RDONLY` open block until a writer appears — hanging strategy startup before the guard can reject the non-regular file.
  - **Proof (live):** raw `os.open(O_RDONLY|…)` on a planted FIFO stayed blocked >3 s; with `O_NONBLOCK` it returned immediately with `S_ISREG=False`. End-to-end on the patched context manager: `_locked_optuna_best_params(exclusive=False)` on a FIFO no longer blocks and raises `OSError: … must be a regular file`; regular-file exclusive/shared locks still succeed.
  - **Fix:** add `os.O_NONBLOCK`. Inert on regular files; independent of `flock()` blocking (governed by `LOCK_NB`, not the fd flag); the lock fd is never used for data I/O.

### ALREADY ADDRESSED in `main` (proof)

- **[#186 2× P1 OUTDATED] terminal / non-terminal trailing pivots.** `main` marks all non-finite pivots as `dependency` (→ frame boundary `n`) and only releases the **leading** run (`leading_stable[:first_finite]`). Live: with `[nan,nan,5,3,nan]`, terminal pivot availability = `n`, leading pivots released at the `first_finite` confirmation; interior/terminal-only cases keep `release_index=-1`.
- **[#158 P2, #169] release single-metric leading run** — implemented (`release_index=first_finite`; consumer releases at `max(weight_availability[:release_index+1])`).
- **[#158 P2, #170] skip zero-valued trailing Gaussian bands** — implemented (`if weight_avail >= n and not pivot_dependency: continue`, with the all-non-finite nonzero-default exception preserved).
- **[#158 P2, #171] release stable combined leading imputations** — implemented (combined leading release guarded by the empirical `all(combined_weights[:stable_length] == 0.0)` check).

### FALSE POSITIVE / OBSOLETE (proof)

- **[#186 P1 ~2793] "Defer Gaussian bands until combined zeros stabilize".** Not a leak. `_gaussian_fill_weights` composes bumps as a **per-row max** and a zero-weight pivot contributes exactly nothing (`if pivot_weight == 0.0: continue`; `Out[i]=max_p w_p·exp(...)`). A leading-stable pivot's final weight is provably `0.0`, so it never enters the max → neighbours' **final** (acausal, training) weights are independent of it. **Proof (live):** dropping the two leading pivots entirely leaves `max|Δ|=0.0` across all rows; neighbour rows are either determined by other (spread-band) pivots or have final weight `0.0` (inert in a weighted loss). The transient non-zero prefix bump does not reach the acausal weight column that training consumes. Skipping the leading band is correct.
- **[#186 P2 ~3420] "Propagate bands when stable release is rejected".** Leading-stable ⊆ dependency, so `avail_pivot[dependency]=n` already defers the pivot when the release guard fails; the band skip stays leak-free by the same zero-weight-bump argument. Propagating would only over-purge.
- **[#186 P2 ~3423] "Retain the legacy inferred release index" (default `-1`).** The sole in-repo caller ([QuickAdapterV3.py](https://github.com/jerome-benoit/freqai-strategies/blob/main/quickadapter/user_data/strategies/QuickAdapterV3.py#L1040)) always passes `leading_stable_mask` and `stable_release_index` together from the dataclass; `-1` is a safe (over-purge) sentinel. No caller triggers the described path.
- **[#186 P2 ~2674] "Preserve tuple unpacking for the public mask helper".** `LabelWeightImputationMasks` is `@dataclass(frozen=True, slots=True)` (non-iterable); repo-wide grep shows the only consumer uses attribute access. No tuple-unpacking exists.

### VALID observation, deliberately NOT changed (safe)

- **[#186 P2 ~2789] "Handle zero-annihilating combined aggregations".** For `geometric_mean` / `harmonic_mean`, a single leading zero annihilates the aggregate, but the release guard requires **every** component to lead with a non-finite run (`min(first_finite_indices) >= 1`). This is a **conservative over-purge, not a leak**, and matches the documented contract of the combined leading release. Relaxing it to aggregation-aware release would trade guaranteed safety for reclaimed training rows in a niche (geometric/harmonic + partial leading NaN + non-default Gaussian fill) configuration — out of scope for a causal-correctness fix. Left as-is intentionally.

## Verification

- `ruff check` — clean; `ruff format --check` — already formatted; `python -m py_compile` — OK.
- FIFO reproduction and all availability checks executed in the pinned `quickadapter-freqtrade:latest` image via stdin heredocs; **no test artifacts written to the tree or included in this PR** (external-tests convention). Working tree contains only the one-file change.

Does not modify the causal-availability logic. No GitHub comments posted on the source PRs.