### PR TITLE
refactor(quickadapter): route inline enum error messages through enum_error_message

### DIFF
--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1079,9 +1079,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         if mode == "none":
             return default
 
-        msg = (
-            f"Invalid {ctx} {value!r}: supported values are {', '.join(valid_options)}"
-        )
+        msg = enum_error_message(ctx, value, valid_options)
         if mode == "raise":
             raise ValueError(msg)
         logger.warning(f"{msg}, using {default!r}")

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -1979,9 +1979,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 split_builder = self._make_timeseries_split_datasets
             case _:
                 raise ValueError(
-                    f"Invalid data_split_parameters.method value {method!r}: "
-                    f"supported values are "
-                    f"{', '.join(QuickAdapterRegressorV3._DATA_SPLIT_METHODS)}"
+                    enum_error_message(
+                        "data_split_parameters.method",
+                        method,
+                        QuickAdapterRegressorV3._DATA_SPLIT_METHODS,
+                    )
                 )
 
         def split_fn(
@@ -3098,8 +3100,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     ) -> None:
         if namespace not in {_OPTUNA_NAMESPACES.label}:
             raise ValueError(
-                f"Invalid namespace value {namespace!r}: "
-                f"supported values are {_OPTUNA_NAMESPACES.label}"
+                enum_error_message("namespace", namespace, (_OPTUNA_NAMESPACES.label,))
             )
         if not callable(callback):
             raise ValueError(
@@ -3564,8 +3565,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             pred_label_minima = pred_label[pred_label < -eps]
         else:
             raise ValueError(
-                f"Invalid selection_method value {selection_method!r}: "
-                f"supported values are {', '.join(EXTREMA_SELECTION_METHODS)}"
+                enum_error_message(
+                    "selection_method", selection_method, EXTREMA_SELECTION_METHODS
+                )
             )
 
         return pred_label_minima, pred_label_maxima
@@ -3668,8 +3670,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             threshold_func = getattr(skimage.filters, f"threshold_{method}")
         except AttributeError:
             raise ValueError(
-                f"Invalid skimage threshold method value {method!r}: "
-                f"supported values are {', '.join(SKIMAGE_THRESHOLD_METHODS)}"
+                enum_error_message(
+                    "skimage threshold method", method, SKIMAGE_THRESHOLD_METHODS
+                )
             )
 
         min_func = QuickAdapterRegressorV3.apply_skimage_threshold
@@ -4052,8 +4055,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
         else:
             raise ValueError(
-                f"Invalid trial_selection_method value {trial_selection_method!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._DISTANCE_METHODS)}"
+                enum_error_message(
+                    "trial_selection_method",
+                    trial_selection_method,
+                    QuickAdapterRegressorV3._DISTANCE_METHODS,
+                )
             )
 
         min_score_position = np.nanargmin(scores)
@@ -4126,8 +4132,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 )
             else:
                 raise ValueError(
-                    f"Invalid selection_method value {selection_method!r}: "
-                    f"supported values are {', '.join(QuickAdapterRegressorV3._DISTANCE_METHODS)}"
+                    enum_error_message(
+                        "selection_method",
+                        selection_method,
+                        QuickAdapterRegressorV3._DISTANCE_METHODS,
+                    )
                 )
             ordered_cluster_indices = np.argsort(cluster_center_scores)
 
@@ -4164,8 +4173,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
 
         else:
             raise ValueError(
-                f"Invalid cluster_method value {cluster_method!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._CLUSTER_METHODS)}"
+                enum_error_message(
+                    "cluster_method",
+                    cluster_method,
+                    QuickAdapterRegressorV3._CLUSTER_METHODS,
+                )
             )
 
     @staticmethod
@@ -4242,8 +4254,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             return np.nanmax(neighbor_distances, axis=1)
         else:
             raise ValueError(
-                f"Invalid aggregation value {aggregation!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._DENSITY_AGGREGATIONS)}"
+                enum_error_message(
+                    "aggregation",
+                    aggregation,
+                    QuickAdapterRegressorV3._DENSITY_AGGREGATIONS,
+                )
             )
 
     @staticmethod
@@ -4580,8 +4595,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
                 )
 
         raise ValueError(
-            f"Invalid label_method value {selection_method!r}: "
-            f"supported values are {', '.join(QuickAdapterRegressorV3._SELECTION_METHODS)}"
+            enum_error_message(
+                "label_method",
+                selection_method,
+                QuickAdapterRegressorV3._SELECTION_METHODS,
+            )
         )
 
     def _get_multi_objective_study_best_trial(
@@ -4589,8 +4607,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
     ) -> Optional[optuna.trial.FrozenTrial]:
         if namespace not in {_OPTUNA_NAMESPACES.label}:
             raise ValueError(
-                f"Invalid namespace value {namespace!r}: "
-                f"supported values are {_OPTUNA_NAMESPACES.label}"
+                enum_error_message("namespace", namespace, (_OPTUNA_NAMESPACES.label,))
             )
         n_objectives = len(study.directions)
         if n_objectives < 2:
@@ -4912,8 +4929,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
         else:
             raise ValueError(
-                f"Invalid optuna storage_backend value {storage_backend!r}: "
-                f"supported values are {', '.join(QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS)}"
+                enum_error_message(
+                    "optuna storage_backend",
+                    storage_backend,
+                    QuickAdapterRegressorV3._OPTUNA_STORAGE_BACKENDS,
+                )
             )
         return storage
 
@@ -4937,8 +4957,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         match sampler:
             case None:
                 raise ValueError(
-                    f"Invalid optuna sampler value {sampler!r}: "
-                    f"supported values are {', '.join(QuickAdapterRegressorV3._OPTUNA_SAMPLERS)}"
+                    enum_error_message(
+                        "optuna sampler",
+                        sampler,
+                        QuickAdapterRegressorV3._OPTUNA_SAMPLERS,
+                    )
                 )
             case QuickAdapterRegressorV3._OPTUNA_SAMPLERS.tpe:
                 return optuna.samplers.TPESampler(
@@ -4978,8 +5001,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             )
         else:
             raise ValueError(
-                f"Invalid namespace value {namespace!r}: "
-                f"supported values are {', '.join(_OPTUNA_NAMESPACES)}"
+                enum_error_message("namespace", namespace, _OPTUNA_NAMESPACES)
             )
 
     @staticmethod
@@ -5103,8 +5125,9 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         samplers, sampler = self.optuna_samplers_by_namespace(namespace)
         if sampler not in samplers:
             raise ValueError(
-                f"Invalid optuna {namespace} sampler value {sampler!r}: "
-                f"supported values are {', '.join(samplers)}"
+                enum_error_message(
+                    f"optuna {namespace} sampler", sampler, tuple(samplers)
+                )
             )
 
         try:

--- a/quickadapter/user_data/strategies/EnumErrors.py
+++ b/quickadapter/user_data/strategies/EnumErrors.py
@@ -1,8 +1,7 @@
-"""Single source of truth for enum validation error messages.
+"""Canonical enum validation error message. Dependency-free (stdlib only).
 
-Dependency-free module (standard library only) so it can be imported by
-``Utils`` (which imports from ``LabelTransformer``) and by ``LabelTransformer``
-itself without introducing an import cycle.
+Owns the ``Invalid <ctx> value <value>: supported values are <options>`` form;
+messages that deviate from it (custom prefix/infix/suffix) are built inline.
 """
 
 from collections.abc import Sequence

--- a/quickadapter/user_data/strategies/EnumErrors.py
+++ b/quickadapter/user_data/strategies/EnumErrors.py
@@ -1,0 +1,13 @@
+"""Single source of truth for enum validation error messages.
+
+Dependency-free module (standard library only) so it can be imported by
+``Utils`` (which imports from ``LabelTransformer``) and by ``LabelTransformer``
+itself without introducing an import cycle.
+"""
+
+from collections.abc import Sequence
+from typing import Any
+
+
+def enum_error_message(ctx: str, value: Any, options: Sequence[str]) -> str:
+    return f"Invalid {ctx} value {value!r}: supported values are {', '.join(options)}"

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -21,6 +21,8 @@ from sklearn.preprocessing import (
     StandardScaler,
 )
 
+from EnumErrors import enum_error_message
+
 logger = logging.getLogger(__name__)
 
 
@@ -422,10 +424,7 @@ class LabelTransformer(BaseTransform):
     ) -> NDArray[np.floating]:
         scaler_attr = family.registry.get(method)
         if scaler_attr is None:
-            raise ValueError(
-                f"Invalid {family.kind} value {method!r}: "
-                f"supported values are {', '.join(family.type_names)}"
-            )
+            raise ValueError(enum_error_message(family.kind, method, family.type_names))
         scaler = getattr(state, scaler_attr, None)
         if scaler is None:
             raise RuntimeError(f"{scaler_attr} not fitted")
@@ -514,8 +513,7 @@ class LabelTransformer(BaseTransform):
             return
 
         raise ValueError(
-            f"Invalid standardization value {method!r}: "
-            f"supported values are {', '.join(STANDARDIZATION_TYPES)}"
+            enum_error_message("standardization", method, STANDARDIZATION_TYPES)
         )
 
     def _fit_normalization(
@@ -536,8 +534,7 @@ class LabelTransformer(BaseTransform):
             return
 
         raise ValueError(
-            f"Invalid normalization value {method!r}: "
-            f"supported values are {', '.join(NORMALIZATION_TYPES)}"
+            enum_error_message("normalization", method, NORMALIZATION_TYPES)
         )
 
     def _fit_column(

--- a/quickadapter/user_data/strategies/LabelTransformer.py
+++ b/quickadapter/user_data/strategies/LabelTransformer.py
@@ -20,7 +20,6 @@ from sklearn.preprocessing import (
     RobustScaler,
     StandardScaler,
 )
-
 from EnumErrors import enum_error_message
 
 logger = logging.getLogger(__name__)

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -59,6 +59,7 @@ from Utils import (
     compute_label_weight_known_at_lookahead,
     compute_label_weights,
     ensure_datetime_series,
+    enum_error_message,
     ewo,
     format_dict,
     format_number,
@@ -1349,8 +1350,11 @@ class QuickAdapterV3(IStrategy):
         )
         if trade_price_target_method_fn is None:
             raise ValueError(
-                f"Invalid trade_price_target_method value {self.trade_price_target_method!r}: "
-                f"supported values are {', '.join(TRADE_PRICE_TARGETS)}"
+                enum_error_message(
+                    "trade_price_target_method",
+                    self.trade_price_target_method,
+                    TRADE_PRICE_TARGETS,
+                )
             )
         return trade_price_target_method_fn()
 
@@ -1849,8 +1853,11 @@ class QuickAdapterV3(IStrategy):
             )
         else:
             raise ValueError(
-                f"Invalid interpolation_direction value {interpolation_direction!r}: "
-                f"supported values are {', '.join(QuickAdapterV3._INTERPOLATION_DIRECTIONS)}"
+                enum_error_message(
+                    "interpolation_direction",
+                    interpolation_direction,
+                    QuickAdapterV3._INTERPOLATION_DIRECTIONS,
+                )
             )
         candle_deviation = (
             candle_label_natr_value / 100.0
@@ -1920,7 +1927,7 @@ class QuickAdapterV3(IStrategy):
             candle_threshold = base_price * (1 - current_deviation)
         else:
             raise ValueError(
-                f"Invalid side value {side!r}: supported values are {', '.join(QuickAdapterV3._TRADE_DIRECTIONS)}"
+                enum_error_message("side", side, QuickAdapterV3._TRADE_DIRECTIONS)
             )
         self._candle_threshold_cache[cache_key] = candle_threshold
         return self._candle_threshold_cache[cache_key]
@@ -2344,8 +2351,9 @@ class QuickAdapterV3(IStrategy):
             return False
         else:
             raise ValueError(
-                f"Invalid trading_mode value {trading_mode!r}: "
-                f"supported values are {', '.join(QuickAdapterV3._TRADING_MODES)}"
+                enum_error_message(
+                    "trading_mode", trading_mode, QuickAdapterV3._TRADING_MODES
+                )
             )
 
     @cached_property

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -4851,7 +4851,7 @@ def get_ngboost_dist(dist_name: str) -> type:
 
     if dist_name not in dist_map:
         raise ValueError(
-            f"Invalid dist_name {dist_name!r}: supported values are {', '.join(dist_map.keys())}"
+            enum_error_message("dist_name", dist_name, tuple(dist_map.keys()))
         )
 
     return dist_map[dist_name]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -37,6 +37,7 @@ import pandas as pd
 import scipy as sp
 import talib.abstract as ta
 from freqtrade.misc import pair_to_filename
+from EnumErrors import enum_error_message
 from LabelTransformer import (
     COMBINED_AGGREGATIONS,
     COMBINED_METRICS,
@@ -1102,10 +1103,6 @@ def as_config_section(value: Any, name: str, logger: Logger) -> dict[str, Any]:
             f"Invalid {name} value {value!r}: must be a mapping, using defaults"
         )
     return as_dict(value)
-
-
-def enum_error_message(ctx: str, value: Any, options: Sequence[str]) -> str:
-    return f"Invalid {ctx} value {value!r}: supported values are {', '.join(options)}"
 
 
 ValidateParamsFn = Callable[[dict[str, Any], Logger, str], dict[str, Any]]

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -2101,10 +2101,7 @@ def _calculate_coeffs(
     elif win_type == SMOOTHING_KERNELS[3]:  # "triang"
         coeffs = sp.signal.windows.triang(M=window, sym=True)
     else:
-        raise ValueError(
-            f"Invalid window type value {win_type!r}: "
-            f"supported values are {', '.join(SMOOTHING_KERNELS)}"
-        )
+        raise ValueError(enum_error_message("window type", win_type, SMOOTHING_KERNELS))
     normalized_coeffs = coeffs / np.sum(coeffs)
     normalized_coeffs.setflags(write=False)
     return normalized_coeffs
@@ -2369,8 +2366,7 @@ def _compute_pivot_sigmas(
         return np.full(M, float(sigma_candles), dtype=float)
     if bandwidth != FILL_BANDWIDTHS[1]:  # "knn"
         raise ValueError(
-            f"Invalid fill_bandwidth value {bandwidth!r}: "
-            f"supported values are {', '.join(FILL_BANDWIDTHS)}"
+            enum_error_message("fill_bandwidth", bandwidth, FILL_BANDWIDTHS)
         )
 
     d_k = _compute_pivot_kth_neighbor_distances(pivot_indices, neighbors)
@@ -3127,10 +3123,7 @@ def compute_label_weights(
             out=fill_weights,
         )
     else:
-        raise ValueError(
-            f"Invalid fill_method value {fill_method!r}: "
-            f"supported values are {', '.join(FILL_METHODS)}"
-        )
+        raise ValueError(enum_error_message("fill_method", fill_method, FILL_METHODS))
 
     return _scatter_weights(
         n_values=n_values,
@@ -4901,10 +4894,7 @@ def get_refit_model_training_parameters(
         fitted_iterations = int(model.tree_count_)
         initial_iterations = 0
     else:
-        raise ValueError(
-            f"Invalid regressor value {regressor!r}: "
-            f"supported values are {', '.join(REGRESSORS)}"
-        )
+        raise ValueError(enum_error_message("regressor", regressor, REGRESSORS))
 
     spec = _REGRESSOR_SPEC_BY_NAME[regressor]
     # The sole caller refits the cold-started selection model
@@ -4964,10 +4954,7 @@ def fit_regressor(
 
     spec = _REGRESSOR_SPEC_BY_NAME.get(regressor)
     if spec is None:
-        raise ValueError(
-            f"Invalid regressor value {regressor!r}: "
-            f"supported values are {', '.join(REGRESSORS)}"
-        )
+        raise ValueError(enum_error_message("regressor", regressor, REGRESSORS))
     model_training_parameters.setdefault(spec.seed_param, 1)
     if trial is not None and vary_model_seed_by_trial:
         model_training_parameters[spec.seed_param] = (


### PR DESCRIPTION
## Requirement

Closes #172. `enum_error_message(ctx, value, options)` is the canonical formatter for "invalid enum value" errors, but the identical `f"...supported values are {', '.join(X)}"` pattern was hand-reconstructed in ~30 other sites — a single-source-of-truth violation (repo `AGENTS.md`): the message format drifts and must be edited in many places.

## Scope

Census of the literal `supported values are` across the four module files = **35** occurrences:

- **28 in-scope** (routed through the helper):
  - **26 byte-identical** — 23 canonical + 3 single-value/collection tuple-wraps that preserve the exact output (`(_OPTUNA_NAMESPACES.label,)` ×2, `tuple(samplers)`).
  - **2 intentional wording changes** (see below).
- **6 out-of-scope** (custom prefix/infix/suffix that the canonical form cannot express, left unchanged): `Utils` (`_EnumValidator.message` fragment; `... for method ...`; `Unknown label kind ...`; `... or metric names ...`), `QuickAdapterRegressorV3` (`... for {method}`; `... value in label_config ...`).
  - 1 = the helper definition itself.

### Design summary

- **New dependency-free module** [`strategies/EnumErrors.py`](https://github.com/jerome-benoit/freqai-strategies/blob/refactor/172-enum-error-message-helper/quickadapter/user_data/strategies/EnumErrors.py) holds `enum_error_message` verbatim. `Utils` re-exports it (`from EnumErrors import enum_error_message`), so the public path `from Utils import enum_error_message` is preserved. This resolves the import-cycle constraint: `Utils` imports from `LabelTransformer`, so `LabelTransformer` cannot import from `Utils`; it imports the dep-free `EnumErrors` instead. `EnumErrors` has **zero** first-party import edges, so no cycle is possible.
- Non-`Sequence` option objects are wrapped to satisfy `options: Sequence[str]`, matching the pre-existing convention (`enum_error_message("namespace", namespace, tuple(stores))`): `tuple(dist_map.keys())`, `tuple(samplers)` (frozenset), and `(_OPTUNA_NAMESPACES.label,)` for the single-value namespace sites. Join output is unchanged.

### Intentional wording change (NOT byte-identical)

Two sites emitted `Invalid {ctx} {value!r}:` **without** the word `value`. Routing them through the helper inserts `" value"` to align with the canonical format:

- `QuickAdapterRegressorV3._validate_enum_value` — the `msg` is reused by the sibling `logger.warning`, so both the raised `ValueError` and the warning log change for its 6 callers.
- `Utils.get_ngboost_dist` (`dist_name`).

No test asserts these strings (quickadapter has no tracked test suite).

## Commits (atomic, each green)

1. relocate `enum_error_message` to `EnumErrors` + re-export from `Utils`
2. route `Utils` (5 sites)
3. route `LabelTransformer` (3 sites) + import
4. route `QuickAdapterV3` (4 sites) + import
5. route `QuickAdapterRegressorV3` (11 canonical + 3 tuple-wrap)
6. `fix`: unify divergent wording (2 sites)
7. `style`: harmonize `EnumErrors` import placement in `LabelTransformer` (glue to preceding import block)
8. `docs`: scope the `EnumErrors` docstring to the canonical form (composed messages built inline)

## Tests executed (proof — not committed)

Per repo convention (quickadapter has no tracked tests; only `ReforceXY/reward_space_analysis/tests/`), the non-regression proof is provided as an **executed, dependency-free** harness kept out of the tree, not a committed test.

- **Gates (all changed files):** `ruff check` → *All checks passed*; `ruff format --check` → *already formatted*; `python -m py_compile` → OK.
- **Byte-identity + no-cycle proof (bare CPython, binds to the real shipped `EnumErrors` helper, same-process):** **116/116 checks passed.** It (1) asserts `enum_error_message(ctx, value, options) == <inline canonical form>` for every routed site over representative values (incl. `None`/int/str, and tuple/list/dict_keys/NamedTuple/frozenset option types); (2) asserts the tuple-wrap sites are byte-identical; (3) asserts the two intentional sites differ from the original by **exactly** `" value"`; (4) binds to git history (pre-image at the parent commit had the inline strings + local def; current `Utils` has neither); (5) builds the first-party AST import graph and asserts it is acyclic, `EnumErrors` has no first-party out-edges, and `LabelTransformer` does not import `Utils`.

```
graph: {'Utils': ['EnumErrors', 'LabelTransformer'], 'LabelTransformer': ['EnumErrors'],
        'QuickAdapterV3': ['LabelTransformer', 'Utils'],
        'QuickAdapterRegressorV3': ['LabelTransformer', 'Utils'], 'EnumErrors': []}
RESULT: 116/116 checks passed; 0 failed.
ALL CHECKS PASSED
```

> Note: `import Utils`/`QuickAdapterRegressorV3` cannot execute here (numpy/scipy/sklearn/optuna/freqtrade/datasieve absent), so the no-cycle proof is done statically over the real source AST plus a live `import EnumErrors`; byte-identity is proven against the real helper and the git pre-image. `py_compile` covers syntax of the heavy modules.

## Risks

- **Behavior change (accepted, documented):** the two wording sites now emit `Invalid {ctx} value {value!r}` and `_validate_enum_value`'s warning log gains `value`. All other messages are byte-identical.
- `frozenset` join order (QAR sampler-namespace site) is non-deterministic across runs — **pre-existing** behavior, unchanged by `tuple(samplers)` (same object, same within-run order).
- Full-interpreter import of the heavy modules was not run locally (missing scientific stack); mitigated by static AST cycle proof + `py_compile`.

