### PR TITLE
fix(reforcexy): harden Optuna best-params persistence

### DIFF
--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -272,11 +272,6 @@ class ReforceXY(BaseReinforcementLearningModel):
     _STORAGE_BACKENDS: Final[Tuple[StorageBackend, ...]] = ("sqlite", "file")
     _SAMPLERS: Final[_Samplers] = _Samplers()
     _JOURNAL_TAIL_PROBE_BYTES: Final[int] = 64 * 1024
-    _JOURNAL_QUARANTINE_TAG: Final[str] = "corrupt"
-    _JOURNAL_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 99
-    _BEST_PARAMS_QUARANTINE_TAG: Final[str] = "corrupt"
-    _BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 99
-    _BEST_PARAMS_LOCK_FILENAME: Final[str] = ".hyperopt-best-params.lock"
     _JOURNAL_OP_CODE_KEY: Final[str] = "op_code"
     _JOURNAL_OPERATION_CODES: Final[frozenset[int]] = frozenset(range(10))
     _JOURNAL_RECOVERABLE_ERRORS: Final[
@@ -288,6 +283,9 @@ class ReforceXY(BaseReinforcementLearningModel):
         ValueError,
         json.JSONDecodeError,
     )
+    _QUARANTINE_TAG: Final[str] = "corrupt"
+    _QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 99
+    _BEST_PARAMS_LOCK_FILENAME: Final[str] = ".hyperopt-best-params.lock"
     _PPO_N_STEPS: Final[Tuple[int, ...]] = (512, 1024, 2048, 4096)
     _PPO_N_STEPS_MIN: Final[int] = min(_PPO_N_STEPS)
     _PPO_N_STEPS_MAX: Final[int] = max(_PPO_N_STEPS)
@@ -1444,15 +1442,15 @@ class ReforceXY(BaseReinforcementLearningModel):
         return quarantine_path
 
     @staticmethod
-    def _quarantine_path(journal_path: Path, now: datetime) -> Path:
+    def _quarantine_path(path: Path, now: datetime) -> Path:
         stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
-        base_name = f"{journal_path.name}.{ReforceXY._JOURNAL_QUARANTINE_TAG}-{stamp}"
-        for index in range(ReforceXY._JOURNAL_QUARANTINE_TIE_BREAK_LIMIT + 1):
+        base_name = f"{path.name}.{ReforceXY._QUARANTINE_TAG}-{stamp}"
+        for index in range(ReforceXY._QUARANTINE_TIE_BREAK_LIMIT + 1):
             suffix = "" if index == 0 else f"-{index}"
-            candidate = journal_path.with_name(f"{base_name}{suffix}")
+            candidate = path.with_name(f"{base_name}{suffix}")
             if not candidate.exists():
                 return candidate
-        raise FileExistsError(journal_path)
+        raise FileExistsError(path)
 
     def create_storage(self, pair: str) -> BaseStorage:
         """
@@ -1790,20 +1788,9 @@ class ReforceXY(BaseReinforcementLearningModel):
     ) -> Optional[Path]:
         if not best_trial_params_path.exists():
             return None
-        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-        quarantine_base = (
-            f"{best_trial_params_path.name}."
-            f"{ReforceXY._BEST_PARAMS_QUARANTINE_TAG}-{stamp}"
+        quarantine_path = ReforceXY._quarantine_path(
+            best_trial_params_path, datetime.now(timezone.utc)
         )
-        for index in range(ReforceXY._BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT + 1):
-            suffix = "" if index == 0 else f"-{index}"
-            quarantine_path = best_trial_params_path.with_name(
-                f"{quarantine_base}{suffix}"
-            )
-            if not quarantine_path.exists():
-                break
-        else:
-            raise FileExistsError(best_trial_params_path)
         try:
             best_trial_params_path.rename(quarantine_path)
         except OSError as quarantine_error:

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -1769,16 +1769,17 @@ class ReforceXY(BaseReinforcementLearningModel):
     def _locked_best_trial_params(
         best_trial_params_path: Path, *, exclusive: bool
     ) -> Iterator[None]:
-        lock_path = (
-            best_trial_params_path.parent / ReforceXY._BEST_PARAMS_LOCK_FILENAME
-        )
+        lock_path = best_trial_params_path.parent / ReforceXY._BEST_PARAMS_LOCK_FILENAME
         # O_NONBLOCK so a pre-existing FIFO (unlike a symlink, not caught by
         # O_NOFOLLOW) cannot hang this open before the S_ISREG guard rejects it.
         # A shared reader omits O_CREAT: a read-only mount cannot create the lock,
         # and os.replace atomicity keeps a lock-free read consistent.
         open_flags = (
-            (os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY
-        ) | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+            ((os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY)
+            | os.O_CLOEXEC
+            | os.O_NOFOLLOW
+            | os.O_NONBLOCK
+        )
         try:
             lock_fd = os.open(lock_path, open_flags, 0o666)
         except FileNotFoundError:
@@ -1846,9 +1847,7 @@ class ReforceXY(BaseReinforcementLearningModel):
         )
         temporary_path: Optional[Path] = None
         try:
-            with self._locked_best_trial_params(
-                best_trial_params_path, exclusive=True
-            ):
+            with self._locked_best_trial_params(best_trial_params_path, exclusive=True):
                 self._reject_best_trial_params_symlink(best_trial_params_path)
                 try:
                     existing_metadata = best_trial_params_path.stat()
@@ -1879,10 +1878,12 @@ class ReforceXY(BaseReinforcementLearningModel):
                                 os.fchown(
                                     write_file.fileno(),
                                     existing_metadata.st_uid
-                                    if temporary_metadata.st_uid != existing_metadata.st_uid
+                                    if temporary_metadata.st_uid
+                                    != existing_metadata.st_uid
                                     else -1,
                                     existing_metadata.st_gid
-                                    if temporary_metadata.st_gid != existing_metadata.st_gid
+                                    if temporary_metadata.st_gid
+                                    != existing_metadata.st_gid
                                     else -1,
                                 )
                             except PermissionError as chown_error:
@@ -1952,9 +1953,7 @@ class ReforceXY(BaseReinforcementLearningModel):
             except (json.JSONDecodeError, UnicodeDecodeError):
                 malformed = True
         if malformed:
-            with self._locked_best_trial_params(
-                best_trial_params_path, exclusive=True
-            ):
+            with self._locked_best_trial_params(best_trial_params_path, exclusive=True):
                 self._reject_best_trial_params_symlink(best_trial_params_path)
                 if not best_trial_params_path.is_file():
                     return None

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -1,12 +1,16 @@
 import copy
+import fcntl
 import gc
 import json
 import logging
 import math
+import os
+import stat
 import time
 import warnings
 from collections import defaultdict, deque
-from collections.abc import Mapping
+from collections.abc import Iterator, Mapping
+from contextlib import contextmanager
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import (
@@ -25,6 +29,7 @@ from typing import (
     assert_never,
     cast,
 )
+from uuid import uuid4
 
 import matplotlib
 import matplotlib.pyplot as plt
@@ -269,6 +274,9 @@ class ReforceXY(BaseReinforcementLearningModel):
     _JOURNAL_TAIL_PROBE_BYTES: Final[int] = 64 * 1024
     _JOURNAL_QUARANTINE_TAG: Final[str] = "corrupt"
     _JOURNAL_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 99
+    _BEST_PARAMS_QUARANTINE_TAG: Final[str] = "corrupt"
+    _BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT: Final[int] = 99
+    _BEST_PARAMS_LOCK_FILENAME: Final[str] = ".hyperopt-best-params.lock"
     _JOURNAL_OP_CODE_KEY: Final[str] = "op_code"
     _JOURNAL_OPERATION_CODES: Final[frozenset[int]] = frozenset(range(10))
     _JOURNAL_RECOVERABLE_ERRORS: Final[
@@ -1721,50 +1729,226 @@ class ReforceXY(BaseReinforcementLearningModel):
             convert_optuna_params_to_model_params(self.model_type, best_trial_params),
         )
 
+    def _best_trial_params_path(self, pair: str) -> Path:
+        return (
+            self.full_path
+            / f"hyperopt-best-params-{ReforceXY._sanitize_pair(pair)}.json"
+        )
+
+    def _warn_ambiguous_legacy_best_trial_params(
+        self, pair: str, best_trial_params_path: Path
+    ) -> None:
+        legacy_path = self.full_path / f"hyperopt-best-params-{pair.split('/')[0]}.json"
+        if legacy_path != best_trial_params_path and legacy_path.is_file():
+            logger.warning(
+                "Hyperopt [%s]: ignoring ambiguous legacy best params at %s: "
+                "filename does not encode the complete pair identity",
+                pair,
+                legacy_path,
+            )
+
+    @staticmethod
+    @contextmanager
+    def _locked_best_trial_params(
+        best_trial_params_path: Path, *, exclusive: bool
+    ) -> Iterator[None]:
+        lock_path = (
+            best_trial_params_path.parent / ReforceXY._BEST_PARAMS_LOCK_FILENAME
+        )
+        # O_NONBLOCK so a pre-existing FIFO (unlike a symlink, not caught by
+        # O_NOFOLLOW) cannot hang this open before the S_ISREG guard rejects it.
+        lock_fd = os.open(
+            lock_path,
+            (os.O_RDWR if exclusive else os.O_RDONLY)
+            | os.O_CREAT
+            | os.O_CLOEXEC
+            | os.O_NOFOLLOW
+            | os.O_NONBLOCK,
+            0o666,
+        )
+        try:
+            if not stat.S_ISREG(os.fstat(lock_fd).st_mode):
+                raise OSError(
+                    f"Hyperopt best params lock {lock_path} must be a regular file"
+                )
+            fcntl.flock(lock_fd, fcntl.LOCK_EX if exclusive else fcntl.LOCK_SH)
+            yield
+        finally:
+            os.close(lock_fd)
+
+    @staticmethod
+    def _reject_best_trial_params_symlink(best_trial_params_path: Path) -> None:
+        if best_trial_params_path.is_symlink():
+            raise OSError(
+                f"Hyperopt best params path {best_trial_params_path} "
+                "must not be a symlink"
+            )
+
+    @staticmethod
+    def _quarantine_corrupt_best_trial_params(
+        best_trial_params_path: Path, pair: str, cause: Exception
+    ) -> Optional[Path]:
+        if not best_trial_params_path.exists():
+            return None
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
+        quarantine_base = (
+            f"{best_trial_params_path.name}."
+            f"{ReforceXY._BEST_PARAMS_QUARANTINE_TAG}-{stamp}"
+        )
+        for index in range(ReforceXY._BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT + 1):
+            suffix = "" if index == 0 else f"-{index}"
+            quarantine_path = best_trial_params_path.with_name(
+                f"{quarantine_base}{suffix}"
+            )
+            if not quarantine_path.exists():
+                break
+        else:
+            raise FileExistsError(best_trial_params_path)
+        try:
+            best_trial_params_path.rename(quarantine_path)
+        except OSError as quarantine_error:
+            logger.error(
+                "Hyperopt [%s]: best params %s quarantine failed: %r",
+                pair,
+                best_trial_params_path.name,
+                quarantine_error,
+                exc_info=True,
+            )
+            raise
+        logger.warning(
+            "Hyperopt [%s]: best params %s corrupt (%r); quarantined to %s; "
+            "no persisted best params recovered",
+            pair,
+            best_trial_params_path.name,
+            cause,
+            quarantine_path.name,
+        )
+        return quarantine_path
+
     def save_best_trial_params(
         self, best_trial_params: Dict[str, Any], pair: str
     ) -> None:
         """
         Save the best trial hyperparameters found during hyperparameter optimization
         """
-        best_trial_params_filename = f"hyperopt-best-params-{pair.split('/')[0]}"
-        best_trial_params_path = Path(
-            self.full_path / f"{best_trial_params_filename}.json"
-        )
+        best_trial_params_path = self._best_trial_params_path(pair)
         logger.info(
             "Hyperopt [%s]: saving best params to %s", pair, best_trial_params_path
         )
+        temporary_path: Optional[Path] = None
         try:
-            with best_trial_params_path.open("w", encoding="utf-8") as write_file:
-                json.dump(best_trial_params, write_file, indent=4)
-        except Exception as e:
-            logger.error(
-                "Hyperopt [%s]: failed to save best params to %s: %r",
-                pair,
-                best_trial_params_path,
-                e,
-                exc_info=True,
-            )
+            with self._locked_best_trial_params(
+                best_trial_params_path, exclusive=True
+            ):
+                self._reject_best_trial_params_symlink(best_trial_params_path)
+                try:
+                    existing_metadata = best_trial_params_path.stat()
+                except FileNotFoundError:
+                    existing_metadata = None
+                temporary_path = best_trial_params_path.with_name(
+                    f".{best_trial_params_path.name}.{uuid4().hex}.tmp"
+                )
+                with os.fdopen(
+                    os.open(
+                        temporary_path,
+                        os.O_WRONLY | os.O_CREAT | os.O_EXCL,
+                        0o666,
+                    ),
+                    mode="w",
+                    encoding="utf-8",
+                ) as write_file:
+                    if existing_metadata is not None:
+                        temporary_metadata = os.fstat(write_file.fileno())
+                        if (
+                            temporary_metadata.st_uid != existing_metadata.st_uid
+                            or temporary_metadata.st_gid != existing_metadata.st_gid
+                        ):
+                            os.fchown(
+                                write_file.fileno(),
+                                existing_metadata.st_uid
+                                if temporary_metadata.st_uid != existing_metadata.st_uid
+                                else -1,
+                                existing_metadata.st_gid
+                                if temporary_metadata.st_gid != existing_metadata.st_gid
+                                else -1,
+                            )
+                        os.fchmod(
+                            write_file.fileno(),
+                            stat.S_IMODE(existing_metadata.st_mode),
+                        )
+                    json.dump(best_trial_params, write_file, indent=4)
+                    write_file.flush()
+                    os.fsync(write_file.fileno())
+                os.replace(temporary_path, best_trial_params_path)
+                temporary_path = None
+        except BaseException as error:
+            if temporary_path is not None:
+                try:
+                    temporary_path.unlink(missing_ok=True)
+                except OSError as cleanup_error:
+                    logger.error(
+                        "Hyperopt [%s]: best params temporary file %s cleanup "
+                        "failed: %r",
+                        pair,
+                        temporary_path.name,
+                        cleanup_error,
+                        exc_info=True,
+                    )
+            if isinstance(error, Exception):
+                logger.error(
+                    "Hyperopt [%s]: failed to save best params to %s: %r",
+                    pair,
+                    best_trial_params_path,
+                    error,
+                    exc_info=True,
+                )
             raise
 
     def load_best_trial_params(self, pair: str) -> Optional[Dict[str, Any]]:
         """
         Load the best trial hyperparameters found and saved during hyperparameter optimization
         """
-        best_trial_params_filename = f"hyperopt-best-params-{pair.split('/')[0]}"
-        best_trial_params_path = Path(
-            self.full_path / f"{best_trial_params_filename}.json"
-        )
-        if best_trial_params_path.is_file():
+        best_trial_params_path = self._best_trial_params_path(pair)
+        if not best_trial_params_path.parent.is_dir():
+            return None
+        malformed = False
+        with self._locked_best_trial_params(best_trial_params_path, exclusive=False):
+            self._reject_best_trial_params_symlink(best_trial_params_path)
+            if not best_trial_params_path.is_file():
+                self._warn_ambiguous_legacy_best_trial_params(
+                    pair, best_trial_params_path
+                )
+                return None
             logger.info(
                 "Hyperopt [%s]: loading best params from %s",
                 pair,
                 best_trial_params_path,
             )
-            with best_trial_params_path.open("r", encoding="utf-8") as read_file:
-                best_trial_params = json.load(read_file)
-            return best_trial_params
-        return None
+            try:
+                with best_trial_params_path.open("r", encoding="utf-8") as read_file:
+                    best_trial_params = json.load(read_file)
+            except (json.JSONDecodeError, UnicodeDecodeError):
+                malformed = True
+        if malformed:
+            with self._locked_best_trial_params(
+                best_trial_params_path, exclusive=True
+            ):
+                self._reject_best_trial_params_symlink(best_trial_params_path)
+                if not best_trial_params_path.is_file():
+                    return None
+                try:
+                    with best_trial_params_path.open(
+                        "r", encoding="utf-8"
+                    ) as read_file:
+                        best_trial_params = json.load(read_file)
+                except (json.JSONDecodeError, UnicodeDecodeError) as decode_error:
+                    quarantined = self._quarantine_corrupt_best_trial_params(
+                        best_trial_params_path, pair, decode_error
+                    )
+                    if quarantined is None:
+                        raise
+                    return None
+        return best_trial_params
 
     def _get_train_and_eval_environments(
         self,

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -1443,6 +1443,13 @@ class ReforceXY(BaseReinforcementLearningModel):
 
     @staticmethod
     def _quarantine_path(path: Path, now: datetime) -> Path:
+        """Quarantine target path for a corrupt Optuna artefact.
+
+        The tag and timestamp are appended after the complete filename
+        (extension included) so live-artefact globs never match quarantined
+        files. Collisions are bounded by ``_QUARANTINE_TIE_BREAK_LIMIT``;
+        exhausted candidates raise instead of reusing a quarantine file.
+        """
         stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
         base_name = f"{path.name}.{ReforceXY._QUARANTINE_TAG}-{stamp}"
         for index in range(ReforceXY._QUARANTINE_TIE_BREAK_LIMIT + 1):

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -1740,17 +1740,29 @@ class ReforceXY(BaseReinforcementLearningModel):
             / f"hyperopt-best-params-{ReforceXY._sanitize_pair(pair)}.json"
         )
 
-    def _warn_ambiguous_legacy_best_trial_params(
+    def _resolve_legacy_best_trial_params(
         self, pair: str, best_trial_params_path: Path
-    ) -> None:
-        legacy_path = self.full_path / f"hyperopt-best-params-{pair.split('/')[0]}.json"
-        if legacy_path != best_trial_params_path and legacy_path.is_file():
-            logger.warning(
-                "Hyperopt [%s]: ignoring ambiguous legacy best params at %s: "
-                "filename does not encode the complete pair identity",
-                pair,
-                legacy_path,
-            )
+    ) -> Optional[Path]:
+        base = pair.split("/")[0]
+        legacy_path = self.full_path / f"hyperopt-best-params-{base}.json"
+        if (
+            legacy_path == best_trial_params_path
+            or legacy_path.is_symlink()
+            or not legacy_path.is_file()
+        ):
+            return None
+        base_pair_count = sum(
+            1 for configured in self.pairs if configured.split("/")[0] == base
+        )
+        if base_pair_count == 1:
+            return legacy_path
+        logger.warning(
+            "Hyperopt [%s]: ignoring ambiguous legacy best params at %s: "
+            "filename does not encode the complete pair identity",
+            pair,
+            legacy_path,
+        )
+        return None
 
     @staticmethod
     @contextmanager
@@ -1762,15 +1774,18 @@ class ReforceXY(BaseReinforcementLearningModel):
         )
         # O_NONBLOCK so a pre-existing FIFO (unlike a symlink, not caught by
         # O_NOFOLLOW) cannot hang this open before the S_ISREG guard rejects it.
-        lock_fd = os.open(
-            lock_path,
-            (os.O_RDWR if exclusive else os.O_RDONLY)
-            | os.O_CREAT
-            | os.O_CLOEXEC
-            | os.O_NOFOLLOW
-            | os.O_NONBLOCK,
-            0o666,
-        )
+        # A shared reader omits O_CREAT: a read-only mount cannot create the lock,
+        # and os.replace atomicity keeps a lock-free read consistent.
+        open_flags = (
+            (os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY
+        ) | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+        try:
+            lock_fd = os.open(lock_path, open_flags, 0o666)
+        except FileNotFoundError:
+            if exclusive:
+                raise
+            yield
+            return
         try:
             if not stat.S_ISREG(os.fstat(lock_fd).st_mode):
                 raise OSError(
@@ -1857,15 +1872,26 @@ class ReforceXY(BaseReinforcementLearningModel):
                             temporary_metadata.st_uid != existing_metadata.st_uid
                             or temporary_metadata.st_gid != existing_metadata.st_gid
                         ):
-                            os.fchown(
-                                write_file.fileno(),
-                                existing_metadata.st_uid
-                                if temporary_metadata.st_uid != existing_metadata.st_uid
-                                else -1,
-                                existing_metadata.st_gid
-                                if temporary_metadata.st_gid != existing_metadata.st_gid
-                                else -1,
-                            )
+                            # Best-effort: a non-root process on a cross-uid bind
+                            # mount lacks CAP_CHOWN; the previous in-place write
+                            # never chowned, so a failure must not abort the save.
+                            try:
+                                os.fchown(
+                                    write_file.fileno(),
+                                    existing_metadata.st_uid
+                                    if temporary_metadata.st_uid != existing_metadata.st_uid
+                                    else -1,
+                                    existing_metadata.st_gid
+                                    if temporary_metadata.st_gid != existing_metadata.st_gid
+                                    else -1,
+                                )
+                            except PermissionError as chown_error:
+                                logger.debug(
+                                    "Hyperopt [%s]: best params ownership "
+                                    "preservation skipped: %r",
+                                    pair,
+                                    chown_error,
+                                )
                         os.fchmod(
                             write_file.fileno(),
                             stat.S_IMODE(existing_metadata.st_mode),
@@ -1909,10 +1935,12 @@ class ReforceXY(BaseReinforcementLearningModel):
         with self._locked_best_trial_params(best_trial_params_path, exclusive=False):
             self._reject_best_trial_params_symlink(best_trial_params_path)
             if not best_trial_params_path.is_file():
-                self._warn_ambiguous_legacy_best_trial_params(
+                legacy_path = self._resolve_legacy_best_trial_params(
                     pair, best_trial_params_path
                 )
-                return None
+                if legacy_path is None:
+                    return None
+                best_trial_params_path = legacy_path
             logger.info(
                 "Hyperopt [%s]: loading best params from %s",
                 pair,

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -103,6 +103,7 @@ from Utils import (
     label_weight_column_name,
     label_weight_known_at_lookahead_column_name,
     migrate_config,
+    _optuna_quarantine_path,
     optuna_load_best_params,
     optuna_save_best_params,
     require_bool,
@@ -4784,26 +4785,6 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         return study
 
     @staticmethod
-    def _optuna_quarantine_path(journal_path: Path, now: datetime) -> Path:
-        """Quarantine target path for a corrupt Optuna journal.
-
-        The tag is appended *after* ``.log`` so the live-journal glob
-        ``optuna-*.log`` never matches quarantined artefacts. Collisions
-        are bounded by ``_OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT``;
-        exhausted candidates raise instead of reusing a quarantine file.
-        """
-        stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
-        tag = QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TAG
-        base_name = f"{journal_path.name}.{tag}-{stamp}"
-        limit = QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT
-        for index in range(limit + 1):
-            suffix = "" if index == 0 else f"-{index}"
-            candidate = journal_path.with_name(f"{base_name}{suffix}")
-            if not candidate.exists():
-                return candidate
-        raise FileExistsError(journal_path)
-
-    @staticmethod
     def _optuna_quarantine_journal(
         journal_path: Path, pair: str, cause: Exception
     ) -> Optional[Path]:
@@ -4817,8 +4798,11 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
         """
         if not journal_path.exists():
             return None
-        quarantine_path = QuickAdapterRegressorV3._optuna_quarantine_path(
-            journal_path, datetime.now(timezone.utc)
+        quarantine_path = _optuna_quarantine_path(
+            journal_path,
+            datetime.now(timezone.utc),
+            tag=QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TAG,
+            limit=QuickAdapterRegressorV3._OPTUNA_JOURNAL_QUARANTINE_TIE_BREAK_LIMIT,
         )
         try:
             journal_path.rename(quarantine_path)

--- a/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
+++ b/quickadapter/user_data/freqaimodels/QuickAdapterRegressorV3.py
@@ -5209,6 +5209,7 @@ class QuickAdapterRegressorV3(BaseRegressionModel):
             pair,
             namespace,
             logger,
+            pairs=self.pairs,
             expected_selection_metadata=expected,
             expected_objective_identity=QuickAdapterRegressorV3._OPTUNA_HP_OBJECTIVE_IDENTITY
             if namespace == _OPTUNA_NAMESPACES.hp

--- a/quickadapter/user_data/strategies/QuickAdapterV3.py
+++ b/quickadapter/user_data/strategies/QuickAdapterV3.py
@@ -2468,4 +2468,6 @@ class QuickAdapterV3(IStrategy):
         # tolerable here. The regressor's ``optuna_load_best_params``
         # passes ``expected_selection_metadata`` and rejects drift before
         # re-running HPO selection.
-        return optuna_load_best_params(self.models_full_path, pair, namespace, logger)
+        return optuna_load_best_params(
+            self.models_full_path, pair, namespace, logger, pairs=self.pairs
+        )

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5326,9 +5326,7 @@ def _resolve_legacy_optuna_best_params(
     ambiguous and must be ignored (with a warning).
     """
     base = pair.split("/")[0]
-    legacy_best_params_path = (
-        base_path / f"optuna-{namespace}-best-params-{base}.json"
-    )
+    legacy_best_params_path = base_path / f"optuna-{namespace}-best-params-{base}.json"
     if (
         legacy_best_params_path == best_params_path
         or legacy_best_params_path.is_symlink()
@@ -5493,9 +5491,7 @@ def _validate_optuna_label_best_params(
     return params
 
 
-def _optuna_quarantine_path(
-    path: Path, now: datetime, *, tag: str, limit: int
-) -> Path:
+def _optuna_quarantine_path(path: Path, now: datetime, *, tag: str, limit: int) -> Path:
     """Quarantine target path for a corrupt Optuna artefact.
 
     The tag and timestamp are appended after the complete filename
@@ -5561,8 +5557,11 @@ def _locked_optuna_best_params(
     # A shared reader omits O_CREAT: a read-only mount cannot create the lock,
     # and os.replace atomicity keeps a lock-free read consistent.
     open_flags = (
-        (os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY
-    ) | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+        ((os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY)
+        | os.O_CLOEXEC
+        | os.O_NOFOLLOW
+        | os.O_NONBLOCK
+    )
     try:
         lock_fd = os.open(lock_path, open_flags, 0o666)
     except FileNotFoundError:

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5482,6 +5482,26 @@ def _validate_optuna_label_best_params(
     return params
 
 
+def _optuna_quarantine_path(
+    path: Path, now: datetime, *, tag: str, limit: int
+) -> Path:
+    """Quarantine target path for a corrupt Optuna artefact.
+
+    The tag and timestamp are appended after the complete filename
+    (extension included) so live-artefact globs never match quarantined
+    files. Collisions are bounded by ``limit``; exhausted candidates raise
+    instead of reusing a quarantine file.
+    """
+    stamp = now.strftime("%Y%m%dT%H%M%S%fZ")
+    base_name = f"{path.name}.{tag}-{stamp}"
+    for index in range(limit + 1):
+        suffix = "" if index == 0 else f"-{index}"
+        candidate = path.with_name(f"{base_name}{suffix}")
+        if not candidate.exists():
+            return candidate
+    raise FileExistsError(path)
+
+
 def _quarantine_corrupt_optuna_best_params(
     best_params_path: Path,
     pair: str,
@@ -5492,17 +5512,12 @@ def _quarantine_corrupt_optuna_best_params(
     """Atomically move corrupt persisted best params out of the live path."""
     if not best_params_path.exists():
         return None
-    stamp = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%S%fZ")
-    quarantine_base = (
-        f"{best_params_path.name}.{_OPTUNA_BEST_PARAMS_QUARANTINE_TAG}-{stamp}"
+    quarantine_path = _optuna_quarantine_path(
+        best_params_path,
+        datetime.now(timezone.utc),
+        tag=_OPTUNA_BEST_PARAMS_QUARANTINE_TAG,
+        limit=_OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT,
     )
-    for index in range(_OPTUNA_BEST_PARAMS_QUARANTINE_TIE_BREAK_LIMIT + 1):
-        suffix = "" if index == 0 else f"-{index}"
-        quarantine_path = best_params_path.with_name(f"{quarantine_base}{suffix}")
-        if not quarantine_path.exists():
-            break
-    else:
-        raise FileExistsError(best_params_path)
     try:
         best_params_path.rename(quarantine_path)
     except OSError as quarantine_error:

--- a/quickadapter/user_data/strategies/Utils.py
+++ b/quickadapter/user_data/strategies/Utils.py
@@ -5311,28 +5311,39 @@ def _optuna_best_params_path(
     return base_path / f"optuna-{namespace}-best-params-{pair_to_filename(pair)}.json"
 
 
-def _warn_ambiguous_legacy_optuna_best_params(
+def _resolve_legacy_optuna_best_params(
     base_path: Path,
     pair: str,
     namespace: OptunaNamespace,
     best_params_path: Path,
+    pairs: Sequence[str] | None,
     logger: Logger | None,
-) -> None:
-    """Warn when a base-only legacy best-params file shadows the pair-safe path."""
-    if logger is None:
-        return
+) -> Path | None:
+    """Return a usable legacy base-only best-params file, or None.
+
+    The legacy filename encodes only the pair base; reusing it is safe only
+    when exactly one configured pair maps to that base. Otherwise it is
+    ambiguous and must be ignored (with a warning).
+    """
+    base = pair.split("/")[0]
     legacy_best_params_path = (
-        base_path / f"optuna-{namespace}-best-params-{pair.split('/')[0]}.json"
+        base_path / f"optuna-{namespace}-best-params-{base}.json"
     )
     if (
-        legacy_best_params_path != best_params_path
-        and legacy_best_params_path.is_file()
+        legacy_best_params_path == best_params_path
+        or legacy_best_params_path.is_symlink()
+        or not legacy_best_params_path.is_file()
     ):
+        return None
+    if pairs is not None and sum(1 for p in pairs if p.split("/")[0] == base) == 1:
+        return legacy_best_params_path
+    if logger is not None:
         logger.warning(
             f"[{pair}] Ignoring ambiguous legacy Optuna {namespace} best params "
             f"at {legacy_best_params_path}: filename does not encode the complete "
             f"pair identity"
         )
+    return None
 
 
 _OPTUNA_LABEL_BEST_PARAMS_SCHEMA_VERSION: Final[int] = 2
@@ -5547,15 +5558,18 @@ def _locked_optuna_best_params(
     lock_path = best_params_path.parent / ".optuna-best-params.lock"
     # O_NONBLOCK so a pre-existing FIFO (unlike a symlink, not caught by
     # O_NOFOLLOW) cannot hang this open before the S_ISREG guard rejects it.
-    lock_fd = os.open(
-        lock_path,
-        (os.O_RDWR if exclusive else os.O_RDONLY)
-        | os.O_CREAT
-        | os.O_CLOEXEC
-        | os.O_NOFOLLOW
-        | os.O_NONBLOCK,
-        0o666,
-    )
+    # A shared reader omits O_CREAT: a read-only mount cannot create the lock,
+    # and os.replace atomicity keeps a lock-free read consistent.
+    open_flags = (
+        (os.O_RDWR | os.O_CREAT) if exclusive else os.O_RDONLY
+    ) | os.O_CLOEXEC | os.O_NOFOLLOW | os.O_NONBLOCK
+    try:
+        lock_fd = os.open(lock_path, open_flags, 0o666)
+    except FileNotFoundError:
+        if exclusive:
+            raise
+        yield
+        return
     try:
         if not stat.S_ISREG(os.fstat(lock_fd).st_mode):
             raise OSError(f"Optuna best params lock {lock_path} must be a regular file")
@@ -5579,6 +5593,7 @@ def optuna_load_best_params(
     namespace: OptunaNamespace,
     logger: Logger | None = None,
     *,
+    pairs: Sequence[str] | None = None,
     expected_selection_metadata: dict[str, Any] | None = None,
     expected_objective_identity: str | None = None,
 ) -> dict[str, Any] | None:
@@ -5589,10 +5604,12 @@ def optuna_load_best_params(
     with _locked_optuna_best_params(best_params_path, exclusive=False):
         _reject_optuna_best_params_symlink(best_params_path)
         if not best_params_path.is_file():
-            _warn_ambiguous_legacy_optuna_best_params(
-                base_path, pair, namespace, best_params_path, logger
+            legacy_best_params_path = _resolve_legacy_optuna_best_params(
+                base_path, pair, namespace, best_params_path, pairs, logger
             )
-            return None
+            if legacy_best_params_path is None:
+                return None
+            best_params_path = legacy_best_params_path
         try:
             with best_params_path.open("r", encoding="utf-8") as read_file:
                 best_params = json.load(read_file)
@@ -5691,15 +5708,25 @@ def optuna_save_best_params(
                         temporary_metadata.st_uid != existing_metadata.st_uid
                         or temporary_metadata.st_gid != existing_metadata.st_gid
                     ):
-                        os.fchown(
-                            write_file.fileno(),
-                            existing_metadata.st_uid
-                            if temporary_metadata.st_uid != existing_metadata.st_uid
-                            else -1,
-                            existing_metadata.st_gid
-                            if temporary_metadata.st_gid != existing_metadata.st_gid
-                            else -1,
-                        )
+                        # Best-effort: a non-root process on a cross-uid bind
+                        # mount lacks CAP_CHOWN; the previous in-place write
+                        # never chowned, so a failure must not abort the save.
+                        try:
+                            os.fchown(
+                                write_file.fileno(),
+                                existing_metadata.st_uid
+                                if temporary_metadata.st_uid != existing_metadata.st_uid
+                                else -1,
+                                existing_metadata.st_gid
+                                if temporary_metadata.st_gid != existing_metadata.st_gid
+                                else -1,
+                            )
+                        except PermissionError as chown_error:
+                            if logger is not None:
+                                logger.debug(
+                                    f"[{pair}] Optuna {namespace} best params "
+                                    f"ownership preservation skipped: {chown_error!r}"
+                                )
                     os.fchmod(
                         write_file.fileno(),
                         stat.S_IMODE(existing_metadata.st_mode),


### PR DESCRIPTION
Hardens ReforceXY's Optuna best-params persistence (porting the QuickAdapter reference), then deduplicates the quarantine machinery in both strategies.

## Commit 1 — `fix(reforcexy)`: harden best-params persistence

`save_best_trial_params` / `load_best_trial_params` were fragile: the filename `hyperopt-best-params-{pair.split('/')[0]}.json` keyed only on the base currency (so `BTC/USDT` and `BTC/USDC` shared one file), the write was a bare `open("w") + json.dump` (torn writes), there was no concurrency guard, symlinks/FIFOs at the path were followed, and a corrupt file made `load` raise.

- Pair-safe filename via `_sanitize_pair` (fixes the base-currency collision).
- Warn and ignore a base-only legacy file that shadows the pair-safe path.
- Atomic write (temp + `fsync` + `os.replace`), preserving previous owner/mode.
- `flock` lock file opened `O_NOFOLLOW | O_NONBLOCK | O_CLOEXEC`, `S_ISREG`-guarded.
- Fail closed on a symlinked live path.
- Quarantine a corrupt file on load and return `None` instead of raising.

All load call sites already treat `None` as "no persisted params", so behavior is unchanged on the happy path and strictly safer on a corrupt file.

## Commit 2 — `refactor(reforcexy)`: deduplicate quarantine machinery

The new best-params quarantine re-inlined the timestamp + tie-break path computation already provided by `_quarantine_path`, and duplicated the journal quarantine tag/limit constants with identical values.

- Reuse `_quarantine_path` from `_quarantine_corrupt_best_trial_params`; the wrapper keeps its pair-prefixed logging and rename handling, so both sites' output is unchanged.
- Collapse the four `_JOURNAL_/_BEST_PARAMS_QUARANTINE_*` constants into a single neutral `_QUARANTINE_TAG` / `_QUARANTINE_TIE_BREAK_LIMIT` (same values: `"corrupt"` / `99`); generalize the `_quarantine_path` parameter name.
- Regroup constants so the `_JOURNAL_*` block stays contiguous.

## Commit 3 — `refactor(quickadapter)`: share the quarantine path helper

Same class of duplication existed in QuickAdapter, but across two modules: `Utils._quarantine_corrupt_optuna_best_params` re-inlined the tie-break loop that `QuickAdapterRegressorV3._optuna_quarantine_path` (journal) already implemented.

- Add a shared, parameterized `_optuna_quarantine_path(path, now, *, tag, limit)` in `Utils` (the module both sites import).
- Delegate from the best-params quarantine (Utils) and the journal quarantine (regressor); each keeps its own **domain-named** constants (`_OPTUNA_JOURNAL_*` vs `_OPTUNA_BEST_PARAMS_*`), logging and rename handling — names, log output and error semantics unchanged.
- Remove the regressor's private `_optuna_quarantine_path` copy.

Constants are intentionally **not** merged here (unlike ReforceXY): they live in different modules with correct per-domain names and separate ownership; only the algorithm is shared.

## Verification

- `py_compile` clean on all changed files.
- `ruff`: identical rule-code profile vs base on every changed file (no new findings); ReforceXY's only pre-existing deltas match the file's own `Optional`/`logger.error(exc_info=True)` style.
- Runtime drivers (AST-extracted actual methods, run outside the repo):
  - ReforceXY 18/18 — best-params suite (collision, round-trip, isolation, atomic no-leftover-`.tmp`, regular lock file, symlink reject on load+save, corrupt→quarantine→`None`, legacy warn) **plus** a journal-quarantine regression proving both sites stay byte-identical after the factoring.
  - QuickAdapter 10/10 — best-params and journal quarantine both go through the shared helper with byte-identical warnings, tag-after-extension naming, and exhaustion→`FileExistsError`.
- No tests cover these paths in-repo; drivers were run outside the repo and not committed, per the repo's test convention.