### PR TITLE
build(docker): pin ReforceXY runtime dependency versions (1/3)

### DIFF
--- a/ReforceXY/Dockerfile
+++ b/ReforceXY/Dockerfile
@@ -1,6 +1,8 @@
 FROM freqtradeorg/freqtrade:stable_freqairl
 
 ARG optuna_version=4.9.0
+ARG optuna_dashboard_version=0.20.0
+ARG optunahub_version=0.4.1
 ARG matplotlib_version=3.11.1
 
 USER root
@@ -10,10 +12,10 @@ RUN apt-get update \
 USER ftuser
 RUN pip install --user --no-cache-dir \
     optuna==${optuna_version} \
-    optuna-dashboard \
-    optunahub \
-    matplotlib==${matplotlib_version} \
-    -r https://hub.optuna.org/samplers/auto_sampler/requirements.txt
+    optuna-dashboard==${optuna_dashboard_version} \
+    optunahub==${optunahub_version} \
+    -r https://hub.optuna.org/samplers/auto_sampler/requirements.txt \
+    matplotlib==${matplotlib_version}
 
 LABEL org.opencontainers.image.source="freqai-strategies" \
       org.opencontainers.image.title="freqtrade-reforcexy" \

--- a/ReforceXY/docker-compose.yml
+++ b/ReforceXY/docker-compose.yml
@@ -18,6 +18,8 @@ services:
       dockerfile: Dockerfile
       args:
         optuna_version: 4.9.0
+        optuna_dashboard_version: 0.20.0
+        optunahub_version: 0.4.1
         matplotlib_version: 3.11.1
     restart: unless-stopped
     container_name: freqtrade-ReforceXY


### PR DESCRIPTION
Install and version-pin the runtime dependencies ReforceXY adds on top of the freqtrade RL base image, inline in the Dockerfile.

- Base stays the selectable `freqtradeorg/freqtrade:stable_freqairl` tag (overridable via `freqtrade_image` build-arg) — the base already provides gymnasium / stable-baselines3 / sb3-contrib / scipy, so those are NOT managed here.
- Adds (absent from the base), version-pinned: cmaes, optuna, optuna-dashboard, optunahub, matplotlib.
- No requirements file, no digest pin, no verification/smoke block, no provenance labels.

Stack: docker (1/3).