### PR TITLE
fix(scripts): port docker-upgrade improvements to the shared script

### DIFF
--- a/scripts/docker-upgrade.sh
+++ b/scripts/docker-upgrade.sh
@@ -43,7 +43,11 @@ if [ -d "$LOCKDIR" ]; then
   rm -rf "$LOCKDIR" || true
 fi
 
-trap 'rm -rf "$LOCKDIR"' 0 HUP INT TERM QUIT
+trap 'rm -rf "$LOCKDIR"' 0
+trap 'exit 129' HUP
+trap 'exit 130' INT
+trap 'exit 143' TERM
+trap 'exit 131' QUIT
 
 if ! create_lock "$LOCKDIR"; then
   echo_timestamped "Error: already running for ${LOCAL_DOCKER_IMAGE}"

--- a/scripts/docker-upgrade.sh
+++ b/scripts/docker-upgrade.sh
@@ -248,6 +248,28 @@ if [ "$rebuild_local_image" = true ]; then
     echo_timestamped "Error: docker compose down failed"
     exit 1
   fi
+  previous_image_id=$(
+    command docker image inspect --format='{{.Id}}' "$LOCAL_DOCKER_IMAGE" 2>/dev/null ||
+      printf '%s\n' 'none'
+  )
+  if [ "$previous_image_id" != none ]; then
+    image_name_part=${LOCAL_DOCKER_IMAGE##*/}
+    image_repo="${LOCAL_DOCKER_IMAGE%"$image_name_part"}${image_name_part%%:*}"
+    archive_repo="${image_repo}-archive"
+    archive_tag="${archive_repo}:${previous_image_id#sha256:}"
+    if command docker image tag "$previous_image_id" "$archive_tag" >/dev/null 2>&1; then
+      echo_timestamped "Info: archived previous image as ${archive_tag}"
+      command docker image ls "$archive_repo" --format '{{.Repository}}:{{.Tag}}' 2>/dev/null |
+        while IFS= read -r existing_archive; do
+          if [ -z "$existing_archive" ] || [ "$existing_archive" = "$archive_tag" ]; then
+            continue
+          fi
+          command docker image rm "$existing_archive" >/dev/null 2>&1 || true
+        done
+    else
+      echo_timestamped "Warning: failed to archive previous image ${previous_image_id}"
+    fi
+  fi
   if ! command docker image rm "$LOCAL_DOCKER_IMAGE" >/dev/null 2>&1; then
     echo_timestamped "Warning: docker image rm failed for ${LOCAL_DOCKER_IMAGE}"
   fi


### PR DESCRIPTION
Port the two provenance-independent improvements from the (dropped) ReforceXY-local upgrade wrapper into the shared `scripts/docker-upgrade.sh` used by both ReforceXY and QuickAdapter. The rest of that wrapper (docker-compose.sh provenance wrapper, digest/label pinning, --build) was dropped with the provenance mechanism (#204/#205) and is not ported.

Two atomic commits:

1. `fix(scripts): propagate signal exit codes in docker-upgrade lock trap`
   The single `trap 'rm -rf "$LOCKDIR"' 0 HUP INT TERM QUIT` cleaned the lock on a signal but did not terminate (after Ctrl-C the script kept running and the real exit code was masked). Split so cleanup stays on EXIT(0) and each signal exits 128+n (HUP 129, INT 130, QUIT 131, TERM 143).

2. `feat(scripts): archive previous image before docker-upgrade rebuild`
   Before removing the current image, tag it `<image>-archive:<id>` so the prior build is retained for rollback (best-effort, non-fatal). Adapted to `$LOCAL_DOCKER_IMAGE` and hardened against the tag-malform bug in the wrapper original (strips any existing tag via `%:*`).