### PR TITLE
feat(protections): expose custom_protections via native ProtectionManager

### DIFF
--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -89,6 +89,7 @@
       "method": "StaticPairList"
     }
   ],
+  "custom_protections": [],
   "telegram": {
     "enabled": false,
     "token": "",

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -63,6 +63,19 @@ class RLAgentStrategy(IStrategy):
     def can_short(self) -> bool:
         return self.is_short_allowed()
 
+    @property
+    def protections(self) -> list[dict[str, Any]]:
+        custom_protections = self.config.get("custom_protections", [])
+        if not isinstance(custom_protections, list) or not all(
+            isinstance(protection, dict) and isinstance(protection.get("method"), str)
+            for protection in custom_protections
+        ):
+            raise ValueError(
+                "Config: 'custom_protections' must be a list of protection objects, "
+                "each with a 'method' string."
+            )
+        return custom_protections
+
     # def feature_engineering_expand_all(
     #     self, dataframe: DataFrame, period: int, metadata: dict[str, Any], **kwargs
     # ) -> DataFrame:


### PR DESCRIPTION
Expose preregistered protections to Freqtrade native ProtectionManager via a read-only `protections` property reading the top-level `custom_protections` config key (same config-key convention as QuickAdapter), validated as a list and passed through in native Freqtrade protection syntax.

Reworked from the original: dropped the bespoke `reforcexy_execution` wrapper (it only existed to co-host the research/live promotion guard, now removed) and the guard itself. config-template ships `custom_protections: []`.

Stack: live-risk (1/2), base = main.