### PR TITLE
fix(native-exit): require use_exit_signal=true and exit_profit_only=false (3/4)

### DIFF
--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -17,6 +17,8 @@
   // "leverage": 2.0,
   "trading_mode": "spot",
   "stoploss": -0.99,
+  "use_exit_signal": true,
+  "exit_profit_only": false,
   "unfilledtimeout": {
     "entry": 10,
     "exit": 10,

--- a/ReforceXY/user_data/strategies/RLAgentStrategy.py
+++ b/ReforceXY/user_data/strategies/RLAgentStrategy.py
@@ -83,6 +83,15 @@ class RLAgentStrategy(IStrategy):
                 f"Expected one of: {list(RLAgentStrategy._EXECUTION_PROFILES)}."
             )
 
+        if getattr(self, "use_exit_signal", None) is not True:
+            return (
+                "Config: ReforceXY RL actions require Freqtrade use_exit_signal=true."
+            )
+        if getattr(self, "exit_profit_only", None) is not False:
+            return (
+                "Config: ReforceXY RL actions require Freqtrade exit_profit_only=false."
+            )
+
         runmode = self.config.get("runmode")
         if (
             runmode == RunMode.LIVE


### PR DESCRIPTION
## What
RL exit actions flow through Freqtrade's native signal path, so the resolved strategy attributes must keep `use_exit_signal=true` (else RL exits are suppressed) and `exit_profit_only=false` (else RL exits from losing trades are suppressed). Adds two `getattr` identity-check branches inside `_execution_contract_error()` returning explicit error strings, and sets top-level `use_exit_signal=true` / `exit_profit_only=false` in config-template.json.

## Source
Carved from #162, unit u2.

## Stack position
3/4. **Base: `atomic/live-risk-02-execution-profile` (2/4)** — the checks are added lines inside the `_execution_contract_error` method created in 2/4. Followed by exit-tag (4/4).