### PR TITLE
feat(reward-space-analysis): unify fee_rate and mirror native LocalTrade PnL (1/10)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -473,83 +473,83 @@
     },
     {
       "endCharacter": 17,
-      "endLine": 3677,
+      "endLine": 3676,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3677
+      "startLine": 3676
     },
     {
       "endCharacter": 5,
-      "endLine": 3681,
+      "endLine": 3680,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3677
+      "startLine": 3676
     },
     {
       "endCharacter": 43,
-      "endLine": 3678,
+      "endLine": 3677,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3678
+      "startLine": 3677
     },
     {
       "endCharacter": 42,
-      "endLine": 3678,
+      "endLine": 3677,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3678
+      "startLine": 3677
     },
     {
       "endCharacter": 9,
-      "endLine": 3824,
+      "endLine": 3823,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3820
+      "startLine": 3819
     },
     {
       "endCharacter": 47,
-      "endLine": 3821,
+      "endLine": 3820,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3821
+      "startLine": 3820
     },
     {
       "endCharacter": 46,
-      "endLine": 3821,
+      "endLine": 3820,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3821
+      "startLine": 3820
     },
     {
       "endCharacter": 14,
-      "endLine": 4560,
+      "endLine": 4559,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4560
+      "startLine": 4559
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -3,553 +3,553 @@
   "diagnostics": [
     {
       "endCharacter": 58,
-      "endLine": 337,
+      "endLine": 343,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"RewardParamValue\" is not assignable to declared type \"bool | None\"\n  Type \"RewardParamValue\" is not assignable to type \"bool | None\"\n    Type \"float\" is not assignable to type \"bool | None\"\n      \"float\" is not assignable to \"bool\"\n      \"float\" is not assignable to \"None\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 337
+      "startLine": 343
     },
     {
       "endCharacter": 92,
-      "endLine": 564,
+      "endLine": 570,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"RewardParamValue\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"RewardParamValue\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 564
+      "startLine": 570
     },
     {
       "endCharacter": 92,
-      "endLine": 564,
+      "endLine": 570,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"RewardParamValue\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"RewardParamValue\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 564
+      "startLine": 570
     },
     {
       "endCharacter": 5,
-      "endLine": 1889,
+      "endLine": 1895,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"cut\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 1884
+      "startLine": 1890
     },
     {
       "endCharacter": 21,
-      "endLine": 1886,
+      "endLine": 1892,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"_Array1D[Any]\" cannot be assigned to parameter \"bins\" of type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\" in function \"cut\"\n  Type \"_Array1D[Any]\" is not assignable to type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"int\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Sequence[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[int]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"IntervalIndex[Interval[Any]]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Series[Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1886
+      "startLine": 1892
     },
     {
       "endCharacter": 5,
-      "endLine": 1911,
+      "endLine": 1917,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 1907
+      "startLine": 1913
     },
     {
       "endCharacter": 43,
-      "endLine": 1908,
+      "endLine": 1914,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1908
+      "startLine": 1914
     },
     {
       "endCharacter": 42,
-      "endLine": 1908,
+      "endLine": 1914,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1908
+      "startLine": 1914
     },
     {
       "endCharacter": 60,
-      "endLine": 2167,
+      "endLine": 2173,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_mean\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 2167
+      "startLine": 2173
     },
     {
       "endCharacter": 58,
-      "endLine": 2168,
+      "endLine": 2174,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_std\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_std\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2168
+      "startLine": 2174
     },
     {
       "endCharacter": 88,
-      "endLine": 2187,
+      "endLine": 2193,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"NDArray[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2187
+      "startLine": 2193
     },
     {
       "endCharacter": 88,
-      "endLine": 2187,
+      "endLine": 2193,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"list[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2187
+      "startLine": 2193
     },
     {
       "endCharacter": 17,
-      "endLine": 2196,
+      "endLine": 2202,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Object of type \"None\" cannot be called",
       "rule": "reportOptionalCall",
       "severity": "error",
       "startCharacter": 28,
-      "startLine": 2190
+      "startLine": 2196
     },
     {
       "endCharacter": 40,
-      "endLine": 2410,
+      "endLine": 2416,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2410
+      "startLine": 2416
     },
     {
       "endCharacter": 38,
-      "endLine": 2410,
+      "endLine": 2416,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2410
+      "startLine": 2416
     },
     {
       "endCharacter": 59,
-      "endLine": 2410,
+      "endLine": 2416,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2410
+      "startLine": 2416
     },
     {
       "endCharacter": 57,
-      "endLine": 2410,
+      "endLine": 2416,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2410
+      "startLine": 2416
     },
     {
       "endCharacter": 40,
-      "endLine": 2411,
+      "endLine": 2417,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2411
+      "startLine": 2417
     },
     {
       "endCharacter": 38,
-      "endLine": 2411,
+      "endLine": 2417,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2411
+      "startLine": 2417
     },
     {
       "endCharacter": 59,
-      "endLine": 2411,
+      "endLine": 2417,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2411
+      "startLine": 2417
     },
     {
       "endCharacter": 57,
-      "endLine": 2411,
+      "endLine": 2417,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2411
+      "startLine": 2417
     },
     {
       "endCharacter": 76,
-      "endLine": 2431,
+      "endLine": 2437,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 24,
-      "startLine": 2431
+      "startLine": 2437
     },
     {
       "endCharacter": 49,
-      "endLine": 2431,
+      "endLine": 2437,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2431
+      "startLine": 2437
     },
     {
       "endCharacter": 74,
-      "endLine": 2432,
+      "endLine": 2438,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2432
+      "startLine": 2438
     },
     {
       "endCharacter": 47,
-      "endLine": 2432,
+      "endLine": 2438,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 2432
+      "startLine": 2438
     },
     {
       "endCharacter": 51,
-      "endLine": 2447,
+      "endLine": 2453,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"u_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2447
+      "startLine": 2453
     },
     {
       "endCharacter": 64,
-      "endLine": 2447,
+      "endLine": 2453,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"v_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 53,
-      "startLine": 2447
+      "startLine": 2453
     },
     {
       "endCharacter": 68,
-      "endLine": 2450,
+      "endLine": 2456,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ks_2samp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 27,
-      "startLine": 2450
+      "startLine": 2456
     },
     {
       "endCharacter": 54,
-      "endLine": 2450,
+      "endLine": 2456,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data1\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2450
+      "startLine": 2456
     },
     {
       "endCharacter": 67,
-      "endLine": 2450,
+      "endLine": 2456,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data2\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 2450
+      "startLine": 2456
     },
     {
       "endCharacter": 26,
-      "endLine": 2720,
+      "endLine": 2726,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"size\" for class \"ExtensionArray\"\n  Attribute \"size\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2720
+      "startLine": 2726
     },
     {
       "endCharacter": 29,
-      "endLine": 2722,
+      "endLine": 2728,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ptp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 11,
-      "startLine": 2722
+      "startLine": 2728
     },
     {
       "endCharacter": 28,
-      "endLine": 2722,
+      "endLine": 2728,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"ptp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 2722
+      "startLine": 2728
     },
     {
       "endCharacter": 65,
-      "endLine": 2735,
+      "endLine": 2741,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"Categorical[object]\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2735
+      "startLine": 2741
     },
     {
       "endCharacter": 65,
-      "endLine": 2735,
+      "endLine": 2741,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"ExtensionArray\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2735
+      "startLine": 2741
     },
     {
       "endCharacter": 56,
-      "endLine": 2815,
+      "endLine": 2821,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"mean\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2815
+      "startLine": 2821
     },
     {
       "endCharacter": 55,
-      "endLine": 2815,
+      "endLine": 2821,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"mean\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 51,
-      "startLine": 2815
+      "startLine": 2821
     },
     {
       "endCharacter": 62,
-      "endLine": 2816,
+      "endLine": 2822,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"std\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2816
+      "startLine": 2822
     },
     {
       "endCharacter": 53,
-      "endLine": 2816,
+      "endLine": 2822,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"std\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 2816
+      "startLine": 2822
     },
     {
       "endCharacter": 39,
-      "endLine": 2817,
+      "endLine": 2823,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"skew\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2817
+      "startLine": 2823
     },
     {
       "endCharacter": 38,
-      "endLine": 2817,
+      "endLine": 2823,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"skew\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 2817
+      "startLine": 2823
     },
     {
       "endCharacter": 56,
-      "endLine": 2818,
+      "endLine": 2824,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"kurtosis\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2818
+      "startLine": 2824
     },
     {
       "endCharacter": 42,
-      "endLine": 2818,
+      "endLine": 2824,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"kurtosis\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2818
+      "startLine": 2824
     },
     {
       "endCharacter": 50,
-      "endLine": 2829,
+      "endLine": 2835,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"shapiro\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 2829
+      "startLine": 2835
     },
     {
       "endCharacter": 49,
-      "endLine": 2829,
+      "endLine": 2835,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"shapiro\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 2829
+      "startLine": 2835
     },
     {
       "endCharacter": 39,
-      "endLine": 2834,
+      "endLine": 2840,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloatND\" in function \"anderson\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2834
+      "startLine": 2840
     },
     {
       "endCharacter": 61,
-      "endLine": 2841,
+      "endLine": 2847,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"probplot\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 57,
-      "startLine": 2841
+      "startLine": 2847
     },
     {
       "endCharacter": 17,
-      "endLine": 3640,
+      "endLine": 3677,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3640
+      "startLine": 3677
     },
     {
       "endCharacter": 5,
-      "endLine": 3644,
+      "endLine": 3681,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3640
+      "startLine": 3677
     },
     {
       "endCharacter": 43,
-      "endLine": 3641,
+      "endLine": 3678,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3641
+      "startLine": 3678
     },
     {
       "endCharacter": 42,
-      "endLine": 3641,
+      "endLine": 3678,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3641
+      "startLine": 3678
     },
     {
       "endCharacter": 9,
-      "endLine": 3787,
+      "endLine": 3824,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3783
+      "startLine": 3820
     },
     {
       "endCharacter": 47,
-      "endLine": 3784,
+      "endLine": 3821,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3784
+      "startLine": 3821
     },
     {
       "endCharacter": 46,
-      "endLine": 3784,
+      "endLine": 3821,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3784
+      "startLine": 3821
     },
     {
       "endCharacter": 14,
-      "endLine": 4496,
+      "endLine": 4560,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4496
+      "startLine": 4560
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -3047,8 +3047,7 @@ def _get_fee_rate(params: RewardParams) -> float:
     max_fee_rate = float(_PARAMETER_BOUNDS["fee_rate"]["max"])
     if not np.isfinite(fee_rate) or not 0.0 <= fee_rate <= max_fee_rate:
         raise ValueError(
-            f"Reward: fee_rate must be finite within [0, {max_fee_rate}], "
-            f"got {fee_rate!r}"
+            f"Reward: fee_rate must be finite within [0, {max_fee_rate}], got {fee_rate!r}"
         )
     return fee_rate
 

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -4420,14 +4420,41 @@ def main() -> None:
     parser = build_argument_parser()
     args = parser.parse_args()
 
-    params = dict(DEFAULT_MODEL_REWARD_PARAMETERS)
-    # Merge CLI tunables first (only those explicitly provided)
     _tunable_keys = set(DEFAULT_MODEL_REWARD_PARAMETERS.keys())
-    for key, value in vars(args).items():
-        if key in _tunable_keys and value is not None:
-            params[key] = value
-    # Then apply --params KEY=VALUE overrides (highest precedence)
-    params.update(parse_overrides(args.params))
+    cli_params = {
+        key: value
+        for key, value in vars(args).items()
+        if key in _tunable_keys and value is not None
+    }
+    override_params = parse_overrides(args.params)
+    params = {
+        **DEFAULT_MODEL_REWARD_PARAMETERS,
+        **cli_params,
+        **override_params,
+    }
+    # Translate explicitly supplied legacy fee aliases into the unified
+    # ``fee_rate`` before they are masked by the canonical default:
+    # ``params`` always carries ``fee_rate``, so ``_get_fee_rate()`` alone
+    # cannot distinguish a default from user intent.
+    if "fee_rate" not in cli_params and "fee_rate" not in override_params:
+        supplied_legacy_fees = [
+            float(params[key])
+            for key in ("entry_fee_rate", "exit_fee_rate")
+            if key in cli_params or key in override_params
+        ]
+        if supplied_legacy_fees:
+            if len(supplied_legacy_fees) > 1 and not np.isclose(
+                supplied_legacy_fees[0], supplied_legacy_fees[1]
+            ):
+                warnings.warn(
+                    "CLI: asymmetric legacy fee rates cannot mirror Freqtrade; "
+                    f"using conservative fee_rate={max(supplied_legacy_fees):.6g}",
+                    RewardDiagnosticsWarning,
+                    stacklevel=2,
+                )
+            params.pop("entry_fee_rate", None)
+            params.pop("exit_fee_rate", None)
+            params["fee_rate"] = max(supplied_legacy_fees)
 
     params_validated, adjustments = validate_reward_parameters(
         params, strict=args.strict_validation

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -245,7 +245,7 @@ DEFAULT_MODEL_REWARD_PARAMETERS_HELP: dict[str, str] = {
 _PARAMETER_BOUNDS: dict[str, dict[str, float]] = {
     # key: {min: ..., max: ...}  (bounds are inclusive where it makes sense)
     "invalid_action": {"max": 0.0},  # penalty should be <= 0
-    "base_factor": {"min": 1e-12},
+    "base_factor": {"min": 0.0},
     "fee_rate": {"min": 0.0, "max": 0.1},
     "idle_penalty_power": {"min": 0.0},
     "idle_penalty_ratio": {"min": 0.0},
@@ -3044,8 +3044,12 @@ def _get_fee_rate(params: RewardParams) -> float:
             )
 
     fee_rate = float(raw_fee_rate)
-    if not np.isfinite(fee_rate) or fee_rate < 0.0:
-        raise ValueError(f"Reward: fee_rate must be finite and non-negative, got {fee_rate!r}")
+    max_fee_rate = float(_PARAMETER_BOUNDS["fee_rate"]["max"])
+    if not np.isfinite(fee_rate) or not 0.0 <= fee_rate <= max_fee_rate:
+        raise ValueError(
+            f"Reward: fee_rate must be finite within [0, {max_fee_rate}], "
+            f"got {fee_rate!r}"
+        )
     return fee_rate
 
 

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -16,6 +16,7 @@ import numbers
 import pickle
 import random
 import warnings
+from decimal import Decimal, localcontext
 from enum import Enum, IntEnum
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, Literal
@@ -70,16 +71,17 @@ _LOG_2 = math.log(2.0)
 
 DEFAULT_IDLE_DURATION_MULTIPLIER = 4
 
-# Tolerance for PBRS invariance classification.
+# Tolerance for PBRS algebraic-conformance classification.
 #
 # When `reward_invariance_correction` is available (reward_shaping - reward_pbrs_delta),
-# canonical PBRS should satisfy max|correction| < PBRS_INVARIANCE_TOL.
-#
-# When that diagnostic column is not available (e.g., reporting from partial datasets),
-# we fall back to the weaker heuristic |Σ shaping| < PBRS_INVARIANCE_TOL.
+# canonical PBRS should satisfy max|correction| < PBRS_INVARIANCE_TOL. A raw
+# shaping sum is never a classifier: for gamma < 1, only the discounted shaping
+# sum has the PBRS telescoping interpretation.
 PBRS_INVARIANCE_TOL: float = 1e-6
 # Default discount factor γ for potential-based reward shaping
 POTENTIAL_GAMMA_DEFAULT: float = 0.95
+BASE_ENVIRONMENT_FEE_FALLBACK: float = 0.0015
+MIN_LIQUIDATION_VALUE: float = 1e-12
 
 # Default risk/reward ratio (RR)
 RISK_REWARD_RATIO_DEFAULT: float = 2.0
@@ -134,6 +136,8 @@ _ADJUST_METHODS_ALIASES: frozenset[str] = frozenset({"benjaminihochberg"})
 DEFAULT_MODEL_REWARD_PARAMETERS: RewardParams = {
     "invalid_action": -2.0,
     "base_factor": 100.0,
+    # One fee mirrors the native LocalTrade open/close fee inputs.
+    "fee_rate": BASE_ENVIRONMENT_FEE_FALLBACK,
     # Idle penalty defaults
     "idle_penalty_ratio": 1.0,
     "idle_penalty_power": 1.025,
@@ -191,6 +195,7 @@ DEFAULT_MODEL_REWARD_PARAMETERS: RewardParams = {
 DEFAULT_MODEL_REWARD_PARAMETERS_HELP: dict[str, str] = {
     "invalid_action": "Penalty for invalid actions",
     "base_factor": "Base reward scale",
+    "fee_rate": "Unified fee rate used by Freqtrade spot LocalTrade",
     "idle_penalty_power": "Idle penalty exponent",
     "idle_penalty_ratio": "Idle penalty ratio",
     "max_trade_duration_candles": "Trade duration cap (candles)",
@@ -240,7 +245,8 @@ DEFAULT_MODEL_REWARD_PARAMETERS_HELP: dict[str, str] = {
 _PARAMETER_BOUNDS: dict[str, dict[str, float]] = {
     # key: {min: ..., max: ...}  (bounds are inclusive where it makes sense)
     "invalid_action": {"max": 0.0},  # penalty should be <= 0
-    "base_factor": {"min": 0.0},
+    "base_factor": {"min": 1e-12},
+    "fee_rate": {"min": 0.0, "max": 0.1},
     "idle_penalty_power": {"min": 0.0},
     "idle_penalty_ratio": {"min": 0.0},
     "max_trade_duration_candles": {"min": 1.0},
@@ -3014,37 +3020,40 @@ def _get_potential_gamma(params: RewardParams) -> float:
 # === PBRS IMPLEMENTATION ===
 
 
-def _get_fee_rates(params: RewardParams) -> tuple[float, float]:
-    """Return clamped `(entry_fee_rate, exit_fee_rate)`.
+def _get_fee_rate(params: RewardParams) -> float:
+    """Return the unified fee used by Freqtrade's spot ``LocalTrade``.
 
-    Semantics follow Freqtrade's `BaseEnvironment` fee helpers:
-    - Entry fee is applied as multiplication: `price * (1 + entry_fee_rate)`.
-    - Exit fee is applied as division: `price / (1 + exit_fee_rate)`.
-
-    Notes:
-    - Supports two tunables (`entry_fee_rate`, `exit_fee_rate`).
-    - Missing/non-finite values fall back to the min bound (usually 0.0).
-    - Values are clamped to `_PARAMETER_BOUNDS`.
-
-    This function intentionally clamps (never raises) so callers do not need to
-    pre-run `validate_reward_parameters()`.
+    Runtime supplies the same pair-specific fee to ``LocalTrade.fee_open`` and
+    ``LocalTrade.fee_close``. ``entry_fee_rate`` and ``exit_fee_rate`` remain
+    accepted only as migration aliases. When asymmetric legacy values are
+    supplied, the larger value is used conservatively and a warning is emitted.
     """
 
-    raw_entry_fee_rate = _get_float_param(params, "entry_fee_rate")
-    raw_exit_fee_rate = _get_float_param(params, "exit_fee_rate")
+    if "fee_rate" in params:
+        raw_fee_rate = _get_float_param(params, "fee_rate")
+    else:
+        entry_fee_rate = _get_float_param(params, "entry_fee_rate", 0.0)
+        exit_fee_rate = _get_float_param(params, "exit_fee_rate", 0.0)
+        raw_fee_rate = max(entry_fee_rate, exit_fee_rate)
+        if not np.isclose(entry_fee_rate, exit_fee_rate):
+            warnings.warn(
+                "Param: asymmetric legacy fee rates cannot mirror Freqtrade; "
+                f"using conservative fee_rate={raw_fee_rate:.6g}",
+                RewardDiagnosticsWarning,
+                stacklevel=2,
+            )
 
-    entry_fee_rate, _ = _clamp_float_to_bounds(
-        "entry_fee_rate",
-        float(raw_entry_fee_rate),
-        strict=False,
-    )
-    exit_fee_rate, _ = _clamp_float_to_bounds(
-        "exit_fee_rate",
-        float(raw_exit_fee_rate),
-        strict=False,
-    )
+    fee_rate = float(raw_fee_rate)
+    if not np.isfinite(fee_rate) or fee_rate < 0.0:
+        raise ValueError(f"Reward: fee_rate must be finite and non-negative, got {fee_rate!r}")
+    return fee_rate
 
-    return entry_fee_rate, exit_fee_rate
+
+def _get_fee_rates(params: RewardParams) -> tuple[float, float]:
+    """Return symmetric fee rates for backward-compatible helper callers."""
+
+    fee_rate = _get_fee_rate(params)
+    return fee_rate, fee_rate
 
 
 def _apply_entry_fee(price: float, entry_fee_rate: float) -> float:
@@ -3054,7 +3063,7 @@ def _apply_entry_fee(price: float, entry_fee_rate: float) -> float:
 def _apply_exit_fee(price: float, exit_fee_rate: float) -> float:
     denom = 1.0 + exit_fee_rate
     if denom <= 0.0 or not np.isfinite(denom):
-        return float(price)
+        raise ValueError(f"Reward: invalid exit fee denominator {denom!r}")
     return float(price / denom)
 
 
@@ -3065,45 +3074,69 @@ def _compute_unrealized_pnl_estimate(
     current_open: float,
     params: RewardParams,
 ) -> float:
-    """Estimate unrealized PnL using fee application parity with Freqtrade.
+    """Retain the historical BaseEnvironment estimate for analytical PBRS.
 
-    Long:
-        entry_price = entry_open * (1 + entry_fee_rate)
-        current_price = current_open / (1 + exit_fee_rate)
-        pnl = (current_price - entry_price) / entry_price
-
-    Short:
-        entry_price = entry_open / (1 + exit_fee_rate)
-        current_price = current_open * (1 + entry_fee_rate)
-        pnl = (entry_price - current_price) / entry_price
+    This helper is compatibility-only and is selected only when the
+    non-promotable ``hold_potential_enabled`` mode is active. Promotable
+    analysis uses ``_compute_spot_local_trade_pnl_estimate``.
     """
 
     if position not in (Positions.Long, Positions.Short):
         return 0.0
 
     if not np.isfinite(entry_open) or entry_open <= 0.0:
-        return 0.0
+        raise ValueError(f"Reward: entry_open must be finite and positive, got {entry_open!r}")
     if not np.isfinite(current_open) or current_open <= 0.0:
-        return 0.0
+        raise ValueError(f"Reward: current_open must be finite and positive, got {current_open!r}")
 
     entry_fee_rate, exit_fee_rate = _get_fee_rates(params)
 
     if position == Positions.Long:
         current_price = _apply_exit_fee(current_open, exit_fee_rate)
         entry_price = _apply_entry_fee(entry_open, entry_fee_rate)
-        if entry_price == 0.0 or not np.isfinite(entry_price):
-            return 0.0
+        if entry_price <= 0.0 or not np.isfinite(entry_price):
+            raise ValueError(f"Reward: invalid long entry price {entry_price!r}")
         pnl = (current_price - entry_price) / entry_price
     else:
         current_price = _apply_entry_fee(current_open, entry_fee_rate)
         entry_price = _apply_exit_fee(entry_open, exit_fee_rate)
-        if entry_price == 0.0 or not np.isfinite(entry_price):
-            return 0.0
+        if entry_price <= 0.0 or not np.isfinite(entry_price):
+            raise ValueError(f"Reward: invalid short entry price {entry_price!r}")
         pnl = (entry_price - current_price) / entry_price
 
     if not np.isfinite(pnl):
-        return 0.0
+        raise ValueError(f"Reward: unrealized PnL is not finite: {pnl!r}")
     return float(pnl)
+
+
+def _compute_spot_local_trade_pnl_estimate(
+    position: Positions,
+    *,
+    entry_open: float,
+    current_open: float,
+    params: RewardParams,
+) -> float:
+    """Mirror ``LocalTrade.calc_profit_ratio`` for spot leverage-one analysis."""
+    if position == Positions.Neutral:
+        return 0.0
+
+    fee_rate = _get_fee_rate(params)
+    with localcontext() as context:
+        context.prec = 64
+        entry_value = Decimal(str(entry_open))
+        mark_value = Decimal(str(current_open))
+        fee_value = Decimal(str(fee_rate))
+        entry_fee = entry_value * fee_value
+        mark_fee = mark_value * fee_value
+        if position == Positions.Long:
+            open_trade_value = float(entry_value + entry_fee)
+            close_trade_value = float(mark_value - mark_fee)
+            pnl = close_trade_value / open_trade_value - 1.0
+        else:
+            open_trade_value = float(entry_value - entry_fee)
+            close_trade_value = float(mark_value + mark_fee)
+            pnl = 1.0 - close_trade_value / open_trade_value
+    return round(pnl, 8) + 0.0
 
 
 def _loss_duration_multiplier(pnl_ratio: float, risk_reward_ratio: float) -> float:


### PR DESCRIPTION
Atomic PR 1/10 of the reward_space_analysis economic-contract split (source: #120, unit u9).

**What**: Introduce a single unified `fee_rate` tunable and mirror Freqtrade's native spot `LocalTrade` PnL arithmetic in the analytical clone.
- New `_get_fee_rate()` (single unified fee; `entry_fee_rate`/`exit_fee_rate` demoted to migration aliases, asymmetric -> conservative max + warning); `_get_fee_rates()` becomes a symmetric shim.
- New `_compute_spot_local_trade_pnl_estimate()` (Decimal prec=64 open/close-value mirror of `LocalTrade.calc_profit_ratio`, `round(pnl, 8)`).
- `_apply_exit_fee()` now raises on invalid denominator; `_compute_unrealized_pnl_estimate()` retained as BaseEnvironment compatibility path and fail-closed.
- `DEFAULT_MODEL_REWARD_PARAMETERS['fee_rate']=BASE_ENVIRONMENT_FEE_FALLBACK` (0.0015), help entry, and `_PARAMETER_BOUNDS` (fee_rate 0..0.1, base_factor min 1e-12); new `MIN_LIQUIDATION_VALUE`; `Decimal`/`localcontext` imports.

**Scope**: `ReforceXY/reward_space_analysis/reward_space_analysis.py` only.

**Stack position**: base `main`; first of 10. Files are disjoint from ReforceXY.py (STACK A). B1-B7 progressively reconstruct the wholesale rewrite of this file; after B7 it is byte-identical to #120.

Verified: `python -m py_compile` clean; `ruff check`/`ruff format --check` under project config introduce no new findings vs the main baseline.