### PR TITLE
refactor(reward-space-analysis): restrict PBRS to canonical and inventory deprecated params (2/10)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -3,553 +3,553 @@
   "diagnostics": [
     {
       "endCharacter": 58,
-      "endLine": 343,
+      "endLine": 369,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"RewardParamValue\" is not assignable to declared type \"bool | None\"\n  Type \"RewardParamValue\" is not assignable to type \"bool | None\"\n    Type \"float\" is not assignable to type \"bool | None\"\n      \"float\" is not assignable to \"bool\"\n      \"float\" is not assignable to \"None\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 343
+      "startLine": 369
     },
     {
       "endCharacter": 92,
-      "endLine": 570,
+      "endLine": 596,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"RewardParamValue\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"RewardParamValue\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 570
+      "startLine": 596
     },
     {
       "endCharacter": 92,
-      "endLine": 570,
+      "endLine": 596,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"RewardParamValue\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"RewardParamValue\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 570
+      "startLine": 596
     },
     {
       "endCharacter": 5,
-      "endLine": 1895,
+      "endLine": 1976,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"cut\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 1890
+      "startLine": 1971
     },
     {
       "endCharacter": 21,
-      "endLine": 1892,
+      "endLine": 1973,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"_Array1D[Any]\" cannot be assigned to parameter \"bins\" of type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\" in function \"cut\"\n  Type \"_Array1D[Any]\" is not assignable to type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"int\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Sequence[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[int]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"IntervalIndex[Interval[Any]]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Series[Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1892
+      "startLine": 1973
     },
     {
       "endCharacter": 5,
-      "endLine": 1917,
+      "endLine": 1998,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 1913
+      "startLine": 1994
     },
     {
       "endCharacter": 43,
-      "endLine": 1914,
+      "endLine": 1995,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1914
+      "startLine": 1995
     },
     {
       "endCharacter": 42,
-      "endLine": 1914,
+      "endLine": 1995,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1914
+      "startLine": 1995
     },
     {
       "endCharacter": 60,
-      "endLine": 2173,
+      "endLine": 2254,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_mean\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 2173
+      "startLine": 2254
     },
     {
       "endCharacter": 58,
-      "endLine": 2174,
+      "endLine": 2255,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_std\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_std\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2174
+      "startLine": 2255
     },
     {
       "endCharacter": 88,
-      "endLine": 2193,
+      "endLine": 2274,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"NDArray[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2193
+      "startLine": 2274
     },
     {
       "endCharacter": 88,
-      "endLine": 2193,
+      "endLine": 2274,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"list[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2193
+      "startLine": 2274
     },
     {
       "endCharacter": 17,
-      "endLine": 2202,
+      "endLine": 2283,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Object of type \"None\" cannot be called",
       "rule": "reportOptionalCall",
       "severity": "error",
       "startCharacter": 28,
-      "startLine": 2196
+      "startLine": 2277
     },
     {
       "endCharacter": 40,
-      "endLine": 2416,
+      "endLine": 2497,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2416
+      "startLine": 2497
     },
     {
       "endCharacter": 38,
-      "endLine": 2416,
+      "endLine": 2497,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2416
+      "startLine": 2497
     },
     {
       "endCharacter": 59,
-      "endLine": 2416,
+      "endLine": 2497,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2416
+      "startLine": 2497
     },
     {
       "endCharacter": 57,
-      "endLine": 2416,
+      "endLine": 2497,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2416
+      "startLine": 2497
     },
     {
       "endCharacter": 40,
-      "endLine": 2417,
+      "endLine": 2498,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2417
+      "startLine": 2498
     },
     {
       "endCharacter": 38,
-      "endLine": 2417,
+      "endLine": 2498,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2417
+      "startLine": 2498
     },
     {
       "endCharacter": 59,
-      "endLine": 2417,
+      "endLine": 2498,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2417
+      "startLine": 2498
     },
     {
       "endCharacter": 57,
-      "endLine": 2417,
+      "endLine": 2498,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2417
+      "startLine": 2498
     },
     {
       "endCharacter": 76,
-      "endLine": 2437,
+      "endLine": 2518,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 24,
-      "startLine": 2437
+      "startLine": 2518
     },
     {
       "endCharacter": 49,
-      "endLine": 2437,
+      "endLine": 2518,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2437
+      "startLine": 2518
     },
     {
       "endCharacter": 74,
-      "endLine": 2438,
+      "endLine": 2519,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2438
+      "startLine": 2519
     },
     {
       "endCharacter": 47,
-      "endLine": 2438,
+      "endLine": 2519,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 2438
+      "startLine": 2519
     },
     {
       "endCharacter": 51,
-      "endLine": 2453,
+      "endLine": 2534,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"u_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2453
+      "startLine": 2534
     },
     {
       "endCharacter": 64,
-      "endLine": 2453,
+      "endLine": 2534,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"v_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 53,
-      "startLine": 2453
+      "startLine": 2534
     },
     {
       "endCharacter": 68,
-      "endLine": 2456,
+      "endLine": 2537,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ks_2samp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 27,
-      "startLine": 2456
+      "startLine": 2537
     },
     {
       "endCharacter": 54,
-      "endLine": 2456,
+      "endLine": 2537,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data1\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2456
+      "startLine": 2537
     },
     {
       "endCharacter": 67,
-      "endLine": 2456,
+      "endLine": 2537,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data2\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 2456
+      "startLine": 2537
     },
     {
       "endCharacter": 26,
-      "endLine": 2726,
+      "endLine": 2807,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"size\" for class \"ExtensionArray\"\n  Attribute \"size\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2726
+      "startLine": 2807
     },
     {
       "endCharacter": 29,
-      "endLine": 2728,
+      "endLine": 2809,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ptp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 11,
-      "startLine": 2728
+      "startLine": 2809
     },
     {
       "endCharacter": 28,
-      "endLine": 2728,
+      "endLine": 2809,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"ptp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 2728
+      "startLine": 2809
     },
     {
       "endCharacter": 65,
-      "endLine": 2741,
+      "endLine": 2822,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"Categorical[object]\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2741
+      "startLine": 2822
     },
     {
       "endCharacter": 65,
-      "endLine": 2741,
+      "endLine": 2822,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"ExtensionArray\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2741
+      "startLine": 2822
     },
     {
       "endCharacter": 56,
-      "endLine": 2821,
+      "endLine": 2902,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"mean\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2821
+      "startLine": 2902
     },
     {
       "endCharacter": 55,
-      "endLine": 2821,
+      "endLine": 2902,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"mean\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 51,
-      "startLine": 2821
+      "startLine": 2902
     },
     {
       "endCharacter": 62,
-      "endLine": 2822,
+      "endLine": 2903,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"std\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2822
+      "startLine": 2903
     },
     {
       "endCharacter": 53,
-      "endLine": 2822,
+      "endLine": 2903,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"std\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 2822
+      "startLine": 2903
     },
     {
       "endCharacter": 39,
-      "endLine": 2823,
+      "endLine": 2904,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"skew\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2823
+      "startLine": 2904
     },
     {
       "endCharacter": 38,
-      "endLine": 2823,
+      "endLine": 2904,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"skew\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 2823
+      "startLine": 2904
     },
     {
       "endCharacter": 56,
-      "endLine": 2824,
+      "endLine": 2905,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"kurtosis\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2824
+      "startLine": 2905
     },
     {
       "endCharacter": 42,
-      "endLine": 2824,
+      "endLine": 2905,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"kurtosis\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2824
+      "startLine": 2905
     },
     {
       "endCharacter": 50,
-      "endLine": 2835,
+      "endLine": 2916,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"shapiro\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 2835
+      "startLine": 2916
     },
     {
       "endCharacter": 49,
-      "endLine": 2835,
+      "endLine": 2916,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"shapiro\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 2835
+      "startLine": 2916
     },
     {
       "endCharacter": 39,
-      "endLine": 2840,
+      "endLine": 2921,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloatND\" in function \"anderson\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2840
+      "startLine": 2921
     },
     {
       "endCharacter": 61,
-      "endLine": 2847,
+      "endLine": 2928,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"probplot\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 57,
-      "startLine": 2847
+      "startLine": 2928
     },
     {
       "endCharacter": 17,
-      "endLine": 3676,
+      "endLine": 3726,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3676
+      "startLine": 3726
     },
     {
       "endCharacter": 5,
-      "endLine": 3680,
+      "endLine": 3730,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3676
+      "startLine": 3726
     },
     {
       "endCharacter": 43,
-      "endLine": 3677,
+      "endLine": 3727,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3677
+      "startLine": 3727
     },
     {
       "endCharacter": 42,
-      "endLine": 3677,
+      "endLine": 3727,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3677
+      "startLine": 3727
     },
     {
       "endCharacter": 9,
-      "endLine": 3823,
+      "endLine": 3873,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3819
+      "startLine": 3869
     },
     {
       "endCharacter": 47,
-      "endLine": 3820,
+      "endLine": 3870,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3820
+      "startLine": 3870
     },
     {
       "endCharacter": 46,
-      "endLine": 3820,
+      "endLine": 3870,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3820
+      "startLine": 3870
     },
     {
       "endCharacter": 14,
-      "endLine": 4559,
+      "endLine": 4609,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4559
+      "startLine": 4609
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -47,9 +47,7 @@ except Exception:
 
 AttenuationMode = Literal["sqrt", "linear", "power", "half_life"]
 TransformFunction = Literal["tanh", "softsign", "arctan", "sigmoid", "clip", "asinh"]
-ExitPotentialMode = Literal[
-    "canonical", "non_canonical", "progressive_release", "spike_cancel", "retain_previous"
-]
+ExitPotentialMode = Literal["canonical"]
 
 
 class Actions(IntEnum):
@@ -116,13 +114,41 @@ ALLOWED_TRANSFORMS = {
     "asinh",
     "clip",
 }
-ALLOWED_EXIT_POTENTIAL_MODES = {
-    "canonical",
-    "non_canonical",
-    "progressive_release",
-    "spike_cancel",
-    "retain_previous",
-}
+ALLOWED_EXIT_POTENTIAL_MODES = {"canonical"}
+
+# Accepted during the migration window but ignored by the economic reward.
+DEPRECATED_REWARD_PARAMETERS: frozenset[str] = frozenset(
+    {
+        "idle_penalty_ratio",
+        "idle_penalty_power",
+        "hold_penalty_ratio",
+        "hold_penalty_power",
+        "exit_attenuation_mode",
+        "exit_plateau",
+        "exit_plateau_grace",
+        "exit_linear_slope",
+        "exit_power_tau",
+        "exit_half_life",
+        "efficiency_weight",
+        "efficiency_center",
+        "win_reward_factor",
+        "pnl_amplification_sensitivity",
+        "exit_factor_threshold",
+        "exit_potential_decay",
+        "entry_additive_enabled",
+        "entry_additive_ratio",
+        "entry_additive_gain",
+        "entry_additive_transform_pnl",
+        "entry_additive_transform_duration",
+        "exit_additive_enabled",
+        "exit_additive_ratio",
+        "exit_additive_gain",
+        "exit_additive_transform_pnl",
+        "exit_additive_transform_duration",
+        "entry_fee_rate",
+        "exit_fee_rate",
+    }
+)
 
 # Supported trading modes
 TRADING_MODES: tuple[str, ...] = ("spot", "margin", "futures")
@@ -167,7 +193,7 @@ DEFAULT_MODEL_REWARD_PARAMETERS: RewardParams = {
     # Potential-based reward shaping core parameters
     # Discount factor γ for potential term (0 ≤ γ ≤ 1)
     "potential_gamma": POTENTIAL_GAMMA_DEFAULT,
-    # Exit potential modes: canonical | non_canonical | progressive_release | spike_cancel | retain_previous
+    # Only canonical PBRS is supported by the economic reward contract.
     "exit_potential_mode": "canonical",
     "exit_potential_decay": 0.5,
     # Hold potential (PBRS function Φ)
@@ -216,8 +242,8 @@ DEFAULT_MODEL_REWARD_PARAMETERS_HELP: dict[str, str] = {
     "exit_factor_threshold": "Warn if |exit_factor| exceeds",
     # PBRS parameters
     "potential_gamma": "PBRS discount γ (0-1)",
-    "exit_potential_mode": "Exit potential mode (canonical|non_canonical|progressive_release|spike_cancel|retain_previous)",
-    "exit_potential_decay": "Decay for progressive_release (0-1)",
+    "exit_potential_mode": "Exit potential mode (canonical only)",
+    "exit_potential_decay": "Deprecated legacy exit-potential decay (no-op)",
     "hold_potential_enabled": "Enable hold potential Φ",
     "hold_potential_ratio": "Hold potential ratio",
     "hold_potential_gain": "Hold potential gain",
@@ -594,6 +620,21 @@ def validate_reward_parameters(
     sanitized = dict(params)
     adjustments: dict[str, dict[str, Any]] = {}
 
+    exit_mode = _get_str_param(sanitized, "exit_potential_mode", "canonical")
+    if exit_mode != "canonical":
+        if strict:
+            raise ValueError(
+                "Param: exit_potential_mode must be 'canonical' for the economic reward, "
+                f"got {exit_mode!r}"
+            )
+        sanitized["exit_potential_mode"] = "canonical"
+        adjustments["exit_potential_mode"] = {
+            "original": exit_mode,
+            "adjusted": "canonical",
+            "reason": "canonical_only",
+            "validation_mode": "strict" if strict else "relaxed",
+        }
+
     # Boolean parameter coercion
     _bool_keys = [
         "check_invariants",
@@ -615,6 +656,46 @@ def validate_reward_parameters(
                     "reason": "bool_coerce",
                     "validation_mode": "strict" if strict else "relaxed",
                 },
+            )
+
+    for additive_key in ("entry_additive_enabled", "exit_additive_enabled"):
+        if not _get_bool_param(sanitized, additive_key, False):
+            continue
+        if strict:
+            raise ValueError(
+                f"Param: {additive_key} is incompatible with canonical PBRS and must be false"
+            )
+        original_val = sanitized[additive_key]
+        sanitized[additive_key] = False
+        adjustments[additive_key] = {
+            "original": original_val,
+            "adjusted": False,
+            "reason": "canonical_pbrs_suppresses_additives",
+            "validation_mode": "relaxed",
+        }
+
+    if _get_bool_param(sanitized, "hold_potential_enabled", False):
+        gamma = _get_float_param(
+            sanitized,
+            "potential_gamma",
+            POTENTIAL_GAMMA_DEFAULT,
+        )
+        if not np.isfinite(gamma) or not (0.0 < gamma <= 1.0):
+            raise ValueError(
+                "Param: potential_gamma must be finite and in (0, 1] when "
+                "hold_potential_enabled=True"
+            )
+        profit_aim = _get_float_param(sanitized, "profit_aim", np.nan)
+        risk_reward_ratio = _get_float_param(
+            sanitized,
+            "risk_reward_ratio",
+            _get_float_param(sanitized, "rr", np.nan),
+        )
+        pnl_target = profit_aim * risk_reward_ratio
+        if not np.isfinite(pnl_target) or pnl_target <= 0.0:
+            raise ValueError(
+                "Param: profit_aim * risk_reward_ratio must be finite and positive "
+                "when hold_potential_enabled=True"
             )
 
     # Coerce and clamp numeric-bounded parameters
@@ -3229,49 +3310,18 @@ def _compute_exit_additive(
 
 
 def _compute_exit_potential(prev_potential: float, params: RewardParams) -> float:
-    """Exit potential per mode (canonical/non_canonical -> 0; others transform Φ(prev))."""
+    """Release all potential at exit as required by canonical PBRS."""
     mode = _get_str_param(params, "exit_potential_mode")
-    if mode == "canonical" or mode == "non_canonical":
-        return _fail_safely("canonical_exit_potential")
-
-    if mode == "progressive_release":
-        decay = _get_float_param(params, "exit_potential_decay")
-        if not np.isfinite(decay) or decay < 0.0:
-            warnings.warn(
-                f"PBRS: exit_potential_decay={decay} invalid or < 0; falling back to 0.0",
-                RewardDiagnosticsWarning,
-                stacklevel=2,
-            )
-            decay = 0.0
-        if decay > 1.0:
-            warnings.warn(
-                f"PBRS: exit_potential_decay={decay} > 1; falling back to 1.0",
-                RewardDiagnosticsWarning,
-                stacklevel=2,
-            )
-            decay = 1.0
-        next_potential = prev_potential * (1.0 - decay)
-    elif mode == "spike_cancel":
-        gamma = _get_potential_gamma(params)
-        if gamma <= 0.0 or not np.isfinite(gamma):
-            next_potential = prev_potential
-        else:
-            next_potential = prev_potential / gamma
-    elif mode == "retain_previous":
-        next_potential = prev_potential
-    else:
+    if mode != "canonical":
         _warn_unknown_mode(
             "exit_potential_mode",
             mode,
             sorted(ALLOWED_EXIT_POTENTIAL_MODES),
-            "canonical (via _fail_safely)",
+            "canonical",
             stacklevel=2,
         )
-        next_potential = _fail_safely("invalid_exit_potential_mode")
-
-    if not np.isfinite(next_potential):
-        next_potential = _fail_safely("non_finite_next_exit_potential")
-    return float(next_potential)
+    _ = prev_potential
+    return 0.0
 
 
 def compute_pbrs_components(
@@ -3301,7 +3351,7 @@ def compute_pbrs_components(
     R'(s,a,s') = R(s,a,s') + Δ(s,a,s') + entry_additive + exit_additive
 
     where:
-        Δ(s,a,s') = γ·Φ(s') - Φ(s)  (PBRS shaping term)
+        Delta(s,a,s') = gamma * Phi(s') - Phi(s)  (PBRS shaping term)
 
     Hold Potential Formula
     ----------------------
@@ -3321,8 +3371,8 @@ def compute_pbrs_components(
     tuple[float, float, float, float, float]
         (reward_shaping, next_potential, pbrs_delta, entry_additive, exit_additive)
 
-        - reward_shaping: Δ(s,a,s') = γ·Φ(s') - Φ(s), the PBRS shaping term
-        - next_potential: Φ(s'), the potential function value for next state
+        - reward_shaping: Delta(s,a,s') = gamma * Phi(s') - Phi(s), the PBRS shaping term
+        - next_potential: Phi(s'), the potential function value for next state
         - pbrs_delta: Same as reward_shaping (kept for backward compatibility)
         - entry_additive: Optional non-PBRS entry bonus (0.0 if disabled or not entry)
         - exit_additive: Optional non-PBRS exit bonus (0.0 if disabled or not exit)
@@ -3330,7 +3380,7 @@ def compute_pbrs_components(
     Notes
     -----
     In canonical mode (exit_potential_mode='canonical'), entry_additive and exit_additive
-    are forced to 0.0 to preserve PBRS policy invariance.
+    are forced to 0.0 to satisfy the canonical PBRS algebraic configuration.
     """
     gamma = _get_potential_gamma(params)
 


### PR DESCRIPTION
Atomic PR 2/10 of the reward_space_analysis economic-contract split (source: #120, unit u10).

**What**: Restrict potential-based reward shaping to the canonical mode and formally inventory the parameters the economic contract no longer honors.
- `ExitPotentialMode = Literal['canonical']`; `ALLOWED_EXIT_POTENTIAL_MODES = {'canonical'}`.
- New `DEPRECATED_REWARD_PARAMETERS` frozenset (idle/hold/exit-attenuation/efficiency/win_reward_factor/amplification/additives/entry_fee_rate/exit_fee_rate).
- `_compute_exit_potential()` collapses non-canonical branches to release-all (returns 0.0).
- `validate_reward_parameters()` gains canonical-only guard (strict raise / relaxed normalize + adjustment record), additive-incompatibility guard, and hold_potential gamma/pnl_target validation.
- `compute_pbrs_components` docstring de-unicode; default/help comments reflect canonical-only.

**Scope**: `reward_space_analysis.py` only.

**Stack position**: base `atomic/rsa-01-fee-rate`; 2 of 10.

Verified: `python -m py_compile` clean; ruff check/format under project config introduce no new findings vs the main baseline (pre-existing RUF002 gamma-docstring noise strictly reduced).