### PR TITLE
feat(reward-space-analysis): compute economic net-log-liquidation reward and breakdown (3/10)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -33,523 +33,523 @@
     },
     {
       "endCharacter": 5,
-      "endLine": 1976,
+      "endLine": 1950,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"cut\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 1971
+      "startLine": 1945
     },
     {
       "endCharacter": 21,
-      "endLine": 1973,
+      "endLine": 1947,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"_Array1D[Any]\" cannot be assigned to parameter \"bins\" of type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\" in function \"cut\"\n  Type \"_Array1D[Any]\" is not assignable to type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"int\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Sequence[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[int]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"IntervalIndex[Interval[Any]]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Series[Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1973
+      "startLine": 1947
     },
     {
       "endCharacter": 5,
-      "endLine": 1998,
+      "endLine": 1972,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 1994
+      "startLine": 1968
     },
     {
       "endCharacter": 43,
-      "endLine": 1995,
+      "endLine": 1969,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1995
+      "startLine": 1969
     },
     {
       "endCharacter": 42,
-      "endLine": 1995,
+      "endLine": 1969,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1995
+      "startLine": 1969
     },
     {
       "endCharacter": 60,
-      "endLine": 2254,
+      "endLine": 2228,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_mean\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 2254
+      "startLine": 2228
     },
     {
       "endCharacter": 58,
-      "endLine": 2255,
+      "endLine": 2229,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_std\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_std\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2255
+      "startLine": 2229
     },
     {
       "endCharacter": 88,
-      "endLine": 2274,
+      "endLine": 2248,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"NDArray[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2274
+      "startLine": 2248
     },
     {
       "endCharacter": 88,
-      "endLine": 2274,
+      "endLine": 2248,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"list[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2274
+      "startLine": 2248
     },
     {
       "endCharacter": 17,
-      "endLine": 2283,
+      "endLine": 2257,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Object of type \"None\" cannot be called",
       "rule": "reportOptionalCall",
       "severity": "error",
       "startCharacter": 28,
-      "startLine": 2277
+      "startLine": 2251
     },
     {
       "endCharacter": 40,
-      "endLine": 2497,
+      "endLine": 2471,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2497
+      "startLine": 2471
     },
     {
       "endCharacter": 38,
-      "endLine": 2497,
+      "endLine": 2471,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2497
+      "startLine": 2471
     },
     {
       "endCharacter": 59,
-      "endLine": 2497,
+      "endLine": 2471,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2497
+      "startLine": 2471
     },
     {
       "endCharacter": 57,
-      "endLine": 2497,
+      "endLine": 2471,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2497
+      "startLine": 2471
     },
     {
       "endCharacter": 40,
-      "endLine": 2498,
+      "endLine": 2472,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2498
+      "startLine": 2472
     },
     {
       "endCharacter": 38,
-      "endLine": 2498,
+      "endLine": 2472,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2498
+      "startLine": 2472
     },
     {
       "endCharacter": 59,
-      "endLine": 2498,
+      "endLine": 2472,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2498
+      "startLine": 2472
     },
     {
       "endCharacter": 57,
-      "endLine": 2498,
+      "endLine": 2472,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2498
+      "startLine": 2472
     },
     {
       "endCharacter": 76,
-      "endLine": 2518,
+      "endLine": 2492,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 24,
-      "startLine": 2518
+      "startLine": 2492
     },
     {
       "endCharacter": 49,
-      "endLine": 2518,
+      "endLine": 2492,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2518
+      "startLine": 2492
     },
     {
       "endCharacter": 74,
-      "endLine": 2519,
+      "endLine": 2493,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2519
+      "startLine": 2493
     },
     {
       "endCharacter": 47,
-      "endLine": 2519,
+      "endLine": 2493,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 2519
+      "startLine": 2493
     },
     {
       "endCharacter": 51,
-      "endLine": 2534,
+      "endLine": 2508,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"u_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2534
+      "startLine": 2508
     },
     {
       "endCharacter": 64,
-      "endLine": 2534,
+      "endLine": 2508,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"v_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 53,
-      "startLine": 2534
+      "startLine": 2508
     },
     {
       "endCharacter": 68,
-      "endLine": 2537,
+      "endLine": 2511,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ks_2samp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 27,
-      "startLine": 2537
+      "startLine": 2511
     },
     {
       "endCharacter": 54,
-      "endLine": 2537,
+      "endLine": 2511,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data1\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2537
+      "startLine": 2511
     },
     {
       "endCharacter": 67,
-      "endLine": 2537,
+      "endLine": 2511,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data2\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 2537
+      "startLine": 2511
     },
     {
       "endCharacter": 26,
-      "endLine": 2807,
+      "endLine": 2781,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"size\" for class \"ExtensionArray\"\n  Attribute \"size\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2807
+      "startLine": 2781
     },
     {
       "endCharacter": 29,
-      "endLine": 2809,
+      "endLine": 2783,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ptp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 11,
-      "startLine": 2809
+      "startLine": 2783
     },
     {
       "endCharacter": 28,
-      "endLine": 2809,
+      "endLine": 2783,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"ptp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 2809
+      "startLine": 2783
     },
     {
       "endCharacter": 65,
-      "endLine": 2822,
+      "endLine": 2796,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"Categorical[object]\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2822
+      "startLine": 2796
     },
     {
       "endCharacter": 65,
-      "endLine": 2822,
+      "endLine": 2796,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"ExtensionArray\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2822
+      "startLine": 2796
     },
     {
       "endCharacter": 56,
-      "endLine": 2902,
+      "endLine": 2876,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"mean\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2902
+      "startLine": 2876
     },
     {
       "endCharacter": 55,
-      "endLine": 2902,
+      "endLine": 2876,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"mean\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 51,
-      "startLine": 2902
+      "startLine": 2876
     },
     {
       "endCharacter": 62,
-      "endLine": 2903,
+      "endLine": 2877,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"std\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2903
+      "startLine": 2877
     },
     {
       "endCharacter": 53,
-      "endLine": 2903,
+      "endLine": 2877,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"std\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 2903
+      "startLine": 2877
     },
     {
       "endCharacter": 39,
-      "endLine": 2904,
+      "endLine": 2878,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"skew\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2904
+      "startLine": 2878
     },
     {
       "endCharacter": 38,
-      "endLine": 2904,
+      "endLine": 2878,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"skew\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 2904
+      "startLine": 2878
     },
     {
       "endCharacter": 56,
-      "endLine": 2905,
+      "endLine": 2879,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"kurtosis\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2905
+      "startLine": 2879
     },
     {
       "endCharacter": 42,
-      "endLine": 2905,
+      "endLine": 2879,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"kurtosis\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2905
+      "startLine": 2879
     },
     {
       "endCharacter": 50,
-      "endLine": 2916,
+      "endLine": 2890,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"shapiro\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 2916
+      "startLine": 2890
     },
     {
       "endCharacter": 49,
-      "endLine": 2916,
+      "endLine": 2890,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"shapiro\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 2916
+      "startLine": 2890
     },
     {
       "endCharacter": 39,
-      "endLine": 2921,
+      "endLine": 2895,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloatND\" in function \"anderson\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2921
+      "startLine": 2895
     },
     {
       "endCharacter": 61,
-      "endLine": 2928,
+      "endLine": 2902,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"probplot\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 57,
-      "startLine": 2928
+      "startLine": 2902
     },
     {
       "endCharacter": 17,
-      "endLine": 3726,
+      "endLine": 3700,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3726
+      "startLine": 3700
     },
     {
       "endCharacter": 5,
-      "endLine": 3730,
+      "endLine": 3704,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3726
+      "startLine": 3700
     },
     {
       "endCharacter": 43,
-      "endLine": 3727,
+      "endLine": 3701,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3727
+      "startLine": 3701
     },
     {
       "endCharacter": 42,
-      "endLine": 3727,
+      "endLine": 3701,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3727
+      "startLine": 3701
     },
     {
       "endCharacter": 9,
-      "endLine": 3873,
+      "endLine": 3847,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3869
+      "startLine": 3843
     },
     {
       "endCharacter": 47,
-      "endLine": 3870,
+      "endLine": 3844,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3870
+      "startLine": 3844
     },
     {
       "endCharacter": 46,
-      "endLine": 3870,
+      "endLine": 3844,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3870
+      "startLine": 3844
     },
     {
       "endCharacter": 14,
-      "endLine": 4609,
+      "endLine": 4583,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4609
+      "startLine": 4583
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -1,8 +1,8 @@
 #!/usr/bin/env python3
-"""Synthetic reward space analysis utilities for ReforceXY.
+"""Synthetic analysis of ReforceXY's pair-local economic reward.
 
-Implements sample generation, reward computation with PBRS, statistical analysis,
-and feature importance calculation with reproducible parameter hashing.
+The reference reward is the scaled log change in a fee-aware liquidation value.
+Optional shaping is restricted to canonical potential-based reward shaping (PBRS).
 """
 
 from __future__ import annotations
@@ -852,7 +852,10 @@ class RewardContext:
     Attributes
     ----------
     current_pnl : float
-        Unrealized PnL at the current tick (state s').
+        Fee-aware liquidation PnL observable in state s.
+    next_pnl : float | None
+        Fee-aware transition PnL at the causal fill/mark for s'. ``None`` keeps
+        the compatibility fallback used by direct analytical API callers.
     """
 
     current_pnl: float
@@ -862,11 +865,15 @@ class RewardContext:
     min_unrealized_profit: float
     position: Positions
     action: Actions
+    previous_liquidation_value: float = 1.0
+    next_pnl: float | None = None
+    next_trade_duration: int | None = None
 
 
 @dataclasses.dataclass
 class RewardBreakdown:
     total: float = 0.0
+    economic_component: float = 0.0
     invalid_penalty: float = 0.0
     idle_penalty: float = 0.0
     hold_penalty: float = 0.0
@@ -881,6 +888,13 @@ class RewardBreakdown:
     base_reward: float = 0.0
     pbrs_delta: float = 0.0  # Δ(s,a,s') = γ·Φ(s') - Φ(s)
     invariance_correction: float = 0.0
+    previous_liquidation_value: float = 1.0
+    reward_liquidation_value: float = 1.0
+    next_liquidation_value: float = 1.0
+    economic_ruin: bool = False
+    terminated: bool = False
+    truncated: bool = False
+    invalid_action: bool = False
 
 
 def _compute_time_attenuation_coefficient(
@@ -1270,240 +1284,200 @@ def calculate_reward(
     action_masking: bool,
     prev_potential: float = np.nan,
 ) -> RewardBreakdown:
-    """Calculate complete reward with base reward and PBRS shaping.
+    """Return the economic reward and optional canonical PBRS diagnostics.
 
-    This function computes the full reward pipeline including base reward calculation,
-    PBRS (Potential-Based Reward Shaping), and optional additives.
+    The economic component is ``base_factor * log(L_reward / L_previous)``.
+    ``L`` is the pair-local, fee-aware liquidation value. Entry therefore pays
+    the complete simulated round-trip fee immediately, holds recognize the
+    incremental marked-to-liquidation return, exits recognize the final mark,
+    and a neutral self-loop has zero economic reward.
 
-    Reward Formula
-    --------------
-    R'(s,a,s') = R(s,a,s') + Δ(s,a,s') + entry_additive + exit_additive
-
-    where:
-        - R(s,a,s'): Base reward (invalid/idle/hold penalty or exit reward)
-        - Δ(s,a,s'): PBRS delta term = γ·Φ(s') - Φ(s)
-        - entry_additive: Optional entry bonus (disabled in canonical mode)
-        - exit_additive: Optional exit bonus (disabled in canonical mode)
-
-    Parameters
-    ----------
-    context : RewardContext
-        Current reward context (position, action, PnL, duration, etc.)
-    params : RewardParams
-        Reward parameter dictionary with configuration
-    base_factor : float
-        Base scaling factor for reward components
-    profit_aim : float
-        Target profit for normalization
-    risk_reward_ratio : float
-        Risk/reward ratio for trade evaluation
-    short_allowed : bool
-        Whether short positions are permitted
-    action_masking : bool
-        Whether to apply action masking (affects invalid action penalty)
-    prev_potential : float, optional
-        Previous state potential Φ(s), by default np.nan
-
-    Returns
-    -------
-    RewardBreakdown
-        Complete breakdown of reward components including:
-        - total: Final shaped reward R'(s,a,s')
-        - base_reward: R(s,a,s')
-        - reward_shaping: Δ(s,a,s')
-        - entry_additive: Entry bonus
-        - exit_additive: Exit bonus
-        - prev_potential: Φ(s)
-        - next_potential: Φ(s')
-        - pbrs_delta: Same as reward_shaping
-        - And component-specific values (invalid_penalty, idle_penalty, etc.)
-
-    Notes
-    -----
-    This is the reference implementation for the reward calculation used in testing
-    and analysis. It mirrors the logic in ReforceXY.calculate_reward() but returns
-    a detailed breakdown for diagnostic purposes.
+    ``profit_aim`` and ``risk_reward_ratio`` are retained only because FreqAI's
+    base environment and the optional potential function require them. They do
+    not alter the economic component.
     """
     breakdown = RewardBreakdown()
-
     is_valid = _is_valid_action(
         context.position,
         context.action,
         short_allowed=short_allowed,
     )
-
-    base_reward: float | None = None
-    if not is_valid and not action_masking:
-        breakdown.invalid_penalty = _get_float_param(params, "invalid_action")
-        base_reward = breakdown.invalid_penalty
-
-    base_factor = _get_float_param(params, "base_factor", base_factor)
-
-    if "profit_aim" in params:
-        profit_aim = _get_float_param(params, "profit_aim", float(profit_aim))
-
-    if "risk_reward_ratio" in params:
-        risk_reward_ratio = _get_float_param(params, "risk_reward_ratio", float(risk_reward_ratio))
-    elif "rr" in params:
-        risk_reward_ratio = _get_float_param(params, "rr", float(risk_reward_ratio))
-
-    pnl_target = float(profit_aim * risk_reward_ratio)
-
-    idle_factor = base_factor * (profit_aim / risk_reward_ratio)
-    hold_factor = idle_factor
-
-    max_trade_duration_candles = _get_int_param(params, "max_trade_duration_candles")
-    current_duration_ratio = _compute_duration_ratio(
-        context.trade_duration, max_trade_duration_candles
-    )
-
-    # Base reward calculation
-    if base_reward is None:
-        if context.action == Actions.Neutral:
-            if context.position == Positions.Neutral:
-                base_reward = _idle_penalty(context, idle_factor, params)
-                breakdown.idle_penalty = base_reward
-            elif context.position in (Positions.Long, Positions.Short):
-                base_reward = _hold_penalty(context, hold_factor, params)
-                breakdown.hold_penalty = base_reward
-            else:
-                base_reward = 0.0
-        else:
-            is_exit_action = (
-                context.action == Actions.Long_exit and context.position == Positions.Long
-            ) or (context.action == Actions.Short_exit and context.position == Positions.Short)
-            if is_exit_action:
-                base_reward = _compute_exit_reward(
-                    base_factor,
-                    pnl_target,
-                    current_duration_ratio,
-                    context,
-                    params,
-                    risk_reward_ratio,
-                )
-                breakdown.exit_component = base_reward
-            else:
-                base_reward = 0.0
-
-    breakdown.base_reward = float(base_reward)
-
-    # === PBRS INTEGRATION ===
-    current_pnl = context.current_pnl if context.position != Positions.Neutral else 0.0
-
+    breakdown.invalid_action = not is_valid
     next_position = _get_next_position(
-        context.position, context.action, short_allowed=short_allowed
+        context.position,
+        context.action,
+        short_allowed=short_allowed,
     )
     is_entry = context.position == Positions.Neutral and next_position in (
         Positions.Long,
         Positions.Short,
     )
-    is_exit = (
-        context.position
-        in (
-            Positions.Long,
-            Positions.Short,
-        )
-        and next_position == Positions.Neutral
+    is_exit = context.position in (Positions.Long, Positions.Short) and (
+        next_position == Positions.Neutral
     )
-    is_hold = context.position in (
-        Positions.Long,
-        Positions.Short,
-    ) and next_position in (Positions.Long, Positions.Short)
     is_neutral = context.position == Positions.Neutral and next_position == Positions.Neutral
+    base_factor = _get_float_param(params, "base_factor", base_factor)
+    if not np.isfinite(base_factor) or base_factor <= 0.0:
+        raise ValueError(f"Reward: invalid base_factor={base_factor!r}")
 
-    if is_entry:
-        next_duration_ratio = 0.0
-        if context.action == Actions.Long_enter:
-            next_pnl = _compute_unrealized_pnl_estimate(
-                Positions.Long,
-                entry_open=1.0,
-                current_open=1.0,
-                params=params,
-            )
-        elif context.action == Actions.Short_enter:
-            next_pnl = _compute_unrealized_pnl_estimate(
-                Positions.Short,
-                entry_open=1.0,
-                current_open=1.0,
-                params=params,
-            )
-        else:
-            next_pnl = current_pnl
-    elif is_hold:
-        next_duration_ratio = _compute_duration_ratio(
-            context.trade_duration, max_trade_duration_candles
+    previous_liquidation_value = float(context.previous_liquidation_value)
+    if not np.isfinite(previous_liquidation_value) or previous_liquidation_value <= 0.0:
+        raise ValueError(
+            "Reward: previous_liquidation_value must be finite and strictly positive, "
+            f"got {previous_liquidation_value!r}"
         )
-        # Optionally simulate unrealized PnL during holds to feed Φ(s)
-        if _get_bool_param(params, "unrealized_pnl", False):
-            center_unrealized = 0.5 * (
-                context.max_unrealized_profit + context.min_unrealized_profit
+    if context.next_pnl is not None:
+        observable_liquidation_value = (
+            1.0 + float(context.current_pnl)
+            if context.position in (Positions.Long, Positions.Short)
+            else 1.0
+        )
+        if (
+            not np.isfinite(observable_liquidation_value)
+            or observable_liquidation_value <= 0.0
+            or not np.isclose(
+                previous_liquidation_value,
+                observable_liquidation_value,
+                rtol=1e-10,
+                atol=1e-12,
             )
-            beta = _get_float_param(params, "pnl_amplification_sensitivity")
-            next_pnl = float(center_unrealized * math.tanh(beta * next_duration_ratio))
-        else:
-            next_pnl = current_pnl
-    elif is_exit:
-        next_pnl = 0.0
-        next_duration_ratio = 0.0
+        ):
+            raise ValueError(
+                "Reward: previous_liquidation_value must match the liquidation "
+                f"value observable in state s, got carry={previous_liquidation_value!r}, "
+                f"observable={observable_liquidation_value!r}"
+            )
+
+    if context.next_pnl is not None:
+        next_pnl = float(context.next_pnl)
+    elif is_entry:
+        pnl_estimator = (
+            _compute_unrealized_pnl_estimate
+            if _get_bool_param(params, "hold_potential_enabled")
+            else _compute_spot_local_trade_pnl_estimate
+        )
+        next_pnl = pnl_estimator(
+            next_position,
+            entry_open=1.0,
+            current_open=1.0,
+            params=params,
+        )
+    elif context.position in (Positions.Long, Positions.Short):
+        next_pnl = float(context.current_pnl)
     else:
-        next_pnl = current_pnl
-        next_duration_ratio = current_duration_ratio
+        next_pnl = 0.0
 
-    # Apply PBRS only if enabled and not neutral self-loop
-    exit_mode = _get_str_param(params, "exit_potential_mode")
+    if is_entry or context.position in (Positions.Long, Positions.Short):
+        reward_liquidation_value = 1.0 + next_pnl
+        next_liquidation_value = 1.0 if is_exit else reward_liquidation_value
+    else:
+        reward_liquidation_value = 1.0
+        next_liquidation_value = 1.0
 
-    hold_potential_enabled = _get_bool_param(params, "hold_potential_enabled")
-    entry_additive_enabled = (
-        False if exit_mode == "canonical" else _get_bool_param(params, "entry_additive_enabled")
-    )
-    exit_additive_enabled = (
-        False if exit_mode == "canonical" else _get_bool_param(params, "exit_additive_enabled")
-    )
-
-    pbrs_enabled = bool(hold_potential_enabled or entry_additive_enabled or exit_additive_enabled)
-
-    if pbrs_enabled:
-        # Stored potential carried across steps.
-        prev_potential = float(prev_potential) if np.isfinite(prev_potential) else 0.0
-
-        if is_neutral:
-            # Neutral self-loop keeps stored potential unchanged.
-            breakdown.prev_potential = prev_potential
-            breakdown.next_potential = prev_potential
-            breakdown.total = base_reward
-            return breakdown
-
-        reward_shaping, next_potential, pbrs_delta, entry_additive, exit_additive = (
-            compute_pbrs_components(
-                current_pnl=current_pnl,
-                pnl_target=pnl_target,
-                current_duration_ratio=current_duration_ratio,
-                next_pnl=next_pnl,
-                next_duration_ratio=next_duration_ratio,
-                is_exit=is_exit,
-                is_entry=is_entry,
-                prev_potential=prev_potential,
-                params=params,
-                risk_reward_ratio=risk_reward_ratio,
-                base_factor=base_factor,
-            )
+    if not np.isfinite(reward_liquidation_value):
+        raise ValueError(
+            f"Reward: reward_liquidation_value must be finite, got {reward_liquidation_value!r}"
         )
+    if reward_liquidation_value <= 0.0:
+        breakdown.economic_ruin = True
+        breakdown.terminated = True
+        reward_liquidation_value = MIN_LIQUIDATION_VALUE
+        if not is_exit:
+            next_liquidation_value = reward_liquidation_value
 
-        breakdown.reward_shaping = reward_shaping
-        breakdown.prev_potential = prev_potential
-        breakdown.next_potential = next_potential
-        breakdown.entry_additive = entry_additive
-        breakdown.exit_additive = exit_additive
-        breakdown.pbrs_delta = pbrs_delta
-        breakdown.invariance_correction = reward_shaping - pbrs_delta
-        breakdown.total = base_reward + reward_shaping + entry_additive + exit_additive
-        return breakdown
+    economic_component = base_factor * (
+        math.log(reward_liquidation_value) - math.log(previous_liquidation_value)
+    )
+    if not np.isfinite(economic_component):
+        raise RuntimeError("Reward: economic reward is not finite")
+    breakdown.economic_component = float(economic_component)
+    breakdown.previous_liquidation_value = previous_liquidation_value
+    breakdown.reward_liquidation_value = float(reward_liquidation_value)
+    breakdown.next_liquidation_value = float(next_liquidation_value)
+    if is_exit:
+        # Compatibility diagnostic: this is no longer a sparse exit reward.
+        breakdown.exit_component = float(economic_component)
+
+    if not is_valid and not action_masking:
+        breakdown.invalid_penalty = _get_float_param(params, "invalid_action")
+        if not np.isfinite(breakdown.invalid_penalty):
+            raise ValueError("Reward: invalid_action reward must be finite")
+
+    breakdown.base_reward = float(economic_component + breakdown.invalid_penalty)
+
+    if "profit_aim" in params:
+        profit_aim = _get_float_param(params, "profit_aim", float(profit_aim))
+    if "risk_reward_ratio" in params:
+        risk_reward_ratio = _get_float_param(
+            params,
+            "risk_reward_ratio",
+            float(risk_reward_ratio),
+        )
+    elif "rr" in params:
+        risk_reward_ratio = _get_float_param(params, "rr", float(risk_reward_ratio))
 
     prev_potential = float(prev_potential) if np.isfinite(prev_potential) else 0.0
     breakdown.prev_potential = prev_potential
     breakdown.next_potential = prev_potential
-    breakdown.total = base_reward
 
+    hold_potential_enabled = _get_bool_param(params, "hold_potential_enabled")
+    if hold_potential_enabled:
+        gamma = _get_float_param(params, "potential_gamma", POTENTIAL_GAMMA_DEFAULT)
+        if not np.isfinite(gamma) or not (0.0 < gamma <= 1.0):
+            raise ValueError(
+                "Reward: potential_gamma must be finite and in (0, 1] when PBRS is active"
+            )
+        max_trade_duration_candles = _get_int_param(params, "max_trade_duration_candles")
+        current_duration_ratio = _compute_duration_ratio(
+            context.trade_duration,
+            max_trade_duration_candles,
+        )
+        next_trade_duration = (
+            context.next_trade_duration
+            if context.next_trade_duration is not None
+            else (0 if is_entry or is_exit else context.trade_duration)
+        )
+        next_duration_ratio = (
+            0.0
+            if is_exit
+            else _compute_duration_ratio(
+                next_trade_duration,
+                max_trade_duration_candles,
+            )
+        )
+        pnl_target = float(profit_aim * risk_reward_ratio)
+        if not np.isfinite(pnl_target) or pnl_target <= 0.0:
+            raise ValueError(
+                "Reward: profit_aim * risk_reward_ratio must be finite and positive "
+                "when PBRS is active"
+            )
+        if not is_neutral:
+            reward_shaping, next_potential, pbrs_delta, _, _ = compute_pbrs_components(
+                current_pnl=float(context.current_pnl),
+                pnl_target=pnl_target,
+                current_duration_ratio=current_duration_ratio,
+                next_pnl=0.0 if is_exit else next_pnl,
+                next_duration_ratio=next_duration_ratio,
+                is_exit=is_exit,
+                is_entry=is_entry,
+                prev_potential=prev_potential,
+                params={**params, "exit_potential_mode": "canonical"},
+                risk_reward_ratio=risk_reward_ratio,
+                base_factor=base_factor,
+            )
+            breakdown.reward_shaping = reward_shaping
+            breakdown.next_potential = next_potential
+            breakdown.pbrs_delta = pbrs_delta
+            breakdown.invariance_correction = reward_shaping - pbrs_delta
+
+    if breakdown.terminated:
+        terminal_reward_shaping = -prev_potential if hold_potential_enabled else 0.0
+        breakdown.reward_shaping = terminal_reward_shaping
+        breakdown.next_potential = 0.0
+        breakdown.pbrs_delta = terminal_reward_shaping
+        breakdown.invariance_correction = 0.0
+
+    breakdown.total = breakdown.base_reward + breakdown.reward_shaping
     return breakdown
 
 


### PR DESCRIPTION
Atomic PR 3/10 of the reward_space_analysis economic-contract split (source: #120, unit u11).

**What**: Rewrite the reference `calculate_reward()` to the economic net-log-liquidation contract, mirroring `MyRLEnv.calculate_reward` for testing.
- Economic component `base_factor * (log(L_reward) - log(L_previous))`, with carry-vs-observable liquidation validation and `MIN_LIQUIDATION_VALUE` floor triggering `economic_ruin`/`terminated`.
- PnL estimator selection: spot `LocalTrade` mirror vs legacy BaseEnvironment estimate when `hold_potential_enabled`.
- `invalid_penalty` addition; terminal PBRS potential release.
- `RewardContext` gains `previous_liquidation_value`/`next_pnl`/`next_trade_duration`; `RewardBreakdown` gains `economic_component`, liquidation values, `economic_ruin`/`terminated`/`truncated`/`invalid_action`.
- Module docstring updated to describe the fee-aware liquidation-value reward.

**Scope**: `reward_space_analysis.py` only. Depends on B1 (fee/estimator) and B2 (canonical PBRS).

**Stack position**: base `atomic/rsa-02-canonical-pbrs`; 3 of 10.

Verified: `python -m py_compile` clean; ruff check/format clean under project config.