### PR TITLE
refactor(reward-space-analysis): rewrite simulator to causal transition trajectory (4/10)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -33,523 +33,523 @@
     },
     {
       "endCharacter": 5,
-      "endLine": 1950,
+      "endLine": 1994,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"cut\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 1945
+      "startLine": 1989
     },
     {
       "endCharacter": 21,
-      "endLine": 1947,
+      "endLine": 1991,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"_Array1D[Any]\" cannot be assigned to parameter \"bins\" of type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\" in function \"cut\"\n  Type \"_Array1D[Any]\" is not assignable to type \"int | Sequence[float] | Index[int] | Index[float] | IntervalIndex[Interval[Any]] | Series[Any]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"int\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Sequence[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[int]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Index[float]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"IntervalIndex[Interval[Any]]\"\n    \"ndarray[tuple[int], dtype[Any]]\" is not assignable to \"Series[Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1947
+      "startLine": 1991
     },
     {
       "endCharacter": 5,
-      "endLine": 1972,
+      "endLine": 2016,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 1968
+      "startLine": 2012
     },
     {
       "endCharacter": 43,
-      "endLine": 1969,
+      "endLine": 2013,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1969
+      "startLine": 2013
     },
     {
       "endCharacter": 42,
-      "endLine": 1969,
+      "endLine": 2013,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 1969
+      "startLine": 2013
     },
     {
       "endCharacter": 60,
-      "endLine": 2228,
+      "endLine": 2272,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_mean\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 44,
-      "startLine": 2228
+      "startLine": 2272
     },
     {
       "endCharacter": 58,
-      "endLine": 2229,
+      "endLine": 2273,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"importances_std\" for class \"dict[Unknown, Bunch]\"\n  Attribute \"importances_std\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2229
+      "startLine": 2273
     },
     {
       "endCharacter": 88,
-      "endLine": 2248,
+      "endLine": 2292,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"NDArray[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2248
+      "startLine": 2292
     },
     {
       "endCharacter": 88,
-      "endLine": 2248,
+      "endLine": 2292,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"columns\" for class \"list[Unknown]\"\n  Attribute \"columns\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 81,
-      "startLine": 2248
+      "startLine": 2292
     },
     {
       "endCharacter": 17,
-      "endLine": 2257,
+      "endLine": 2301,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Object of type \"None\" cannot be called",
       "rule": "reportOptionalCall",
       "severity": "error",
       "startCharacter": 28,
-      "startLine": 2251
+      "startLine": 2295
     },
     {
       "endCharacter": 40,
-      "endLine": 2471,
+      "endLine": 2515,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2471
+      "startLine": 2515
     },
     {
       "endCharacter": 38,
-      "endLine": 2471,
+      "endLine": 2515,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2471
+      "startLine": 2515
     },
     {
       "endCharacter": 59,
-      "endLine": 2471,
+      "endLine": 2515,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@min\" in function \"min\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2471
+      "startLine": 2515
     },
     {
       "endCharacter": 57,
-      "endLine": 2471,
+      "endLine": 2515,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"min\" for class \"ExtensionArray\"\n  Attribute \"min\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2471
+      "startLine": 2515
     },
     {
       "endCharacter": 40,
-      "endLine": 2472,
+      "endLine": 2516,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg1\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2472
+      "startLine": 2516
     },
     {
       "endCharacter": 38,
-      "endLine": 2472,
+      "endLine": 2516,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2472
+      "startLine": 2516
     },
     {
       "endCharacter": 59,
-      "endLine": 2472,
+      "endLine": 2516,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | object | NAType | Unknown\" cannot be assigned to parameter \"arg2\" of type \"SupportsRichComparisonT@max\" in function \"max\"\n  Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n    Type \"Any | object | NAType | Unknown\" is not assignable to type \"SupportsRichComparison\"\n      Type \"object\" is not assignable to type \"SupportsRichComparison\"\n        \"object\" is incompatible with protocol \"SupportsDunderLT[Any]\"\n          \"__lt__\" is not present\n        \"object\" is incompatible with protocol \"SupportsDunderGT[Any]\"\n          \"__gt__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2472
+      "startLine": 2516
     },
     {
       "endCharacter": 57,
-      "endLine": 2472,
+      "endLine": 2516,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"max\" for class \"ExtensionArray\"\n  Attribute \"max\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 54,
-      "startLine": 2472
+      "startLine": 2516
     },
     {
       "endCharacter": 76,
-      "endLine": 2492,
+      "endLine": 2536,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 24,
-      "startLine": 2492
+      "startLine": 2536
     },
     {
       "endCharacter": 49,
-      "endLine": 2492,
+      "endLine": 2536,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2492
+      "startLine": 2536
     },
     {
       "endCharacter": 74,
-      "endLine": 2493,
+      "endLine": 2537,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"histogram\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2493
+      "startLine": 2537
     },
     {
       "endCharacter": 47,
-      "endLine": 2493,
+      "endLine": 2537,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeComplex_co\" in function \"histogram\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeComplex_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeComplex_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[numpy.bool[builtins.bool] | number[Any, Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 2493
+      "startLine": 2537
     },
     {
       "endCharacter": 51,
-      "endLine": 2508,
+      "endLine": 2552,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"u_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2508
+      "startLine": 2552
     },
     {
       "endCharacter": 64,
-      "endLine": 2508,
+      "endLine": 2552,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"v_values\" of type \"ToFloatND\" in function \"wasserstein_distance\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 53,
-      "startLine": 2508
+      "startLine": 2552
     },
     {
       "endCharacter": 68,
-      "endLine": 2511,
+      "endLine": 2555,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ks_2samp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 27,
-      "startLine": 2511
+      "startLine": 2555
     },
     {
       "endCharacter": 54,
-      "endLine": 2511,
+      "endLine": 2555,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data1\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2511
+      "startLine": 2555
     },
     {
       "endCharacter": 67,
-      "endLine": 2511,
+      "endLine": 2555,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"data2\" of type \"ToFloatND\" in function \"ks_2samp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 2511
+      "startLine": 2555
     },
     {
       "endCharacter": 26,
-      "endLine": 2781,
+      "endLine": 2825,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"size\" for class \"ExtensionArray\"\n  Attribute \"size\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 22,
-      "startLine": 2781
+      "startLine": 2825
     },
     {
       "endCharacter": 29,
-      "endLine": 2783,
+      "endLine": 2827,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"ptp\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 11,
-      "startLine": 2783
+      "startLine": 2827
     },
     {
       "endCharacter": 28,
-      "endLine": 2783,
+      "endLine": 2827,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"ptp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 2783
+      "startLine": 2827
     },
     {
       "endCharacter": 65,
-      "endLine": 2796,
+      "endLine": 2840,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"Categorical[object]\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2796
+      "startLine": 2840
     },
     {
       "endCharacter": 65,
-      "endLine": 2796,
+      "endLine": 2840,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Cannot access attribute \"mean\" for class \"ExtensionArray\"\n  Attribute \"mean\" is unknown",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 61,
-      "startLine": 2796
+      "startLine": 2840
     },
     {
       "endCharacter": 56,
-      "endLine": 2876,
+      "endLine": 2920,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"mean\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2876
+      "startLine": 2920
     },
     {
       "endCharacter": 55,
-      "endLine": 2876,
+      "endLine": 2920,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"mean\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 51,
-      "startLine": 2876
+      "startLine": 2920
     },
     {
       "endCharacter": 62,
-      "endLine": 2877,
+      "endLine": 2921,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"std\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2877
+      "startLine": 2921
     },
     {
       "endCharacter": 53,
-      "endLine": 2877,
+      "endLine": 2921,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"std\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 2877
+      "startLine": 2921
     },
     {
       "endCharacter": 39,
-      "endLine": 2878,
+      "endLine": 2922,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"skew\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2878
+      "startLine": 2922
     },
     {
       "endCharacter": 38,
-      "endLine": 2878,
+      "endLine": 2922,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"skew\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 2878
+      "startLine": 2922
     },
     {
       "endCharacter": 56,
-      "endLine": 2879,
+      "endLine": 2923,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"kurtosis\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2879
+      "startLine": 2923
     },
     {
       "endCharacter": 42,
-      "endLine": 2879,
+      "endLine": 2923,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"kurtosis\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2879
+      "startLine": 2923
     },
     {
       "endCharacter": 50,
-      "endLine": 2890,
+      "endLine": 2934,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"shapiro\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 2890
+      "startLine": 2934
     },
     {
       "endCharacter": 49,
-      "endLine": 2890,
+      "endLine": 2934,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"shapiro\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 2890
+      "startLine": 2934
     },
     {
       "endCharacter": 39,
-      "endLine": 2895,
+      "endLine": 2939,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloatND\" in function \"anderson\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2895
+      "startLine": 2939
     },
     {
       "endCharacter": 61,
-      "endLine": 2902,
+      "endLine": 2946,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"probplot\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 57,
-      "startLine": 2902
+      "startLine": 2946
     },
     {
       "endCharacter": 17,
-      "endLine": 3700,
+      "endLine": 3744,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3700
+      "startLine": 3744
     },
     {
       "endCharacter": 5,
-      "endLine": 3704,
+      "endLine": 3748,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3700
+      "startLine": 3744
     },
     {
       "endCharacter": 43,
-      "endLine": 3701,
+      "endLine": 3745,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3701
+      "startLine": 3745
     },
     {
       "endCharacter": 42,
-      "endLine": 3701,
+      "endLine": 3745,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3701
+      "startLine": 3745
     },
     {
       "endCharacter": 9,
-      "endLine": 3847,
+      "endLine": 3891,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3843
+      "startLine": 3887
     },
     {
       "endCharacter": 47,
-      "endLine": 3844,
+      "endLine": 3888,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3844
+      "startLine": 3888
     },
     {
       "endCharacter": 46,
-      "endLine": 3844,
+      "endLine": 3888,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3844
+      "startLine": 3888
     },
     {
       "endCharacter": 14,
-      "endLine": 4583,
+      "endLine": 4627,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4583
+      "startLine": 4627
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -1515,6 +1515,7 @@ _SAMPLE_DURATION_HAZARD_OVERTIME_MULTIPLIER = 4.0
 _SAMPLE_DURATION_HAZARD_MAX_PROBABILITY = 0.9
 _SAMPLE_EXIT_PROBABILITY_MIN = 0.002
 _SAMPLE_EXIT_PROBABILITY_MAX = 0.2
+_SAMPLE_INVALID_ACTION_PROBABILITY = 0.05
 
 
 def _sampling_probabilities(
@@ -1565,6 +1566,7 @@ def _sample_action(
     max_trade_duration_candles: int,
     idle_duration: int,
     max_idle_duration_candles: int,
+    action_masking: bool = True,
 ) -> tuple[Actions, float, float, float]:
     entry_prob, exit_prob, neutral_prob = _sampling_probabilities(
         position,
@@ -1574,6 +1576,15 @@ def _sample_action(
         idle_duration=idle_duration,
         max_idle_duration_candles=max_idle_duration_candles,
     )
+
+    if not action_masking and rng.random() < _SAMPLE_INVALID_ACTION_PROBABILITY:
+        invalid_actions = [
+            action
+            for action in Actions
+            if not _is_valid_action(position, action, short_allowed=short_allowed)
+        ]
+        if invalid_actions:
+            return rng.choice(invalid_actions), entry_prob, exit_prob, neutral_prob
 
     if position == Positions.Neutral:
         if short_allowed:
@@ -1623,31 +1634,26 @@ def simulate_samples(
     """Simulate synthetic samples for reward analysis.
 
     The synthetic generator produces a *coherent trajectory* (state carried across samples)
-    so PJRS/PBRS stored-potential mechanics can be exercised realistically.
+    so liquidation-value and PBRS state can be exercised realistically.
 
-    Notes
-    -----
-    - PnL is a state variable while in position (may be non-zero on holds).
-    - Neutral states always have pnl=0.
-    - Realized PnL appears on the exit step (position still Long/Short).
+    Each row is one causal transition. The row state is marked at the previous
+    close, its action fills at the next open, and a position that remains open
+    is marked at that candle's close. An exit is liquidated at its fill open.
     """
 
     rng = random.Random(seed)
+    resolved_base_factor = _get_float_param(params, "base_factor", base_factor)
     max_trade_duration_candles = _get_int_param(params, "max_trade_duration_candles")
     short_allowed = _is_short_allowed(trading_mode)
     action_masking = _get_bool_param(params, "action_masking", True)
-
-    # Theoretical PBRS invariance flag
-    exit_mode = _get_str_param(params, "exit_potential_mode")
-    entry_enabled_raw = _get_bool_param(params, "entry_additive_enabled")
-    exit_enabled_raw = _get_bool_param(params, "exit_additive_enabled")
-
-    entry_enabled, exit_enabled, _additives_suppressed = _resolve_additive_enablement(
-        exit_mode,
-        entry_enabled_raw,
-        exit_enabled_raw,
+    pnl_estimator = (
+        _compute_unrealized_pnl_estimate
+        if _get_bool_param(params, "hold_potential_enabled")
+        else _compute_spot_local_trade_pnl_estimate
     )
-    pbrs_invariant = bool(exit_mode == "canonical" and not (entry_enabled or exit_enabled))
+
+    # The implemented shaping contract is canonical-only; additives are no-ops.
+    pbrs_invariant = True
 
     max_idle_duration_candles = get_max_idle_duration_candles(
         params, max_trade_duration_candles=max_trade_duration_candles
@@ -1656,6 +1662,8 @@ def simulate_samples(
 
     samples: list[dict[str, float]] = []
     prev_potential: float = 0.0
+    previous_liquidation_value: float = 1.0
+    cumulative_pair_log_return: float = 0.0
 
     # Stateful trajectory variables
     position = Positions.Neutral
@@ -1666,47 +1674,32 @@ def simulate_samples(
     min_unrealized_profit = 0.0
 
     # Synthetic market state
-    current_open = 1.0
-    entry_open = current_open
+    previous_close = 1.0
+    entry_open = previous_close
 
-    for _ in range(num_samples):
-        # Simulate synthetic open-price movement.
+    for sample_index in range(num_samples):
         duration_ratio = (
             _compute_duration_ratio(trade_duration, max_trade_duration_candles)
             if position in (Positions.Long, Positions.Short)
             else 0.0
         )
         open_return_std = pnl_base_std * (1.0 + pnl_duration_vol_scale * duration_ratio)
-        step_return = rng.gauss(0.0, open_return_std)
+        gap_return = rng.gauss(0.0, open_return_std * 0.5)
+        intrabar_return = rng.gauss(0.0, open_return_std * math.sqrt(0.75))
 
-        # Small directional drift so long/short trajectories are not perfectly symmetric
+        # Small directional drift so long/short trajectories are not perfectly symmetric.
         drift = 0.001 * duration_ratio
         if position == Positions.Long:
-            step_return += drift
+            intrabar_return += drift
         elif position == Positions.Short:
-            step_return -= drift
+            intrabar_return -= drift
 
-        if not np.isfinite(step_return):
-            step_return = 0.0
-        step_return = float(np.clip(step_return, -0.95, 0.95))
-
-        current_open = float(max(1e-6, current_open * (1.0 + step_return)))
-
-        # Compute fee-aware unrealized PnL from (entry_open, current_open)
-        if position in (Positions.Long, Positions.Short):
-            pnl = _compute_unrealized_pnl_estimate(
-                position,
-                entry_open=entry_open,
-                current_open=current_open,
-                params=params,
-            )
-            pnl = float(np.clip(pnl, -0.15, 0.15))
-            max_unrealized_profit = max(max_unrealized_profit, pnl)
-            min_unrealized_profit = min(min_unrealized_profit, pnl)
-        else:
-            pnl = 0.0
-            max_unrealized_profit = 0.0
-            min_unrealized_profit = 0.0
+        gap_return = float(np.clip(gap_return, -0.95, 0.95)) if np.isfinite(gap_return) else 0.0
+        intrabar_return = (
+            float(np.clip(intrabar_return, -0.95, 0.95)) if np.isfinite(intrabar_return) else 0.0
+        )
+        fill_open = float(max(1e-6, previous_close * (1.0 + gap_return)))
+        mark_close = float(max(1e-6, fill_open * (1.0 + intrabar_return)))
 
         action, sample_entry_prob, sample_exit_prob, sample_neutral_prob = _sample_action(
             position,
@@ -1716,7 +1709,46 @@ def simulate_samples(
             max_trade_duration_candles=max_trade_duration_candles,
             idle_duration=idle_duration,
             max_idle_duration_candles=max_idle_duration_candles,
+            action_masking=action_masking,
         )
+
+        next_position = _get_next_position(
+            position,
+            action,
+            short_allowed=short_allowed,
+        )
+        is_entry = position == Positions.Neutral and next_position in (
+            Positions.Long,
+            Positions.Short,
+        )
+        is_exit = position in (Positions.Long, Positions.Short) and (
+            next_position == Positions.Neutral
+        )
+        transition_entry_open = fill_open if is_entry else entry_open
+        if is_exit:
+            transition_pnl = pnl_estimator(
+                position,
+                entry_open=entry_open,
+                current_open=fill_open,
+                params=params,
+            )
+        elif next_position in (Positions.Long, Positions.Short):
+            transition_pnl = pnl_estimator(
+                next_position,
+                entry_open=transition_entry_open,
+                current_open=mark_close,
+                params=params,
+            )
+        else:
+            transition_pnl = 0.0
+        transition_pnl = float(transition_pnl)
+
+        if is_entry:
+            next_trade_duration = 1
+        elif next_position in (Positions.Long, Positions.Short):
+            next_trade_duration = min(trade_duration + 1, max_trade_duration_cap)
+        else:
+            next_trade_duration = 0
 
         context = RewardContext(
             current_pnl=pnl,
@@ -1726,6 +1758,9 @@ def simulate_samples(
             min_unrealized_profit=min_unrealized_profit,
             position=position,
             action=action,
+            previous_liquidation_value=previous_liquidation_value,
+            next_pnl=transition_pnl,
+            next_trade_duration=next_trade_duration,
         )
 
         breakdown = calculate_reward(
@@ -1739,11 +1774,19 @@ def simulate_samples(
             prev_potential=prev_potential,
         )
         prev_potential = breakdown.next_potential
+        previous_liquidation_value = breakdown.next_liquidation_value
+        if resolved_base_factor > 0.0:
+            cumulative_pair_log_return += breakdown.economic_component / resolved_base_factor
 
         idle_ratio = context.idle_duration / max(1, max_idle_duration_candles)
+        breakdown.truncated = bool(sample_index == num_samples - 1 and not breakdown.terminated)
         samples.append(
             {
                 "pnl": context.current_pnl,
+                "next_pnl": transition_pnl,
+                "previous_close": previous_close,
+                "fill_open": fill_open,
+                "mark_close": mark_close,
                 "trade_duration": context.trade_duration,
                 "idle_duration": context.idle_duration,
                 "duration_ratio": _compute_duration_ratio(
@@ -1757,6 +1800,7 @@ def simulate_samples(
                 "sample_exit_prob": sample_exit_prob,
                 "sample_neutral_prob": sample_neutral_prob,
                 "reward": breakdown.total,
+                "reward_economic": breakdown.economic_component,
                 "reward_invalid": breakdown.invalid_penalty,
                 "reward_idle": breakdown.idle_penalty,
                 "reward_hold": breakdown.hold_penalty,
@@ -1771,53 +1815,53 @@ def simulate_samples(
                 "reward_base": breakdown.base_reward,
                 "reward_pbrs_delta": breakdown.pbrs_delta,
                 "reward_invariance_correction": breakdown.invariance_correction,
-                "is_invalid": float(breakdown.invalid_penalty != 0.0),
+                "previous_liquidation_value": breakdown.previous_liquidation_value,
+                "reward_liquidation_value": breakdown.reward_liquidation_value,
+                "next_liquidation_value": breakdown.next_liquidation_value,
+                "economic_log_return": (
+                    breakdown.economic_component / resolved_base_factor
+                    if resolved_base_factor > 0.0
+                    else 0.0
+                ),
+                "cumulative_pair_log_return": cumulative_pair_log_return,
+                "synthetic_pair_equity": math.exp(cumulative_pair_log_return),
+                "economic_ruin": bool(breakdown.economic_ruin),
+                "terminated": bool(breakdown.terminated),
+                "truncated": bool(breakdown.truncated),
+                "drawdown_breached": np.nan,
+                "drawdown_breached_available": False,
+                "is_invalid": float(breakdown.invalid_action),
                 "pbrs_invariant": bool(pbrs_invariant),
             }
         )
 
-        # Transition state
-        if position == Positions.Neutral:
-            if action == Actions.Neutral:
-                idle_duration = min(idle_duration + 1, max_idle_duration_candles)
-            elif action == Actions.Long_enter:
-                position = Positions.Long
-                trade_duration = 0
-                idle_duration = 0
-                entry_open = current_open
-                pnl = _compute_unrealized_pnl_estimate(
-                    Positions.Long,
-                    entry_open=entry_open,
-                    current_open=current_open,
-                    params=params,
-                )
-                max_unrealized_profit = pnl
-                min_unrealized_profit = pnl
-            elif action == Actions.Short_enter and short_allowed:
-                position = Positions.Short
-                trade_duration = 0
-                idle_duration = 0
-                entry_open = current_open
-                pnl = _compute_unrealized_pnl_estimate(
-                    Positions.Short,
-                    entry_open=entry_open,
-                    current_open=current_open,
-                    params=params,
-                )
-                max_unrealized_profit = pnl
-                min_unrealized_profit = pnl
+        if breakdown.terminated:
+            break
+
+        # Carry the close-marked post-action state into the next observation.
+        previous_close = mark_close
+        if is_entry:
+            entry_open = fill_open
+            max_unrealized_profit = transition_pnl
+            min_unrealized_profit = transition_pnl
+        elif next_position in (Positions.Long, Positions.Short):
+            max_unrealized_profit = max(max_unrealized_profit, transition_pnl)
+            min_unrealized_profit = min(min_unrealized_profit, transition_pnl)
+        else:
+            max_unrealized_profit = 0.0
+            min_unrealized_profit = 0.0
+
+        if next_position == Positions.Neutral:
+            idle_duration = 0 if is_exit else min(idle_duration + 1, max_idle_duration_candles)
+            pnl = 0.0
         else:
             idle_duration = 0
-            if action == Actions.Neutral:
-                trade_duration = min(trade_duration + 1, max_trade_duration_cap)
-            elif action in (Actions.Long_exit, Actions.Short_exit):
-                position = Positions.Neutral
-                trade_duration = 0
-                idle_duration = 0
-                entry_open = current_open
+            pnl = transition_pnl
+        position = next_position
+        trade_duration = next_trade_duration
 
     df = pd.DataFrame(samples)
-    df.attrs["reward_params"] = dict(params)
+    df.attrs["reward_params"] = {**params, "base_factor": resolved_base_factor}
 
     # Validate critical algorithmic invariants
     _validate_simulation_invariants(df)


### PR DESCRIPTION
Atomic PR 4/10 of the reward_space_analysis economic-contract split (source: #120, unit u12).

**What**: Rewrite `simulate_samples()` to emit one causal transition per row matching the runtime clock.
- Split `gap_return`/`intrabar_return`, `fill_open`/`mark_close`; compute `next_position`/`is_entry`/`is_exit`, `transition_pnl` via the estimator, `next_trade_duration`, `previous_liquidation_value` carry, `cumulative_pair_log_return`/`synthetic_pair_equity`; `terminated` breaks the trajectory, last sample `truncated`.
- `_sample_action()` gains `action_masking` and `_SAMPLE_INVALID_ACTION_PROBABILITY` (0.05) invalid-action injection.
- New CSV columns (next_pnl, previous_close, fill_open, mark_close, reward_economic, liquidation values, economic_log_return, economic_ruin, terminated, truncated, drawdown_breached NaN).

**Scope**: `reward_space_analysis.py` only. Depends on B1/B3 (estimator + economic breakdown).

**Stack position**: base `atomic/rsa-03-economic-reward`; 4 of 10.

Verified: `python -m py_compile` clean; ruff check/format clean under project config.