### PR TITLE
fix(reward-space-analysis): fail-close constant-distribution normality diagnostics (6/10)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -353,203 +353,223 @@
     },
     {
       "endCharacter": 56,
-      "endLine": 2964,
+      "endLine": 2966,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"mean\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 43,
-      "startLine": 2964
+      "startLine": 2966
     },
     {
       "endCharacter": 55,
-      "endLine": 2964,
+      "endLine": 2966,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"mean\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 51,
-      "startLine": 2964
+      "startLine": 2966
     },
     {
       "endCharacter": 62,
-      "endLine": 2965,
+      "endLine": 2967,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"std\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 42,
-      "startLine": 2965
+      "startLine": 2967
     },
     {
       "endCharacter": 53,
-      "endLine": 2965,
+      "endLine": 2967,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"std\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 2965
+      "startLine": 2967
+    },
+    {
+      "endCharacter": 23,
+      "endLine": 2968,
+      "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
+      "message": "No overloads for \"ptp\" match the provided arguments",
+      "rule": "reportCallIssue",
+      "severity": "error",
+      "startCharacter": 11,
+      "startLine": 2968
+    },
+    {
+      "endCharacter": 22,
+      "endLine": 2968,
+      "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
+      "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"_ArrayLikeNumeric_co\" in function \"ptp\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"_ArrayLikeNumeric_co\"\n    Type \"ExtensionArray\" is not assignable to type \"_ArrayLikeNumeric_co\"\n      \"ExtensionArray\" is incompatible with protocol \"_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"_NestedSequence[_SupportsArray[dtype[number[Any, Any] | numpy.bool[builtins.bool] | object_ | timedelta64[Any]]]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 18,
+      "startLine": 2968
     },
     {
       "endCharacter": 39,
-      "endLine": 2966,
+      "endLine": 2995,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"skew\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2966
+      "startLine": 2995
     },
     {
       "endCharacter": 38,
-      "endLine": 2966,
+      "endLine": 2995,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"skew\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 2966
+      "startLine": 2995
     },
     {
       "endCharacter": 56,
-      "endLine": 2967,
+      "endLine": 2996,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"kurtosis\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 23,
-      "startLine": 2967
+      "startLine": 2996
     },
     {
       "endCharacter": 42,
-      "endLine": 2967,
+      "endLine": 2996,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"a\" of type \"ToFloatND\" in function \"kurtosis\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 2967
+      "startLine": 2996
     },
     {
       "endCharacter": 50,
-      "endLine": 2978,
+      "endLine": 3007,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"shapiro\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 2978
+      "startLine": 3007
     },
     {
       "endCharacter": 49,
-      "endLine": 2978,
+      "endLine": 3007,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"shapiro\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 2978
+      "startLine": 3007
     },
     {
       "endCharacter": 39,
-      "endLine": 2983,
+      "endLine": 3013,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloatND\" in function \"anderson\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloatND\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n      \"ExtensionArray\" is incompatible with protocol \"SequenceND[py_float | _CanArray[floating_co]]\"\n        \"__reversed__\" is not present\n        \"count\" is not present\n        \"index\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 2983
+      "startLine": 3013
     },
     {
       "endCharacter": 61,
-      "endLine": 2990,
+      "endLine": 3020,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" cannot be assigned to parameter \"x\" of type \"ToFloat | ToFloatND\" in function \"probplot\"\n  Type \"np_1darray[Any] | ExtensionArray | Categorical[object]\" is not assignable to type \"ToFloat | ToFloatND\"\n    Type \"ExtensionArray\" is not assignable to type \"ToFloat | ToFloatND\"\n      \"ExtensionArray\" is not assignable to \"float\"\n      \"ExtensionArray\" is not assignable to \"floating[Any]\"\n      \"ExtensionArray\" is not assignable to \"integer[Any]\"\n      \"ExtensionArray\" is not assignable to \"numpy.bool[builtins.bool]\"\n      \"ExtensionArray\" is incompatible with protocol \"_CanArrayND[floating_co]\"\n        \"__array__\" is not present\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 57,
-      "startLine": 2990
+      "startLine": 3020
     },
     {
       "endCharacter": 17,
-      "endLine": 3788,
+      "endLine": 3818,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"reward_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 3788
+      "startLine": 3818
     },
     {
       "endCharacter": 5,
-      "endLine": 3792,
+      "endLine": 3822,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3788
+      "startLine": 3818
     },
     {
       "endCharacter": 43,
-      "endLine": 3789,
+      "endLine": 3819,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3789
+      "startLine": 3819
     },
     {
       "endCharacter": 42,
-      "endLine": 3789,
+      "endLine": 3819,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 3789
+      "startLine": 3819
     },
     {
       "endCharacter": 9,
-      "endLine": 3935,
+      "endLine": 3965,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to declared type \"RewardParams\"\n  Type \"dict[bytes, bytes] | dict[str, RewardParamValue]\" is not assignable to type \"RewardParams\"\n    \"dict[bytes, bytes]\" is not assignable to \"dict[str, RewardParamValue]\"\n      Type parameter \"_KT@dict\" is invariant, but \"bytes\" is not the same as \"str\"\n      Type parameter \"_VT@dict\" is invariant, but \"bytes\" is not the same as \"RewardParamValue\"",
       "rule": "reportAssignmentType",
       "severity": "error",
       "startCharacter": 38,
-      "startLine": 3931
+      "startLine": 3961
     },
     {
       "endCharacter": 47,
-      "endLine": 3932,
+      "endLine": 3962,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "No overloads for \"__init__\" match the provided arguments",
       "rule": "reportCallIssue",
       "severity": "error",
       "startCharacter": 12,
-      "startLine": 3932
+      "startLine": 3962
     },
     {
       "endCharacter": 46,
-      "endLine": 3932,
+      "endLine": 3962,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"iterable\" of type \"Iterable[list[bytes]]\" in function \"__init__\"\n  Type \"Any | None\" is not assignable to type \"Iterable[list[bytes]]\"\n    \"None\" is incompatible with protocol \"Iterable[list[bytes]]\"\n      \"__iter__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 17,
-      "startLine": 3932
+      "startLine": 3962
     },
     {
       "endCharacter": 14,
-      "endLine": 4671,
+      "endLine": 4701,
       "file": "ReforceXY/reward_space_analysis/reward_space_analysis.py",
       "message": "Declaration \"sim_params\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 4,
-      "startLine": 4671
+      "startLine": 4701
     },
     {
       "endCharacter": 51,

--- a/ReforceXY/reward_space_analysis/reward_space_analysis.py
+++ b/ReforceXY/reward_space_analysis/reward_space_analysis.py
@@ -2949,7 +2949,9 @@ def distribution_diagnostics(
 ) -> dict[str, Any]:
     """Return mapping col-> diagnostics (tests, moments, entropy, divergences).
 
-    Skips missing columns; selects Shapiro-Wilk when n<=5000 else K2; ignores non-finite intermediates.
+    Skips missing columns and selects Shapiro-Wilk when n<5000. Constant
+    distributions have no defined normality test and omit those results in
+    relaxed mode.
     """
     diagnostics = {}
     _ = seed  # placeholder to keep signature for future reproducibility extensions
@@ -2964,6 +2966,33 @@ def distribution_diagnostics(
 
         diagnostics[f"{col}_mean"] = float(np.mean(data))
         diagnostics[f"{col}_std"] = float(np.std(data, ddof=1))
+        if np.ptp(data) == 0:
+            message = (
+                f"Stats: Shapiro-Wilk and Anderson-Darling normality tests for {col} are undefined "
+                "(constant distribution); result unavailable"
+            )
+            if strict_diagnostics:
+                raise AssertionError(message)
+            diagnostics[f"{col}_skewness"] = INTERNAL_GUARDS.get(
+                "distribution_constant_fallback_moment", 0.0
+            )
+            diagnostics[f"{col}_kurtosis"] = INTERNAL_GUARDS.get(
+                "distribution_constant_fallback_moment", 0.0
+            )
+            diagnostics[f"{col}_shapiro_available"] = False
+            diagnostics[f"{col}_shapiro_reason"] = "constant_distribution"
+            diagnostics[f"{col}_anderson_available"] = False
+            diagnostics[f"{col}_anderson_reason"] = "constant_distribution"
+            diagnostics[f"{col}_qq_r_squared"] = INTERNAL_GUARDS.get(
+                "distribution_constant_fallback_qq_r2", 1.0
+            )
+            warnings.warn(
+                message,
+                RewardDiagnosticsWarning,
+                stacklevel=2,
+            )
+            continue
+
         skew_v = float(stats.skew(data))
         kurt_v = float(stats.kurtosis(data, fisher=True))
         diagnostics[f"{col}_skewness"] = skew_v
@@ -2977,6 +3006,7 @@ def distribution_diagnostics(
 
         if len(data) < 5000:
             sw_stat, sw_pval = stats.shapiro(data)
+            diagnostics[f"{col}_shapiro_available"] = True
             diagnostics[f"{col}_shapiro_stat"] = float(sw_stat)
             diagnostics[f"{col}_shapiro_pval"] = float(sw_pval)
             diagnostics[f"{col}_is_normal_shapiro"] = bool(sw_pval > 0.05)
@@ -3737,7 +3767,7 @@ def build_argument_parser() -> argparse.ArgumentParser:
         action="store_true",
         help=(
             "Enable fail-fast mode for statistical diagnostics: raise on zero-width bootstrap CIs or undefined "
-            "skewness/kurtosis/Anderson/Q-Q metrics produced by constant distributions instead of applying graceful replacements."
+            "Shapiro-Wilk/skewness/kurtosis/Anderson/Q-Q metrics produced by constant distributions instead of applying graceful replacements."
         ),
     )
     parser.add_argument(


### PR DESCRIPTION
Atomic PR 6/10 of the reward_space_analysis economic-contract split (source: #120, unit u14).

**What**: Make `distribution_diagnostics()` fail-closed on constant distributions instead of invoking SciPy on zero-variance data.
- `np.ptp == 0` path emits `*_shapiro_available`/`*_shapiro_reason=constant_distribution`, `*_anderson_available`/`*_anderson_reason`, fallback moments/qq_r2 with a `RewardDiagnosticsWarning`, and omits stat/pval keys; `strict_diagnostics` raises `AssertionError`.
- Shapiro selection threshold `n < 5000` and `*_shapiro_available` flag.
- `--strict_diagnostics` help text updated to mention Shapiro-Wilk.

**Scope**: `reward_space_analysis.py` only.

**Stack position**: base `atomic/rsa-05-invariants`; 6 of 10.

Verified: `python -m py_compile` clean; ruff check/format clean under project config.