### PR TITLE
test(reward-space-analysis): migrate tracked analytical suite to economic contract (8/10)

### DIFF
--- a/ReforceXY/reward_space_analysis/test_reward_space_analysis_cli.py
+++ b/ReforceXY/reward_space_analysis/test_reward_space_analysis_cli.py
@@ -334,7 +334,7 @@ def main():
     parser.add_argument(
         "--unrealized_pnl",
         action="store_true",
-        help="Forward --unrealized_pnl to child process to exercise hold Φ(s) path.",
+        help="Forward the deprecated --unrealized_pnl compatibility alias.",
     )
     parser.add_argument(
         "--params",

--- a/ReforceXY/reward_space_analysis/tests/api/test_api_helpers.py
+++ b/ReforceXY/reward_space_analysis/tests/api/test_api_helpers.py
@@ -141,12 +141,23 @@ class TestAPIAndHelpers(RewardSpaceTestBase):
             "sample_exit_prob",
             "sample_neutral_prob",
             "reward",
+            "reward_economic",
             "reward_invalid",
             "reward_idle",
             "reward_hold",
             "reward_exit",
+            "previous_liquidation_value",
+            "reward_liquidation_value",
+            "next_liquidation_value",
+            "economic_log_return",
+            "economic_ruin",
+            "terminated",
+            "truncated",
         ]:
             self.assertIn(col, df_margin.columns)
+        self.assertTrue((df_margin["terminated"] == df_margin["economic_ruin"]).all())
+        self.assertTrue(bool(df_margin.iloc[-1]["terminated"] or df_margin.iloc[-1]["truncated"]))
+        self.assertFalse(bool(df_margin.iloc[-1]["terminated"] and df_margin.iloc[-1]["truncated"]))
 
     def test_simulate_samples_sampling_probabilities_are_bounded(self):
         """simulate_samples() exposes bounded sampling probabilities."""
@@ -166,24 +177,28 @@ class TestAPIAndHelpers(RewardSpaceTestBase):
         prob_upper_bound = SCENARIOS.API_PROBABILITY_UPPER_BOUND
         self.assertTrue(((values >= 0.0) & (values <= prob_upper_bound)).all())
 
-    def test_simulate_samples_interprets_bool_string_params(self):
-        """Test simulate_samples correctly interprets string boolean params like action_masking."""
+    def test_simulate_samples_action_masking_controls_invalid_sampling(self):
+        """String booleans preserve masking, including the diagnostic invalid-action stream."""
         df1 = simulate_samples_with_defaults(
             self.base_params(
                 action_masking="true", max_trade_duration_candles=PARAMS.TRADE_DURATION_SHORT
             ),
-            num_samples=SCENARIOS.SAMPLE_SIZE_REPORT_MINIMAL,
+            num_samples=SCENARIOS.SAMPLE_SIZE_MEDIUM,
             trading_mode="spot",
         )
         self.assertIsInstance(df1, pd.DataFrame)
+        self.assertEqual(float(df1["is_invalid"].sum()), 0.0)
         df2 = simulate_samples_with_defaults(
             self.base_params(
                 action_masking="false", max_trade_duration_candles=PARAMS.TRADE_DURATION_SHORT
             ),
-            num_samples=SCENARIOS.SAMPLE_SIZE_REPORT_MINIMAL,
+            num_samples=SCENARIOS.SAMPLE_SIZE_MEDIUM,
             trading_mode="spot",
         )
         self.assertIsInstance(df2, pd.DataFrame)
+        invalid_rate = float(df2["is_invalid"].mean())
+        self.assertGreater(invalid_rate, 0.0)
+        self.assertLess(invalid_rate, 0.15)
 
     def test_short_allowed_via_simulation(self):
         """Test _is_short_allowed via different trading modes."""
@@ -363,8 +378,8 @@ class TestPrivateFunctions(RewardSpaceTestBase):
                 )
                 self.assertFinite(breakdown.total, name="total")
 
-    def test_invalid_action_handling(self):
-        """Test invalid action penalty."""
+    def test_invalid_action_preserves_economic_decomposition(self):
+        """An invalid action adds its penalty without replacing the economic mark."""
         context = self.make_ctx(
             pnl=PARAMS.PNL_SMALL,
             trade_duration=PARAMS.TRADE_DURATION_SHORT,
@@ -380,13 +395,12 @@ class TestPrivateFunctions(RewardSpaceTestBase):
         self.assertLess(breakdown.invalid_penalty, 0, "Invalid action should have negative penalty")
         self.assertAlmostEqualFloat(
             breakdown.total,
-            breakdown.invalid_penalty
-            + breakdown.reward_shaping
-            + breakdown.entry_additive
-            + breakdown.exit_additive,
+            breakdown.economic_component + breakdown.invalid_penalty + breakdown.reward_shaping,
             tolerance=TOLERANCE.IDENTITY_RELAXED,
-            msg="Total should equal invalid penalty plus shaping/additives",
+            msg="Total should equal economic reward plus invalid penalty and PBRS",
         )
+        self.assertEqual(breakdown.entry_additive, 0.0)
+        self.assertEqual(breakdown.exit_additive, 0.0)
 
     def test_new_invariant_and_warn_parameters(self):
         """Ensure new tunables (check_invariants, exit_factor_threshold) exist and behave.

--- a/ReforceXY/reward_space_analysis/tests/cli/test_cli_params_and_csv.py
+++ b/ReforceXY/reward_space_analysis/tests/cli/test_cli_params_and_csv.py
@@ -12,7 +12,7 @@ import pytest
 
 from reward_space_analysis import Actions
 
-from ..constants import SCENARIOS, SEEDS, TOLERANCE
+from ..constants import PARAMS, SCENARIOS, SEEDS, TOLERANCE
 from ..test_base import RewardSpaceTestBase
 
 # Pytest marker for taxonomy classification
@@ -100,8 +100,9 @@ class TestParamsPropagation(RewardSpaceTestBase):
         fi_path = out_dir / "feature_importance.csv"
         self.assertFalse(fi_path.exists(), "feature_importance.csv should be absent when skipped")
 
-    def test_manifest_params_hash_generation(self):
-        """Ensure params_hash appears when non-default simulation params differ (risk_reward_ratio altered)."""
+    # Owns invariant: cli-economic-manifest-124
+    def test_manifest_economic_contract_and_params_hash(self):
+        """The manifest separates the reward contract, costs and episode boundaries."""
         out_dir = self.output_path / "manifest_hash"
         result = _run_cli(
             out_dir=out_dir,
@@ -112,15 +113,44 @@ class TestParamsPropagation(RewardSpaceTestBase):
                 str(SEEDS.BASE),
                 "--risk_reward_ratio",
                 str(SCENARIOS.CLI_RISK_REWARD_RATIO_NON_DEFAULT),
+                "--profit_aim",
+                str(PARAMS.PROFIT_AIM),
+                "--unrealized_pnl",
             ],
         )
         _assert_cli_success(self, result)
+        self.assertIn("deprecated and ignored", result.stderr)
         manifest_path = out_dir / "manifest.json"
         self.assertTrue(manifest_path.exists(), "Missing manifest.json")
         manifest = json.loads(manifest_path.read_text())
         self.assertIn("params_hash", manifest, "params_hash should be present when params differ")
         self.assertIn("simulation_params", manifest)
-        self.assertIn("risk_reward_ratio", manifest["simulation_params"])
+        self.assertEqual(
+            manifest["reward_contract"]["name"],
+            "pair_local_net_log_liquidation_return",
+        )
+        self.assertEqual(manifest["cost_accounting"]["fee_source"], "analytical_assumption")
+        self.assertEqual(manifest["episode_boundaries"]["termination"], "economic_ruin")
+        self.assertEqual(manifest["episode_boundaries"]["truncation"], "synthetic_sample_limit")
+        reward_params = manifest["reward_params"]
+        self.assertNotIn("unrealized_pnl", reward_params)
+        self.assertNotIn("unrealized_pnl", manifest["simulation_params"])
+        self.assertAlmostEqualFloat(
+            reward_params["risk_reward_ratio"],
+            SCENARIOS.CLI_RISK_REWARD_RATIO_NON_DEFAULT,
+            tolerance=TOLERANCE.IDENTITY_STRICT,
+        )
+        self.assertAlmostEqualFloat(
+            reward_params["profit_aim"],
+            PARAMS.PROFIT_AIM,
+            tolerance=TOLERANCE.IDENTITY_STRICT,
+        )
+        expected_target = reward_params["profit_aim"] * reward_params["risk_reward_ratio"]
+        self.assertAlmostEqualFloat(
+            manifest["compatibility_only"]["pnl_target"],
+            expected_target,
+            tolerance=TOLERANCE.IDENTITY_STRICT,
+        )
 
     def test_pbrs_invariance_section_present(self):
         """When reward_shaping column exists, summary should include PBRS invariance section."""
@@ -139,8 +169,8 @@ class TestParamsPropagation(RewardSpaceTestBase):
         report_path = out_dir / "statistical_analysis.md"
         self.assertTrue(report_path.exists(), "Missing statistical_analysis.md")
         content = report_path.read_text(encoding="utf-8")
-        # Section numbering includes PBRS invariance line 7
-        self.assertIn("PBRS Invariance", content)
+        # Section numbering includes the PBRS algebraic-conformance line 7
+        self.assertIn("PBRS Algebraic Conformance", content)
 
     def test_strict_diagnostics_constant_distribution_succeeds(self):
         """Run with --strict_diagnostics and low num_samples; expect success, exercising assertion branches before graceful fallback paths."""
@@ -176,9 +206,11 @@ class TestParamsPropagation(RewardSpaceTestBase):
                 str(SEEDS.BASE),
                 "--params",
                 f"max_trade_duration_candles={SCENARIOS.CLI_MAX_TRADE_DURATION_PARAMS}",
+                "unrealized_pnl=1",
             ],
         )
         _assert_cli_success(self, result)
+        self.assertIn("deprecated and ignored", result.stderr)
         manifest_path = out_dir / "manifest.json"
         self.assertTrue(manifest_path.exists(), "Missing manifest.json")
         with manifest_path.open() as f:
@@ -186,6 +218,8 @@ class TestParamsPropagation(RewardSpaceTestBase):
         self.assertIn("reward_params", manifest)
         self.assertIn("simulation_params", manifest)
         rp = manifest["reward_params"]
+        self.assertNotIn("unrealized_pnl", rp)
+        self.assertNotIn("unrealized_pnl", manifest["simulation_params"])
         self.assertIn("max_trade_duration_candles", rp)
         self.assertEqual(
             int(rp["max_trade_duration_candles"]), SCENARIOS.CLI_MAX_TRADE_DURATION_PARAMS
@@ -218,9 +252,9 @@ class TestParamsPropagation(RewardSpaceTestBase):
             int(rp["max_trade_duration_candles"]), SCENARIOS.CLI_MAX_TRADE_DURATION_FLAG
         )
 
-    # Owns invariant: cli-pbrs-csv-columns-121
-    def test_csv_contains_pbrs_columns_when_shaping_present(self):
-        """Verify reward_samples.csv includes PBRS columns when shaping is enabled.
+    # Owns invariant: cli-economic-contract-columns-121
+    def test_csv_contains_economic_and_pbrs_contract_columns(self):
+        """Verify reward_samples.csv exposes the complete economic transition contract.
 
         Verifies:
         - reward_base, reward_pbrs_delta, reward_invariance_correction columns exist
@@ -247,8 +281,19 @@ class TestParamsPropagation(RewardSpaceTestBase):
 
         df = pd.read_csv(csv_path)
 
-        # Verify PBRS columns exist
-        required_cols = ["reward_base", "reward_pbrs_delta", "reward_invariance_correction"]
+        required_cols = [
+            "reward_economic",
+            "reward_base",
+            "reward_pbrs_delta",
+            "reward_invariance_correction",
+            "previous_liquidation_value",
+            "reward_liquidation_value",
+            "next_liquidation_value",
+            "economic_log_return",
+            "economic_ruin",
+            "terminated",
+            "truncated",
+        ]
         for col in required_cols:
             self.assertIn(col, df.columns, f"Missing column: {col}")
 
@@ -268,6 +313,19 @@ class TestParamsPropagation(RewardSpaceTestBase):
             TOLERANCE.GENERIC_EQ,
             "Expected reward_shaping == reward_pbrs_delta + reward_invariance_correction",
         )
+        total_residual = (
+            df["reward"] - (df["reward_economic"] + df["reward_invalid"] + df["reward_shaping"])
+        ).abs()
+        self.assertLessEqual(float(total_residual.max()), TOLERANCE.GENERIC_EQ)
+        for column in [
+            "previous_liquidation_value",
+            "reward_liquidation_value",
+            "next_liquidation_value",
+        ]:
+            self.assertTrue((df[column] > 0.0).all(), f"{column} must stay positive")
+        self.assertTrue((df["terminated"] == df["economic_ruin"]).all())
+        self.assertTrue(bool(df.iloc[-1]["terminated"] or df.iloc[-1]["truncated"]))
+        self.assertFalse(bool(df.iloc[-1]["terminated"] and df.iloc[-1]["truncated"]))
 
         # Total reward should decompose into base + shaping + additives
         reward_residual = (

--- a/ReforceXY/reward_space_analysis/tests/components/test_additives.py
+++ b/ReforceXY/reward_space_analysis/tests/components/test_additives.py
@@ -1,14 +1,14 @@
 #!/usr/bin/env python3
 """Additive deterministic contribution tests moved from helpers/test_utilities.py.
 
-Owns invariant: report-additives-deterministic-092 (components category)
+Owns invariant: components-canonical-additives-092 (components category)
 """
 
 import unittest
 
 import pytest
 
-from reward_space_analysis import compute_pbrs_components
+from reward_space_analysis import compute_pbrs_components, validate_reward_parameters
 
 from ..constants import PARAMS, TOLERANCE
 from ..test_base import RewardSpaceTestBase
@@ -17,38 +17,17 @@ pytestmark = pytest.mark.components
 
 
 class TestAdditivesDeterministicContribution(RewardSpaceTestBase):
-    """Additives enabled increase total reward; shaping impact limited."""
+    """Canonical PBRS rejects or suppresses non-potential additives."""
 
-    def test_additive_activation_deterministic_contribution(self):
-        """Enabling additives increases total reward while limiting shaping impact.
-
-        **Invariant:** report-additives-deterministic-092
-
-        Validates that when entry/exit additives are enabled, the total reward
-        increases deterministically, but the shaping component remains bounded.
-        This ensures additives provide meaningful reward contribution without
-        destabilizing PBRS shaping dynamics.
-
-        **Setup:**
-        - Base configuration: hold_potential enabled, additives disabled
-        - Test configuration: entry_additive and exit_additive enabled
-        - Additive parameters: ratio=PARAMS.ADDITIVE_RATIO_DEFAULT, gain=PARAMS.ADDITIVE_GAIN_DEFAULT for both entry/exit
-        - Context: base_reward=0.05, pnl=0.01, duration_ratio=0.2
-
-        **Assertions:**
-        - Total reward with additives > total reward without additives
-        - Shaping difference remains bounded: |s1 - s0| < TOLERANCE.SHAPING_BOUND_TOLERANCE
-        - Both total and shaping rewards are finite
-
-        **Tolerance rationale:**
-        - Custom bound TOLERANCE.SHAPING_BOUND_TOLERANCE for shaping delta: Additives should not cause
-          large shifts in shaping component, which maintains PBRS properties
-        """
+    def test_canonical_additives_rejected_or_suppressed(self):
+        """Strict validation rejects additives and relaxed validation records suppression."""
         base = self.base_params(
             hold_potential_enabled=True,
             entry_additive_enabled=False,
             exit_additive_enabled=False,
-            exit_potential_mode="non_canonical",
+            exit_potential_mode="canonical",
+            profit_aim=PARAMS.PROFIT_AIM,
+            risk_reward_ratio=PARAMS.RISK_REWARD_RATIO,
         )
         with_add = base.copy()
         with_add.update(
@@ -61,7 +40,19 @@ class TestAdditivesDeterministicContribution(RewardSpaceTestBase):
                 "exit_additive_gain": PARAMS.ADDITIVE_GAIN_DEFAULT,
             }
         )
-        base_reward = 0.05
+        with self.assertRaisesRegex(ValueError, "canonical PBRS"):
+            validate_reward_parameters(with_add, strict=True)
+        sanitized, adjustments = validate_reward_parameters(with_add, strict=False)
+        self.assertFalse(sanitized["entry_additive_enabled"])
+        self.assertFalse(sanitized["exit_additive_enabled"])
+        self.assertEqual(
+            adjustments["entry_additive_enabled"]["reason"],
+            "canonical_pbrs_suppresses_additives",
+        )
+        self.assertEqual(
+            adjustments["exit_additive_enabled"]["reason"],
+            "canonical_pbrs_suppresses_additives",
+        )
         ctx = {
             "current_pnl": 0.01,
             "pnl_target": PARAMS.PROFIT_AIM * PARAMS.RISK_REWARD_RATIO,
@@ -72,24 +63,15 @@ class TestAdditivesDeterministicContribution(RewardSpaceTestBase):
             "is_entry": True,
             "is_exit": False,
         }
-        s0, _n0, _pbrs0, _entry0, _exit0 = compute_pbrs_components(
-            params=base,
+        shaping, _next, pbrs_delta, entry_additive, exit_additive = compute_pbrs_components(
+            params=sanitized,
             base_factor=PARAMS.BASE_FACTOR,
             prev_potential=0.0,
             **ctx,
         )
-        t0 = base_reward + s0 + _entry0 + _exit0
-        s1, _n1, _pbrs1, _entry1, _exit1 = compute_pbrs_components(
-            params=with_add,
-            base_factor=PARAMS.BASE_FACTOR,
-            prev_potential=0.0,
-            **ctx,
-        )
-        t1 = base_reward + s1 + _entry1 + _exit1
-        self.assertFinite(t1)
-        self.assertFinite(s1)
-        self.assertLess(abs(s1 - s0), TOLERANCE.SHAPING_BOUND_TOLERANCE)
-        self.assertGreater(t1 - t0, 0.0, "Total reward should increase with additives present")
+        self.assertAlmostEqualFloat(shaping, pbrs_delta, tolerance=TOLERANCE.IDENTITY_STRICT)
+        self.assertEqual(entry_additive, 0.0)
+        self.assertEqual(exit_additive, 0.0)
 
 
 if __name__ == "__main__":

--- a/ReforceXY/reward_space_analysis/tests/components/test_reward_components.py
+++ b/ReforceXY/reward_space_analysis/tests/components/test_reward_components.py
@@ -14,22 +14,16 @@ from reward_space_analysis import (
     _compute_hold_potential,
     _compute_pnl_target_coefficient,
     _get_exit_factor,
-    _get_float_param,
     get_max_idle_duration_candles,
 )
 
 from ..constants import EFFICIENCY, PARAMS, SCENARIOS, TOLERANCE
 from ..helpers import (
     RewardScenarioConfig,
-    ThresholdTestConfig,
-    ValidationConfig,
-    assert_component_sum_integrity,
     assert_exit_factor_plateau_behavior,
-    assert_hold_penalty_threshold_behavior,
     assert_progressive_scaling_behavior,
     assert_reward_calculation_scenarios,
     calculate_reward_with_defaults,
-    make_idle_penalty_test_contexts,
 )
 from ..test_base import RewardSpaceTestBase
 
@@ -58,70 +52,42 @@ class TestRewardComponents(RewardSpaceTestBase):
         )
         self.assertFinite(val, name="hold_potential")
 
-    def test_hold_penalty_basic_calculation(self):
-        """Test hold penalty calculation when trade_duration exceeds max_duration.
-
-        Verifies:
-        - trade_duration > max_duration → hold_penalty < 0
-        - Total reward equals sum of active components
-        """
+    def test_hold_economic_log_delta_calculation(self):
+        """A hold recognizes only the log change in liquidation value."""
         context = self.make_ctx(
             pnl=0.01,
-            trade_duration=150,  # > default max_duration (128)
+            trade_duration=150,
             idle_duration=0,
             max_unrealized_profit=0.02,
             min_unrealized_profit=0.0,
             position=Positions.Long,
             action=Actions.Neutral,
+            previous_liquidation_value=0.995,
         )
         breakdown = calculate_reward_with_defaults(context, self.DEFAULT_PARAMS)
-        self.assertLess(breakdown.hold_penalty, 0, "Hold penalty should be negative")
-        config = ValidationConfig(
-            tolerance_strict=TOLERANCE.IDENTITY_STRICT,
-            tolerance_relaxed=TOLERANCE.IDENTITY_RELAXED,
-            exclude_components=["idle_penalty", "exit_component", "invalid_penalty"],
-            component_description="hold + shaping/additives",
+        expected = float(self.DEFAULT_PARAMS["base_factor"]) * math.log(1.01 / 0.995)
+        self.assertAlmostEqualFloat(
+            breakdown.economic_component, expected, tolerance=TOLERANCE.IDENTITY_STRICT
         )
-        assert_component_sum_integrity(self, breakdown, config)
+        self.assertEqual(breakdown.hold_penalty, 0.0)
+        self.assertAlmostEqualFloat(breakdown.total, expected, tolerance=TOLERANCE.IDENTITY_STRICT)
 
-    def test_hold_penalty_threshold_behavior(self):
-        """Test hold penalty activation at max_duration threshold.
-
-        Verifies:
-        - duration < max_duration → hold_penalty = 0
-        - duration >= max_duration → hold_penalty <= 0
-        """
-        max_duration = 128
-        threshold_test_cases = [
-            (64, "before max_duration"),
-            (127, "just before max_duration"),
-            (128, "exactly at max_duration"),
-            (129, "just after max_duration"),
-        ]
-
-        def context_factory(trade_duration):
-            return self.make_ctx(
-                pnl=0.0,
-                trade_duration=trade_duration,
-                idle_duration=0,
-                position=Positions.Long,
-                action=Actions.Neutral,
-            )
-
-        config = ThresholdTestConfig(
-            max_duration=max_duration,
-            test_cases=threshold_test_cases,
-            tolerance=TOLERANCE.IDENTITY_RELAXED,
-        )
-        assert_hold_penalty_threshold_behavior(
-            self,
-            context_factory,
-            self.DEFAULT_PARAMS,
-            PARAMS.BASE_FACTOR,
-            PARAMS.PROFIT_AIM,
-            1.0,
-            config,
-        )
+    def test_hold_reward_is_independent_of_duration_threshold(self):
+        """Duration thresholds do not alter the economic mark-to-liquidation reward."""
+        rewards = []
+        for trade_duration in (64, 127, 128, 129):
+            with self.subTest(trade_duration=trade_duration):
+                context = self.make_ctx(
+                    pnl=0.0,
+                    trade_duration=trade_duration,
+                    idle_duration=0,
+                    position=Positions.Long,
+                    action=Actions.Neutral,
+                )
+                breakdown = calculate_reward_with_defaults(context, self.DEFAULT_PARAMS)
+                rewards.append(breakdown.economic_component)
+                self.assertEqual(breakdown.hold_penalty, 0.0)
+        self.assertTrue(all(value == 0.0 for value in rewards))
 
     def test_hold_penalty_progressive_scaling(self):
         """Test hold penalty scales progressively with increasing duration.
@@ -147,46 +113,15 @@ class TestRewardComponents(RewardSpaceTestBase):
 
         assert_progressive_scaling_behavior(self, penalties, durations, "Hold penalty")
 
-    def test_idle_penalty_calculation(self):
-        """Test idle penalty calculation for neutral idle state.
-
-        Verifies:
-        - idle_duration > 0 → idle_penalty < 0
-        - Component sum integrity maintained
-        """
-        context = self.make_ctx(
-            pnl=0.0,
-            trade_duration=0,
-            idle_duration=20,
-            max_unrealized_profit=0.0,
-            min_unrealized_profit=0.0,
-            position=Positions.Neutral,
-            action=Actions.Neutral,
-        )
-
-        def validate_idle_penalty(test_case, breakdown, description, tolerance):
-            test_case.assertLess(breakdown.idle_penalty, 0, "Idle penalty should be negative")
-            config = ValidationConfig(
-                tolerance_strict=TOLERANCE.IDENTITY_STRICT,
-                tolerance_relaxed=tolerance,
-                exclude_components=["hold_penalty", "exit_component", "invalid_penalty"],
-                component_description="idle + shaping/additives",
-            )
-            assert_component_sum_integrity(test_case, breakdown, config)
-
-        scenarios = [(context, self.DEFAULT_PARAMS, "idle_penalty_basic")]
-        config = RewardScenarioConfig(
-            base_factor=PARAMS.BASE_FACTOR,
-            profit_aim=PARAMS.PROFIT_AIM,
-            risk_reward_ratio=PARAMS.RISK_REWARD_RATIO,
-            tolerance_relaxed=TOLERANCE.IDENTITY_RELAXED,
-        )
-        assert_reward_calculation_scenarios(
-            self,
-            scenarios,
-            config,
-            validate_idle_penalty,
-        )
+    def test_neutral_self_loop_has_zero_economic_reward(self):
+        """A neutral self-loop remains at liquidation value one, regardless of idling."""
+        context = self.make_ctx(idle_duration=20)
+        breakdown = calculate_reward_with_defaults(context, self.DEFAULT_PARAMS)
+        self.assertEqual(breakdown.previous_liquidation_value, 1.0)
+        self.assertEqual(breakdown.reward_liquidation_value, 1.0)
+        self.assertEqual(breakdown.next_liquidation_value, 1.0)
+        self.assertEqual(breakdown.economic_component, 0.0)
+        self.assertEqual(breakdown.idle_penalty, 0.0)
 
     def test_pnl_target_coefficient_zero_pnl(self):
         """PnL target coefficient returns neutral value for zero PnL.
@@ -530,13 +465,8 @@ class TestRewardComponents(RewardSpaceTestBase):
             "Exit component must not be positive when pnl < 0",
         )
 
-    def test_max_idle_duration_candles_logic(self):
-        """Test max idle duration candles parameter affects penalty magnitude.
-
-        Verifies:
-        - penalty(max=50) < penalty(max=200) < 0
-        - Smaller max → larger penalty magnitude
-        """
+    def test_max_idle_duration_does_not_change_economic_reward(self):
+        """Sampling limits do not leak into the neutral economic reward."""
         params_small = self.base_params(max_idle_duration_candles=50)
         params_large = self.base_params(max_idle_duration_candles=200)
         context = self.make_ctx(
@@ -548,9 +478,10 @@ class TestRewardComponents(RewardSpaceTestBase):
         )
         small = calculate_reward_with_defaults(context, params_small)
         large = calculate_reward_with_defaults(context, params_large)
-        self.assertLess(small.idle_penalty, 0.0)
-        self.assertLess(large.idle_penalty, 0.0)
-        self.assertGreater(large.idle_penalty, small.idle_penalty)
+        self.assertEqual(small.idle_penalty, 0.0)
+        self.assertEqual(large.idle_penalty, 0.0)
+        self.assertEqual(small.economic_component, 0.0)
+        self.assertEqual(large.economic_component, 0.0)
 
     @pytest.mark.smoke
     def test_exit_factor_calculation(self):
@@ -645,94 +576,32 @@ class TestRewardComponents(RewardSpaceTestBase):
             validate_zero_penalty,
         )
 
-    def test_win_reward_factor_saturation(self):
-        """Test PnL amplification factor saturates at asymptotic limit.
-
-        Verifies:
-        - Amplification ratio increases monotonically with PnL
-        - Saturation approaches (1 + win_reward_factor)
-        - Observed matches theoretical saturation behavior
-        """
-        win_reward_factor = 3.0
-        beta = 0.5
-        profit_aim = PARAMS.PROFIT_AIM
-        risk_reward_ratio = PARAMS.RISK_REWARD_RATIO
-        pnl_target = profit_aim * risk_reward_ratio
-        params = self.base_params(
-            win_reward_factor=win_reward_factor,
-            pnl_amplification_sensitivity=beta,
-            efficiency_weight=0.0,
-            exit_attenuation_mode="linear",
-            exit_plateau=False,
-            exit_linear_slope=0.0,
+    def test_base_factor_scales_log_return_linearly(self):
+        """The sole economic scale is ``base_factor``."""
+        context = self.make_ctx(
+            pnl=0.08,
+            position=Positions.Long,
+            action=Actions.Long_exit,
         )
+        params = self.base_params(win_reward_factor=1000.0)
         params.pop("base_factor", None)
-        pnl_values = [pnl_target * m for m in (1.05, 2.0, 5.0, 10.0)]
-        ratios_observed: list[float] = []
-        for pnl in pnl_values:
-            context = self.make_ctx(
-                pnl=pnl,
-                trade_duration=0,
-                idle_duration=0,
-                max_unrealized_profit=pnl,
-                min_unrealized_profit=0.0,
-                position=Positions.Long,
-                action=Actions.Long_exit,
-            )
-            br = calculate_reward_with_defaults(
-                context,
-                params,
-                base_factor=1.0,
-                profit_aim=profit_aim,
-                risk_reward_ratio=risk_reward_ratio,
-            )
-            ratio = br.exit_component / pnl if pnl != 0 else 0.0
-            ratios_observed.append(float(ratio))
-        self.assertMonotonic(
-            ratios_observed,
-            non_decreasing=True,
-            tolerance=TOLERANCE.IDENTITY_STRICT,
-            name="pnl_amplification_ratio",
-        )
-        asymptote = 1.0 + win_reward_factor
-        final_ratio = ratios_observed[-1]
-        self.assertFinite(final_ratio, name="final_ratio")
-        self.assertLess(
-            abs(final_ratio - asymptote),
-            0.001,
-            f"Final amplification {final_ratio:.6f} not close to asymptote {asymptote:.6f}",
-        )
-        expected_ratios: list[float] = []
-        for pnl in pnl_values:
-            pnl_ratio = pnl / pnl_target
-            expected = 1.0 + win_reward_factor * math.tanh(beta * (pnl_ratio - 1.0))
-            expected_ratios.append(expected)
-        for obs, exp in zip(ratios_observed, expected_ratios, strict=False):
-            self.assertFinite(obs, name="observed_ratio")
-            self.assertFinite(exp, name="expected_ratio")
-            self.assertLess(
-                abs(obs - exp),
-                5e-06,
-                f"Observed amplification {obs:.8f} deviates from expected {exp:.8f}",
-            )
+        unit = calculate_reward_with_defaults(context, params, base_factor=1.0)
+        for scale in (1.0, PARAMS.RISK_REWARD_RATIO, PARAMS.BASE_FACTOR):
+            with self.subTest(scale=scale):
+                scaled = calculate_reward_with_defaults(context, params, base_factor=scale)
+                self.assertAlmostEqualFloat(
+                    scaled.economic_component,
+                    scale * unit.economic_component,
+                    tolerance=TOLERANCE.IDENTITY_STRICT,
+                )
 
-    def test_idle_penalty_fallback_and_proportionality(self):
-        """Test idle penalty fallback and proportional scaling behavior.
-
-        Verifies:
-        - max_idle_duration = None → use max_trade_duration as fallback
-        - penalty(duration=40) ≈ 2 * penalty(duration=20)
-        - Proportional scaling with idle duration
-        """
-        base_factor = PARAMS.BASE_FACTOR
-        profit_aim = PARAMS.PROFIT_AIM
-        risk_reward_ratio = PARAMS.RISK_REWARD_RATIO
+    def test_idle_duration_fallback_is_sampling_only(self):
+        """The derived idle limit remains available but does not shape reward."""
         max_trade_duration_candles = PARAMS.TRADE_DURATION_MEDIUM
 
         params = self.base_params(
             max_idle_duration_candles=None,
             max_trade_duration_candles=max_trade_duration_candles,
-            base_factor=base_factor,
         )
         expected_max_idle_duration_candles = int(
             DEFAULT_IDLE_DURATION_MULTIPLIER * max_trade_duration_candles
@@ -743,52 +612,15 @@ class TestRewardComponents(RewardSpaceTestBase):
             "Expected fallback max_idle_duration from max_trade_duration",
         )
 
-        base_context_kwargs = {
-            "pnl": 0.0,
-            "trade_duration": 0,
-            "position": Positions.Neutral,
-            "action": Actions.Neutral,
-        }
-        idle_scenarios = [20, 40, 120]
-        contexts_and_descriptions = make_idle_penalty_test_contexts(
-            self.make_ctx, idle_scenarios, base_context_kwargs
-        )
+        for idle_duration in (20, 40, 120):
+            with self.subTest(idle_duration=idle_duration):
+                breakdown = calculate_reward_with_defaults(
+                    self.make_ctx(idle_duration=idle_duration), params
+                )
+                self.assertEqual(breakdown.idle_penalty, 0.0)
+                self.assertEqual(breakdown.total, 0.0)
 
-        results = []
-        for context, description in contexts_and_descriptions:
-            breakdown = calculate_reward_with_defaults(
-                context,
-                params,
-                base_factor=base_factor,
-                profit_aim=profit_aim,
-                risk_reward_ratio=risk_reward_ratio,
-            )
-            results.append((breakdown, context.idle_duration, description))
-
-        br_a, br_b, br_mid = [r[0] for r in results]
-        self.assertLess(br_a.idle_penalty, 0.0)
-        self.assertLess(br_b.idle_penalty, 0.0)
-        self.assertLess(br_mid.idle_penalty, 0.0)
-
-        ratio = br_b.idle_penalty / br_a.idle_penalty if br_a.idle_penalty != 0 else None
-        self.assertIsNotNone(ratio)
-        if ratio is not None:
-            self.assertAlmostEqualFloat(abs(ratio), 2.0, tolerance=0.2)
-
-        idle_penalty_ratio = _get_float_param(params, "idle_penalty_ratio", 1.0)
-        idle_penalty_power = _get_float_param(params, "idle_penalty_power", 1.025)
-        idle_factor = base_factor * (profit_aim / risk_reward_ratio)
-        observed_ratio = abs(br_mid.idle_penalty) / (idle_factor * idle_penalty_ratio)
-        if observed_ratio > 0:
-            implied_max_idle_duration_candles = 120 / observed_ratio ** (1 / idle_penalty_power)
-            tolerance = 0.05 * expected_max_idle_duration_candles
-            self.assertAlmostEqualFloat(
-                implied_max_idle_duration_candles,
-                float(expected_max_idle_duration_candles),
-                tolerance=tolerance,
-            )
-
-    # Owns invariant: components-pbrs-breakdown-fields-119
+    # Owns invariant: components-economic-pbrs-breakdown-119
     def test_pbrs_breakdown_fields_finite_and_aligned(self):
         """Test PBRS breakdown fields are finite and mathematically aligned.
 

--- a/ReforceXY/reward_space_analysis/tests/helpers/assertions.py
+++ b/ReforceXY/reward_space_analysis/tests/helpers/assertions.py
@@ -1184,28 +1184,28 @@ def assert_relaxed_multi_reason_aggregation(
 def assert_pbrs_invariance_report_classification(
     test_case, content: str, expected_status: str, expect_additives: bool
 ):
-    """Validate PBRS invariance report classification and additive reporting.
+    """Validate PBRS algebraic report classification and additive reporting.
 
-    Checks that the invariance report correctly classifies PBRS behavior
+    Checks that the report correctly classifies PBRS algebraic conformance
     and appropriately reports additive component involvement.
 
     Args:
         test_case: Test case instance with assertion methods
         content: Report content string to validate
-        expected_status: Expected classification: "Canonical",
-                        "Canonical (with warning)", or "Non-canonical"
+        expected_status: Expected classification such as "Canonical algebraic conformance",
+                        "Algebraic contract violation", or "Non-conformant configuration"
         expect_additives: Whether additive components should be mentioned
 
     Example:
         assert_pbrs_invariance_report_classification(
-            self, report_content, "Canonical", expect_additives=False
+            self, report_content, "Canonical algebraic conformance", expect_additives=False
         )
         assert_pbrs_invariance_report_classification(
-            self, report_content, "Non-canonical", expect_additives=True
+            self, report_content, "Non-conformant configuration", expect_additives=True
         )
     """
     test_case.assertIn(
-        expected_status, content, f"Expected invariance status '{expected_status}' not found"
+        expected_status, content, f"Expected algebraic status '{expected_status}' not found"
     )
     if expect_additives:
         test_case.assertRegex(

--- a/ReforceXY/reward_space_analysis/tests/helpers/test_internal_branches.py
+++ b/ReforceXY/reward_space_analysis/tests/helpers/test_internal_branches.py
@@ -38,24 +38,25 @@ def test_get_bool_param_none_and_invalid_literal():
     assert _get_bool_param(params_invalid, "check_invariants", True) is True
 
 
-def test_calculate_reward_unrealized_pnl_hold_path():
-    """Verify unrealized PnL branch activates during hold action.
+def test_calculate_reward_current_pnl_hold_path():
+    """Verify current PnL drives liquidation value during a hold action.
 
-    Tests that when hold_potential_enabled and unrealized_pnl are both True,
-    the reward calculation uses max/min unrealized profit to compute next_pnl
-    via the tanh transformation path.
+    The reward calculation uses current_pnl for next_pnl. The extrema remain
+    available to other diagnostics but do not replace current_pnl here.
 
     **Setup:**
     - Position: Long, Action: Neutral (hold)
-    - PnL: 0.01, max_unrealized_profit: 0.02, min_unrealized_profit: -0.01
-    - Parameters: hold_potential_enabled=True, unrealized_pnl=True
+    - Current PnL: 0.01
+    - Extrema: max_unrealized_profit=0.02, min_unrealized_profit=-0.01
+    - Parameters: hold_potential_enabled=True
     - Trade duration: 5 steps
 
     **Assertions:**
+    - Reward and next liquidation values equal 1 + current_pnl
     - Both prev_potential and next_potential are finite
     - At least one potential is non-zero (shaping should activate)
     """
-    # Exercise unrealized_pnl branch during hold to cover next_pnl tanh path
+    # Exercise the fee-aware marked-to-liquidation hold path.
     context = make_ctx(
         pnl=0.01,
         trade_duration=5,
@@ -67,7 +68,6 @@ def test_calculate_reward_unrealized_pnl_hold_path():
     )
     params = {
         "hold_potential_enabled": True,
-        "unrealized_pnl": True,
         "pnl_amplification_sensitivity": 0.5,
     }
     breakdown = calculate_reward_with_defaults(
@@ -78,6 +78,8 @@ def test_calculate_reward_unrealized_pnl_hold_path():
         risk_reward_ratio=PARAMS.RISK_REWARD_RATIO,
         prev_potential=np.nan,
     )
+    assert math.isclose(breakdown.reward_liquidation_value, 1.01)
+    assert math.isclose(breakdown.next_liquidation_value, 1.01)
     assert math.isfinite(breakdown.prev_potential)
     assert math.isfinite(breakdown.next_potential)
     # shaping should activate (non-zero or zero after potential difference)

--- a/ReforceXY/reward_space_analysis/tests/integration/test_integration.py
+++ b/ReforceXY/reward_space_analysis/tests/integration/test_integration.py
@@ -9,6 +9,8 @@ from pathlib import Path
 
 import pytest
 
+from reward_space_analysis import BASE_ENVIRONMENT_FEE_FALLBACK
+
 from ..constants import SCENARIOS, SEEDS
 from ..test_base import RewardSpaceTestBase
 
@@ -99,6 +101,10 @@ class TestIntegration(RewardSpaceTestBase):
                 "params_hash",
                 "reward_params",
                 "simulation_params",
+                "reward_contract",
+                "cost_accounting",
+                "episode_boundaries",
+                "compatibility_only",
             }
             self.assertTrue(
                 required_keys.issubset(manifest.keys()),
@@ -111,6 +117,12 @@ class TestIntegration(RewardSpaceTestBase):
             self.assertNotIn("params", manifest)
             self.assertEqual(manifest["num_samples"], SCENARIOS.SAMPLE_SIZE_SMALL)
             self.assertEqual(manifest["seed"], SEEDS.BASE)
+            self.assertEqual(
+                manifest["reward_contract"]["name"],
+                "pair_local_net_log_liquidation_return",
+            )
+            self.assertEqual(manifest["cost_accounting"]["fee_rate"], BASE_ENVIRONMENT_FEE_FALLBACK)
+            self.assertEqual(manifest["episode_boundaries"]["termination"], "economic_ruin")
 
         with (self.output_path / "run1" / "manifest.json").open() as f:
             manifest1 = json.load(f)

--- a/ReforceXY/reward_space_analysis/tests/integration/test_report_formatting.py
+++ b/ReforceXY/reward_space_analysis/tests/integration/test_report_formatting.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """Report formatting focused tests moved from helpers/test_utilities.py.
 
-Owns invariant: report-abs-shaping-line-091 (integration category)
+Owns invariant: report-raw-shaping-diagnostic-091 (integration category)
 """
 
 import re
@@ -60,7 +60,9 @@ class TestReportFormatting(RewardSpaceTestBase):
         # Ensure required columns present (action required for summary stats)
         required_cols = [
             "action",
+            "reward_economic",
             "reward_invalid",
+            "reward_exit",
             "reward_shaping",
             "reward_entry_additive",
             "reward_exit_additive",
@@ -70,8 +72,12 @@ class TestReportFormatting(RewardSpaceTestBase):
         df = df.copy()
         for col in required_cols:
             if col not in df.columns:
-                if col == "action":
-                    df[col] = 0.0
+                if col == "reward_economic":
+                    df[col] = (
+                        df.get("reward", 0.0)
+                        - df.get("reward_invalid", 0.0)
+                        - df.get("reward_shaping", 0.0)
+                    )
                 else:
                     df[col] = 0.0
         write_complete_statistical_analysis(
@@ -90,8 +96,8 @@ class TestReportFormatting(RewardSpaceTestBase):
         report_path = out_dir / "statistical_analysis.md"
         return report_path.read_text(encoding="utf-8")
 
-    def test_abs_shaping_line_present_and_constant(self):
-        """Abs Σ Shaping Reward line present, formatted, uses constant not literal."""
+    def test_raw_shaping_line_is_explicitly_descriptive(self):
+        """The raw shaping sum is formatted as a diagnostic, never an invariance gate."""
         df = pd.DataFrame(
             {
                 "reward_shaping": [TOLERANCE.IDENTITY_STRICT, -TOLERANCE.IDENTITY_STRICT],
@@ -101,9 +107,12 @@ class TestReportFormatting(RewardSpaceTestBase):
         )
         total_shaping = df["reward_shaping"].sum()
         self.assertLess(abs(total_shaping), PBRS_INVARIANCE_TOL)
-        lines = [f"| Abs Σ Shaping Reward | {abs(total_shaping):.6e} |"]
+        lines = [f"| Abs Raw Σ Shaping (not a classifier) | {abs(total_shaping):.6e} |"]
         content = "\n".join(lines)
-        m = re.search("\\| Abs Σ Shaping Reward \\| ([0-9]+\\.[0-9]{6}e[+-][0-9]{2}) \\|", content)
+        m = re.search(
+            "\\| Abs Raw Σ Shaping \\(not a classifier\\) \\| ([0-9]+\\.[0-9]{6}e[+-][0-9]{2}) \\|",
+            content,
+        )
         self.assertIsNotNone(m, "Abs Σ Shaping Reward line missing or misformatted")
         val = float(m.group(1)) if m else None
         if val is not None:
@@ -158,7 +167,7 @@ class TestReportFormatting(RewardSpaceTestBase):
 
         Verifies:
         - PBRS Metrics subsection exists when PBRS columns present
-        - Section includes Mean Base Reward, Mean PBRS Term, Mean Invariance Correction
+        - Section includes Mean Base Reward, Mean PBRS Term, and algebraic correction metrics
         - All metrics are formatted with proper precision
         """
         # Create df with PBRS columns
@@ -192,6 +201,14 @@ class TestReportFormatting(RewardSpaceTestBase):
 
         # Verify PBRS Metrics section exists
         self.assertIn("**PBRS Metrics:**", content)
+        self.assertIn(
+            "| Normal? (Shapiro-Wilk) | N/A (constant distribution) |",
+            content,
+        )
+        self.assertIn(
+            "| Normal? (Anderson-Darling) | N/A (constant distribution) |",
+            content,
+        )
 
         # Verify key metrics are present
         required_metrics = [
@@ -199,9 +216,9 @@ class TestReportFormatting(RewardSpaceTestBase):
             "Std Base Reward",
             "Mean PBRS Delta",
             "Std PBRS Delta",
-            "Mean Invariance Correction",
-            "Std Invariance Correction",
-            "Max \\|Invariance Correction\\|",
+            "Mean Algebraic Correction",
+            "Std Algebraic Correction",
+            "Max \\|Algebraic Correction\\|",
             "Mean \\|PBRS\\| / \\|Base\\| Ratio",
         ]
 

--- a/ReforceXY/reward_space_analysis/tests/integration/test_reward_calculation.py
+++ b/ReforceXY/reward_space_analysis/tests/integration/test_reward_calculation.py
@@ -36,32 +36,28 @@ class TestRewardCalculation(RewardSpaceTestBase):
     """High-level integration smoke tests for reward calculation."""
 
     @pytest.mark.smoke
-    def test_reward_component_activation_smoke(
+    def test_economic_transition_decomposition_smoke(
         self,
     ):
-        """Smoke: each primary component activates in a representative scenario.
-
-        # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
-        Detailed progressive / boundary / proportional invariants are NOT asserted here.
-        We only check sign / non-zero activation plus total decomposition identity.
-        """
+        """Smoke the neutral, hold, exit and invalid-action economic transitions."""
         scenarios = [
             (
-                "hold_penalty_active",
+                "marked_hold",
                 self.make_ctx(
-                    pnl=0.0,
+                    pnl=0.01,
                     trade_duration=HOLD_PENALTY_ACTIVE_TRADE_DURATION,  # > default threshold
                     idle_duration=0,
                     max_unrealized_profit=0.02,
                     min_unrealized_profit=-0.01,
                     position=Positions.Long,
                     action=Actions.Neutral,
+                    previous_liquidation_value=0.99,
                 ),
-                "hold_penalty",
+                1,
                 True,
             ),
             (
-                "idle_penalty_active",
+                "neutral_self_loop",
                 self.make_ctx(
                     pnl=0.0,
                     trade_duration=0,
@@ -71,7 +67,7 @@ class TestRewardCalculation(RewardSpaceTestBase):
                     position=Positions.Neutral,
                     action=Actions.Neutral,
                 ),
-                "idle_penalty",
+                0,
                 True,
             ),
             (
@@ -85,7 +81,7 @@ class TestRewardCalculation(RewardSpaceTestBase):
                     position=Positions.Long,
                     action=Actions.Long_exit,
                 ),
-                "exit_component",
+                1,
                 True,
             ),
             (
@@ -99,12 +95,12 @@ class TestRewardCalculation(RewardSpaceTestBase):
                     position=Positions.Short,
                     action=Actions.Long_exit,  # invalid pairing
                 ),
-                "invalid_penalty",
+                None,
                 False,
             ),
         ]
 
-        for name, ctx, expected_component, action_masking in scenarios:
+        for name, ctx, expected_sign, action_masking in scenarios:
             with self.subTest(scenario=name):
                 breakdown = calculate_reward_with_defaults(
                     ctx,
@@ -112,22 +108,17 @@ class TestRewardCalculation(RewardSpaceTestBase):
                     action_masking=action_masking,
                 )
 
-                value = getattr(breakdown, expected_component)
-                # Sign / activation expectations
-                if expected_component in {"hold_penalty", "idle_penalty", "invalid_penalty"}:
-                    self.assertLess(value, 0.0, f"{expected_component} should be negative: {name}")
-                elif expected_component == "exit_component":
-                    self.assertGreater(value, 0.0, f"exit_component should be positive: {name}")
+                if expected_sign == 1:
+                    self.assertGreater(breakdown.economic_component, 0.0, name)
+                elif expected_sign == 0:
+                    self.assertEqual(breakdown.economic_component, 0.0, name)
+                else:
+                    self.assertLess(breakdown.invalid_penalty, 0.0, name)
 
-                # Decomposition identity (relaxed tolerance)
                 comp_sum = (
-                    breakdown.exit_component
-                    + breakdown.idle_penalty
-                    + breakdown.hold_penalty
+                    breakdown.economic_component
                     + breakdown.invalid_penalty
                     + breakdown.reward_shaping
-                    + breakdown.entry_additive
-                    + breakdown.exit_additive
                 )
                 self.assertAlmostEqualFloat(
                     breakdown.total,
@@ -135,6 +126,10 @@ class TestRewardCalculation(RewardSpaceTestBase):
                     tolerance=TOLERANCE.IDENTITY_RELAXED,
                     msg=f"Total != sum components in {name}",
                 )
+                self.assertEqual(breakdown.idle_penalty, 0.0)
+                self.assertEqual(breakdown.hold_penalty, 0.0)
+                self.assertEqual(breakdown.entry_additive, 0.0)
+                self.assertEqual(breakdown.exit_additive, 0.0)
 
     def test_long_short_symmetry_smoke(self):
         """Smoke: exit component sign & approximate magnitude symmetry for long vs short.

--- a/ReforceXY/reward_space_analysis/tests/pbrs/test_pbrs.py
+++ b/ReforceXY/reward_space_analysis/tests/pbrs/test_pbrs.py
@@ -19,7 +19,7 @@ from reward_space_analysis import (
     _compute_exit_additive,
     _compute_exit_potential,
     _compute_hold_potential,
-    _compute_unrealized_pnl_estimate,
+    _compute_spot_local_trade_pnl_estimate,
     _get_float_param,
     apply_potential_shaping,
     get_max_idle_duration_candles,
@@ -107,8 +107,8 @@ class TestPBRS(RewardSpaceTestBase):
             reward_shaping, -prev_potential, tolerance=TOLERANCE.IDENTITY_RELAXED
         )
 
-    def test_pbrs_spike_cancel_invariance(self):
-        """Verifies spike_cancel mode produces near-zero terminal shaping."""
+    def test_noncanonical_spike_cancel_falls_back_to_canonical(self):
+        """Unsupported spike-cancel semantics cannot bypass canonical termination."""
         params = self.DEFAULT_PARAMS.copy()
         params.update(
             {
@@ -131,14 +131,6 @@ class TestPBRS(RewardSpaceTestBase):
             PARAMS.BASE_FACTOR,
         )
 
-        gamma = _get_float_param(
-            params,
-            "potential_gamma",
-            DEFAULT_MODEL_REWARD_PARAMETERS.get("potential_gamma", 0.95),
-        )
-        expected_next_potential = (
-            prev_potential / gamma if gamma not in (0.0, None) else prev_potential
-        )
         (
             _total_reward,
             reward_shaping,
@@ -160,10 +152,10 @@ class TestPBRS(RewardSpaceTestBase):
             prev_potential=prev_potential,
             params=params,
         )
+        self.assertAlmostEqualFloat(next_potential, 0.0, tolerance=TOLERANCE.IDENTITY_RELAXED)
         self.assertAlmostEqualFloat(
-            next_potential, expected_next_potential, tolerance=TOLERANCE.IDENTITY_RELAXED
+            reward_shaping, -prev_potential, tolerance=TOLERANCE.IDENTITY_RELAXED
         )
-        self.assertNearZero(reward_shaping, atol=TOLERANCE.IDENTITY_RELAXED)
 
     # ---------------- Invariance flags (simulate_samples) ---------------- #
 
@@ -199,8 +191,8 @@ class TestPBRS(RewardSpaceTestBase):
             self.assertFinite(float(v), name="reward_shaping")
         self.assertLessEqual(float(df["reward_shaping"].abs().max()), PBRS.MAX_ABS_SHAPING)
 
-    def test_non_canonical_flag_false_and_sum_nonzero(self):
-        """Non-canonical mode -> invariant flags False and Σ shaping non-zero."""
+    def test_noncanonical_simulation_is_canonicalized(self):
+        """The simulator exposes only the canonical PBRS contract."""
 
         params = self.base_params(
             exit_potential_mode="progressive_release",
@@ -222,7 +214,7 @@ class TestPBRS(RewardSpaceTestBase):
             pnl_duration_vol_scale=PARAMS.PNL_DUR_VOL_SCALE,
         )
         unique_flags = set(df["pbrs_invariant"].unique().tolist())
-        self.assertEqual(unique_flags, {False}, f"Unexpected invariant flags: {unique_flags}")
+        self.assertEqual(unique_flags, {True}, f"Unexpected invariant flags: {unique_flags}")
         abs_sum = float(df["reward_shaping"].abs().sum())
         self.assertGreater(
             abs_sum,
@@ -498,8 +490,8 @@ class TestPBRS(RewardSpaceTestBase):
         max_abs = max(abs(v) for v in shaping_values) if shaping_values else 0.0
         self.assertLessEqual(max_abs, PBRS.MAX_ABS_SHAPING)
 
-    def test_progressive_release_negative_decay_clamped(self):
-        """Verifies negative decay clamping: next potential equals last potential."""
+    def test_noncanonical_negative_decay_still_terminates_potential(self):
+        """Deprecated decay values cannot retain potential at an exit."""
         params = self.base_params(
             exit_potential_mode="progressive_release",
             exit_potential_decay=-0.75,
@@ -521,20 +513,8 @@ class TestPBRS(RewardSpaceTestBase):
                 params=params,
             )
         )
-        self.assertPlacesEqual(
-            next_potential, prev_potential, places=TOLERANCE.DECIMAL_PLACES_STRICT
-        )
-        raw_gamma = DEFAULT_MODEL_REWARD_PARAMETERS.get("potential_gamma", 0.95)
-        gamma_fallback = 0.95 if raw_gamma is None else raw_gamma
-        try:
-            gamma = float(gamma_fallback)
-        except Exception:
-            gamma = 0.95
-        # PBRS shaping Δ = γ·Φ(next) - Φ(prev). Here Φ(next)=Φ(prev) since decay clamps to 0.
-        self.assertLessEqual(
-            abs(shaping - ((gamma - 1.0) * prev_potential)),
-            TOLERANCE.GENERIC_EQ,
-        )
+        self.assertPlacesEqual(next_potential, 0.0, places=TOLERANCE.DECIMAL_PLACES_STRICT)
+        self.assertPlacesEqual(shaping, -prev_potential, places=TOLERANCE.DECIMAL_PLACES_STRICT)
         self.assertPlacesEqual(total, shaping, places=TOLERANCE.DECIMAL_PLACES_STRICT)
 
     def test_potential_gamma_nan_fallback(self):
@@ -583,13 +563,12 @@ class TestPBRS(RewardSpaceTestBase):
     def test_calculate_reward_entry_next_pnl_fee_aware(self):
         """calculate_reward() entry PBRS uses fee-aware next_pnl estimate."""
         params = self.base_params(
-            exit_potential_mode="non_canonical",
+            exit_potential_mode="canonical",
             hold_potential_enabled=True,
             entry_additive_enabled=False,
             exit_additive_enabled=False,
             potential_gamma=0.9,
-            entry_fee_rate=0.001,
-            exit_fee_rate=0.001,
+            fee_rate=0.001,
         )
 
         for action in (Actions.Long_enter, Actions.Short_enter):
@@ -605,74 +584,72 @@ class TestPBRS(RewardSpaceTestBase):
                 f"Expected negative next_potential on entry for action={action}",
             )
 
-    def test_fee_rates_are_clamped_to_parameter_bounds(self):
-        """Fee clamping uses _PARAMETER_BOUNDS (max 0.1)."""
-        cases = [
-            ("entry_fee_rate", self.base_params(entry_fee_rate=999.0, exit_fee_rate=0.0)),
-            ("exit_fee_rate", self.base_params(entry_fee_rate=0.0, exit_fee_rate=999.0)),
-        ]
+    def test_fee_rate_is_bounded_by_parameter_validation(self):
+        """Strict validation rejects excessive fees and relaxed validation clamps them."""
+        params = self.base_params(fee_rate=999.0)
+        with self.assertRaisesRegex(ValueError, "above max 0.1"):
+            validate_reward_parameters(params, strict=True)
+        sanitized, adjustments = validate_reward_parameters(params, strict=False)
+        self.assertEqual(sanitized["fee_rate"], 0.1)
+        self.assertIn("max=0.1", adjustments["fee_rate"]["reason"])
 
-        for key, params in cases:
-            pnl_clamped = _compute_unrealized_pnl_estimate(
-                Positions.Long,
-                entry_open=1.0,
-                current_open=1.0,
-                params=params,
-            )
-            pnl_expected = _compute_unrealized_pnl_estimate(
-                Positions.Long,
-                entry_open=1.0,
-                current_open=1.0,
-                params={**params, key: 0.1},
-            )
-            self.assertAlmostEqualFloat(
-                pnl_clamped,
-                pnl_expected,
-                tolerance=TOLERANCE.IDENTITY_STRICT,
-                msg=f"Expected {key} values above max to clamp to 0.1",
-            )
+    # Owns invariant: pbrs-unified-fee-primitives-122
+    def test_unrealized_pnl_uses_unified_freqtrade_fee(self):
+        """Long and short marks reproduce native spot LocalTrade fee primitives."""
+        params = self.base_params(fee_rate=0.1)
 
-    def test_unrealized_pnl_estimate_uses_division_for_exit_fee(self):
-        """Exit fee uses division `open/(1+fee)`."""
-        params = self.base_params(entry_fee_rate=0.0, exit_fee_rate=0.1)
-
-        pnl_long = _compute_unrealized_pnl_estimate(
+        pnl_long = _compute_spot_local_trade_pnl_estimate(
             Positions.Long,
             entry_open=1.0,
             current_open=1.0,
             params=params,
         )
-        expected_pnl_long = (1.0 / 1.1 - 1.0) / 1.0
+        expected_pnl_long = float(f"{((1.0 - 0.1) / (1.0 + 0.1)) - 1.0:.8f}")
         self.assertAlmostEqualFloat(
             float(pnl_long),
             float(expected_pnl_long),
             tolerance=TOLERANCE.IDENTITY_STRICT,
-            msg="Long entry PnL mismatch for division-based exit fee",
+            msg="Long entry PnL mismatch for native LocalTrade fees",
         )
 
-        pnl_short = _compute_unrealized_pnl_estimate(
+        pnl_short = _compute_spot_local_trade_pnl_estimate(
             Positions.Short,
             entry_open=1.0,
             current_open=1.0,
             params=params,
         )
-        expected_pnl_short = (1.0 / 1.1 - 1.0) / (1.0 / 1.1)
+        expected_pnl_short = float(f"{1.0 - ((1.0 + 0.1) / (1.0 - 0.1)):.8f}")
         self.assertAlmostEqualFloat(
             float(pnl_short),
             float(expected_pnl_short),
             tolerance=TOLERANCE.IDENTITY_STRICT,
-            msg="Short entry PnL mismatch for division-based exit fee",
+            msg="Short entry PnL mismatch for native LocalTrade fees",
         )
 
-    def test_simulate_samples_initializes_pnl_on_entry(self):
-        """simulate_samples() sets in-position pnl to fee-aware entry estimate."""
+        boundary_long = _compute_spot_local_trade_pnl_estimate(
+            Positions.Long,
+            entry_open=0.0023495419767750668,
+            current_open=0.0013865227751233074,
+            params=self.base_params(fee_rate=0.03242886144889218),
+        )
+        self.assertEqual(boundary_long, -0.44694724)
+
+        boundary_short = _compute_spot_local_trade_pnl_estimate(
+            Positions.Short,
+            entry_open=0.002034122119849911,
+            current_open=0.0012583412865205445,
+            params=self.base_params(fee_rate=0.08376601506746104),
+        )
+        self.assertEqual(boundary_short, 0.26827052)
+
+    def test_simulate_samples_records_fee_aware_entry_mark(self):
+        """The entry row records the promotable native LocalTrade liquidation mark."""
         params = self.base_params(
-            exit_potential_mode="non_canonical",
-            hold_potential_enabled=True,
+            exit_potential_mode="canonical",
+            hold_potential_enabled=False,
             entry_additive_enabled=False,
             exit_additive_enabled=False,
-            entry_fee_rate=0.001,
-            exit_fee_rate=0.001,
+            fee_rate=0.001,
         )
 
         df = simulate_samples(
@@ -700,26 +677,18 @@ class TestPBRS(RewardSpaceTestBase):
             "Expected Neutral position on Long_enter row",
         )
 
-        next_pos = first_enter_pos + 1
-        self.assertLess(next_pos, len(enter_pos), "Sample must include post-entry step")
-        self.assertEqual(
-            float(enter_pos.iloc[next_pos]["position"]),
-            float(Positions.Long.value),
-            "Expected Long position immediately after Long_enter",
-        )
-
-        expected_pnl = _compute_unrealized_pnl_estimate(
+        expected_pnl = _compute_spot_local_trade_pnl_estimate(
             Positions.Long,
             entry_open=1.0,
             current_open=1.0,
             params=params,
         )
-        post_entry_pnl = float(enter_pos.iloc[next_pos]["pnl"])
+        entry_mark = float(enter_pos.iloc[first_enter_pos]["reward_liquidation_value"])
         self.assertAlmostEqualFloat(
-            post_entry_pnl,
-            expected_pnl,
+            entry_mark,
+            1.0 + expected_pnl,
             tolerance=TOLERANCE.IDENTITY_STRICT,
-            msg="Expected pnl after entry to match entry fee estimate",
+            msg="Expected entry liquidation mark to use native LocalTrade fees",
         )
 
     def test_calculate_reward_hold_uses_current_duration_ratio(self):
@@ -814,8 +783,8 @@ class TestPBRS(RewardSpaceTestBase):
 
     # ---------------- Exit potential mode comparisons ---------------- #
 
-    def test_compute_exit_potential_mode_differences(self):
-        """Exit potential modes: canonical vs spike_cancel shaping magnitude differences."""
+    def test_unsupported_exit_potential_mode_matches_canonical(self):
+        """Every unsupported exit mode degrades to the canonical zero terminal potential."""
         gamma = 0.93
         base_common = {
             "hold_potential_enabled": True,
@@ -853,15 +822,16 @@ class TestPBRS(RewardSpaceTestBase):
         params_spike = self.base_params(exit_potential_mode="spike_cancel", **base_common)
         next_phi_spike = _compute_exit_potential(prev_phi, params_spike)
         shaping_spike = gamma * next_phi_spike - prev_phi
-        self.assertNearZero(
-            shaping_spike,
-            atol=TOLERANCE.IDENTITY_RELAXED,
-            msg="Spike cancel should nullify shaping delta",
+        self.assertAlmostEqualFloat(
+            next_phi_spike,
+            0.0,
+            tolerance=TOLERANCE.IDENTITY_RELAXED,
+            msg="Unsupported modes must use the canonical terminal potential",
         )
-        self.assertGreaterEqual(
-            abs(canonical_delta) + TOLERANCE.IDENTITY_STRICT,
-            abs(shaping_spike),
-            "Canonical shaping magnitude should exceed spike_cancel",
+        self.assertAlmostEqualFloat(
+            shaping_spike,
+            canonical_delta,
+            tolerance=TOLERANCE.IDENTITY_RELAXED,
         )
 
     def test_pbrs_retain_previous_cumulative_drift(self):
@@ -985,10 +955,7 @@ class TestPBRS(RewardSpaceTestBase):
         )
         self.assertAlmostEqualFloat(
             breakdown.total,
-            breakdown.invalid_penalty
-            + breakdown.reward_shaping
-            + breakdown.entry_additive
-            + breakdown.exit_additive,
+            breakdown.economic_component + breakdown.invalid_penalty + breakdown.reward_shaping,
             tolerance=TOLERANCE.IDENTITY_RELAXED,
             msg="Total should decompose for invalid actions",
         )
@@ -1050,10 +1017,10 @@ class TestPBRS(RewardSpaceTestBase):
 
     # ---------------- Report classification / formatting ---------------- #
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101), robustness/test_robustness.py:127 (robustness-exit-pnl-only-117)
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101), robustness/test_robustness.py:86 (robustness-episode-boundaries-117)
     @pytest.mark.smoke
-    def test_pbrs_non_canonical_report_generation(self):
-        """Synthetic invariance section: Non-canonical classification formatting."""
+    def test_pbrs_ineligible_report_formatting(self):
+        """Synthetic report formatting distinguishes ineligible configuration from PBRS proof."""
 
         df = pd.DataFrame(
             {
@@ -1064,23 +1031,26 @@ class TestPBRS(RewardSpaceTestBase):
         )
         total_shaping = df["reward_shaping"].sum()
         self.assertGreater(abs(total_shaping), PBRS_INVARIANCE_TOL)
-        invariance_status = "❌ Non-canonical"
+        invariance_status = "❌ Non-conformant configuration"
         section = []
-        section.append("**PBRS Invariance Summary:**\n")
+        section.append("**PBRS Algebraic Conformance Summary:**\n")
         section.append("| Field | Value |\n")
         section.append("|-------|-------|\n")
-        section.append(f"| Invariance | {invariance_status} |\n")
+        section.append(f"| Algebraic Status | {invariance_status} |\n")
         section.append(f"| Note | Total shaping = {total_shaping:.6f} (non-zero) |\n")
-        section.append(f"| Σ Shaping Reward | {total_shaping:.6f} |\n")
-        section.append(f"| Abs Σ Shaping Reward | {abs(total_shaping):.6e} |\n")
+        section.append(f"| Raw Σ Shaping Reward (descriptive only) | {total_shaping:.6f} |\n")
+        section.append(f"| Abs Raw Σ Shaping (not a classifier) | {abs(total_shaping):.6e} |\n")
         section.append(f"| Σ Entry Additive | {df['reward_entry_additive'].sum():.6f} |\n")
         section.append(f"| Σ Exit Additive | {df['reward_exit_additive'].sum():.6f} |\n")
         content = "".join(section)
         assert_pbrs_invariance_report_classification(
-            self, content, "Non-canonical", expect_additives=False
+            self, content, "Non-conformant configuration", expect_additives=False
         )
-        self.assertRegex(content, "Σ Shaping Reward \\| 0\\.008000 \\|")
-        m_abs = re.search("Abs Σ Shaping Reward \\| ([0-9.]+e[+-][0-9]{2}) \\|", content)
+        self.assertRegex(content, "Raw Σ Shaping Reward \\(descriptive only\\) \\| 0\\.008000 \\|")
+        m_abs = re.search(
+            "Abs Raw Σ Shaping \\(not a classifier\\) \\| ([0-9.]+e[+-][0-9]{2}) \\|",
+            content,
+        )
         self.assertIsNotNone(m_abs)
         if m_abs:
             val = float(m_abs.group(1))
@@ -1219,20 +1189,20 @@ class TestPBRS(RewardSpaceTestBase):
             f"Expected non-zero shaping (got {shaping_sum})",
         )
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
-    # Owns invariant: pbrs-canonical-near-zero-report-116
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101)
+    # Owns invariant: pbrs-canonical-correction-report-116
     @pytest.mark.smoke
-    def test_pbrs_canonical_near_zero_report(self):
-        """Invariant 116: canonical near-zero cumulative shaping classified in full report."""
+    def test_pbrs_canonical_verified_by_termwise_correction(self):
+        """Invariant 116: correction and discounted telescoping verify PBRS algebra."""
 
-        small_vals = [1.0e-7, -2.0e-7, 3.0e-7]  # sum = 2.0e-7 < tolerance
+        small_vals = [0.19, -0.105, -0.1]
         total_shaping = float(sum(small_vals))
-        self.assertLess(
+        self.assertGreater(
             abs(total_shaping),
             PBRS_INVARIANCE_TOL,
-            f"Total shaping {total_shaping} exceeds invariance tolerance",
+            "Raw shaping sum must be non-zero to prove it is not the classifier",
         )
-        inv_corr_vals = [1.0e-7, -1.0e-7, 2.0e-7]
+        inv_corr_vals = [0.0, 0.0, 0.0]
         max_abs_corr = float(np.max(np.abs(inv_corr_vals)))
         self.assertLess(max_abs_corr, PBRS_INVARIANCE_TOL)
 
@@ -1240,6 +1210,7 @@ class TestPBRS(RewardSpaceTestBase):
         df = pd.DataFrame(
             {
                 "reward": np.random.normal(0, 1, n),
+                "reward_economic": np.random.normal(0, 1, n),
                 "reward_idle": np.zeros(n),
                 "reward_hold": np.random.normal(-0.2, 0.05, n),
                 "reward_exit": np.random.normal(0.4, 0.15, n),
@@ -1253,12 +1224,18 @@ class TestPBRS(RewardSpaceTestBase):
                 "reward_exit_additive": [0.0] * n,
                 "reward_invariance_correction": inv_corr_vals,
                 "reward_invalid": np.zeros(n),
+                "prev_potential": [0.0, 0.2, 0.1],
+                "next_potential": [0.2, 0.1, 0.0],
+                "terminated": [False, False, True],
+                "truncated": [False, False, False],
                 "duration_ratio": np.random.uniform(0.2, 1.0, n),
                 "idle_ratio": np.zeros(n),
             }
         )
         df.attrs["reward_params"] = {
             "exit_potential_mode": "canonical",
+            "potential_gamma": 0.95,
+            "hold_potential_enabled": True,
             "entry_additive_enabled": False,
             "exit_additive_enabled": False,
         }
@@ -1277,27 +1254,32 @@ class TestPBRS(RewardSpaceTestBase):
         self.assertTrue(report_path.exists(), "Report file missing for canonical near-zero test")
         content = report_path.read_text(encoding="utf-8")
         assert_pbrs_invariance_report_classification(
-            self, content, "Canonical", expect_additives=False
+            self, content, "Canonical algebraic conformance", expect_additives=False
         )
-        self.assertRegex(content, r"\| Σ Shaping Reward \| 0\.000000 \|")
-        m_abs = re.search(r"\| Abs Σ Shaping Reward \| ([0-9.]+e[+-][0-9]{2}) \|", content)
+        self.assertRegex(content, r"\| Raw Σ Shaping Reward \(descriptive only\) \| -0\.015000 \|")
+        m_abs = re.search(
+            r"\| Abs Raw Σ Shaping \(not a classifier\) \| ([0-9.]+e[+-][0-9]{2}) \|",
+            content,
+        )
         self.assertIsNotNone(m_abs)
         if m_abs:
             val_abs = float(m_abs.group(1))
             self.assertAlmostEqual(
                 abs(total_shaping), val_abs, places=TOLERANCE.DECIMAL_PLACES_STRICT
             )
-        self.assertIn("max|correction|≈0", content)
+        residual_match = re.search(
+            r"\| Discounted Telescoping Residual \| ([0-9.]+e[+-][0-9]{2}) \|",
+            content,
+        )
+        self.assertIsNotNone(residual_match)
+        if residual_match:
+            self.assertLess(abs(float(residual_match.group(1))), PBRS_INVARIANCE_TOL)
+        self.assertIn("True termination: Phi(final)=0 is required.", content)
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101)
     @pytest.mark.smoke
-    def test_pbrs_canonical_suppresses_additives_in_report(self):
-        """Canonical exit mode suppresses additives for classification.
-
-        The reward engine suppresses additive terms when exit_potential_mode is "canonical".
-        The report should align: classification stays canonical and should not claim
-        non-canonical additives involvement.
-        """
+    def test_pbrs_requested_additives_are_reported_ineligible(self):
+        """Requested additives make imported report configuration ineligible."""
 
         small_vals = [1.0e-7, -2.0e-7, 3.0e-7]  # sum = 2.0e-7 < tolerance
         total_shaping = float(sum(small_vals))
@@ -1310,6 +1292,7 @@ class TestPBRS(RewardSpaceTestBase):
         df = pd.DataFrame(
             {
                 "reward": np.random.normal(0, 1, n),
+                "reward_economic": np.random.normal(0, 1, n),
                 "reward_idle": np.zeros(n),
                 "reward_hold": np.random.normal(-0.2, 0.05, n),
                 "reward_exit": np.random.normal(0.4, 0.15, n),
@@ -1346,17 +1329,16 @@ class TestPBRS(RewardSpaceTestBase):
         report_path = out_dir / "statistical_analysis.md"
         self.assertTrue(report_path.exists(), "Report file missing for canonical additives test")
         content = report_path.read_text(encoding="utf-8")
-        assert_pbrs_invariance_report_classification(
-            self, content, "Canonical", expect_additives=False
-        )
-        self.assertIn("Additives are suppressed in canonical mode", content)
+        self.assertIn("Non-conformant configuration", content)
+        self.assertIn("entry_additive_enabled=True", content)
+        self.assertIn("exit_additive_enabled=True", content)
         self.assertIn("| Entry Additive Enabled | True |", content)
         self.assertIn("| Exit Additive Enabled | True |", content)
         self.assertIn("| Entry Additive Effective | False |", content)
         self.assertIn("| Exit Additive Effective | False |", content)
 
-    def test_pbrs_canonical_warning_report(self):
-        """Canonical mode + no additives but max|invariance_correction| > tolerance -> warning."""
+    def test_pbrs_canonical_contract_violation_report(self):
+        """A non-zero termwise correction is an algebraic contract violation."""
 
         shaping_vals = [1.2e-4, 1.3e-4, 8.0e-5, -2.0e-5, 1.4e-4]  # Σ not near 0
         total_shaping = float(sum(shaping_vals))
@@ -1370,6 +1352,7 @@ class TestPBRS(RewardSpaceTestBase):
         df = pd.DataFrame(
             {
                 "reward": np.random.normal(0, 1, n),
+                "reward_economic": np.random.normal(0, 1, n),
                 "reward_idle": np.zeros(n),
                 "reward_hold": np.random.normal(-0.2, 0.1, n),
                 "reward_exit": np.random.normal(0.5, 0.2, n),
@@ -1407,15 +1390,15 @@ class TestPBRS(RewardSpaceTestBase):
         self.assertTrue(report_path.exists(), "Report file missing for canonical warning test")
         content = report_path.read_text(encoding="utf-8")
         assert_pbrs_invariance_report_classification(
-            self, content, "Canonical (with warning)", expect_additives=False
+            self, content, "Algebraic contract violation", expect_additives=False
         )
         expected_corr_fragment = f"{max_abs_corr:.6e}"
         self.assertIn(expected_corr_fragment, content)
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101)
     @pytest.mark.smoke
-    def test_pbrs_non_canonical_full_report_reason_aggregation(self):
-        """Full report: Non-canonical classification aggregates mode + additives reasons."""
+    def test_pbrs_invalid_noncanonical_report_reason_aggregation(self):
+        """The report identifies every reason an imported configuration is invalid."""
 
         shaping_vals = [0.02, -0.005, 0.007]
         entry_add_vals = [0.003, 0.0, 0.004]
@@ -1424,6 +1407,7 @@ class TestPBRS(RewardSpaceTestBase):
         df = pd.DataFrame(
             {
                 "reward": np.random.normal(0, 1, n),
+                "reward_economic": np.random.normal(0, 1, n),
                 "reward_idle": np.zeros(n),
                 "reward_hold": np.random.normal(-0.1, 0.05, n),
                 "reward_exit": np.random.normal(0.4, 0.15, n),
@@ -1461,15 +1445,15 @@ class TestPBRS(RewardSpaceTestBase):
             report_path.exists(), "Report file missing for non-canonical full report test"
         )
         content = report_path.read_text(encoding="utf-8")
-        assert_pbrs_invariance_report_classification(
-            self, content, "Non-canonical", expect_additives=True
-        )
+        self.assertIn("Non-conformant configuration", content)
         self.assertIn("exit_potential_mode='progressive_release'", content)
+        self.assertIn("entry_additive_enabled=True", content)
+        self.assertIn("exit_additive_enabled=True", content)
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101)
     @pytest.mark.smoke
-    def test_pbrs_non_canonical_mode_only_reason(self):
-        """Non-canonical exit mode with additives disabled -> reason excludes additive list."""
+    def test_pbrs_invalid_noncanonical_mode_only_reason(self):
+        """A lone unsupported mode is reported without inventing additive reasons."""
 
         shaping_vals = [0.002, -0.0005, 0.0012]
         total_shaping = sum(shaping_vals)
@@ -1478,6 +1462,7 @@ class TestPBRS(RewardSpaceTestBase):
         df = pd.DataFrame(
             {
                 "reward": np.random.normal(0, 1, n),
+                "reward_economic": np.random.normal(0, 1, n),
                 "reward_idle": np.zeros(n),
                 "reward_hold": np.random.normal(-0.15, 0.05, n),
                 "reward_exit": np.random.normal(0.3, 0.1, n),
@@ -1515,20 +1500,20 @@ class TestPBRS(RewardSpaceTestBase):
             report_path.exists(), "Report file missing for non-canonical mode-only reason test"
         )
         content = report_path.read_text(encoding="utf-8")
-        assert_pbrs_invariance_report_classification(
-            self, content, "Non-canonical", expect_additives=False
-        )
+        self.assertIn("Non-conformant configuration", content)
         self.assertIn("exit_potential_mode='retain_previous'", content)
+        self.assertNotIn("additives=['entry', 'exit']", content)
 
-    # Owns invariant: pbrs-absence-shift-placeholder-118
-    def test_pbrs_absence_and_distribution_shift_placeholder(self):
-        """Report generation without PBRS columns triggers absence + shift placeholder."""
+    # Owns invariant: pbrs-unverified-shift-placeholder-118
+    def test_pbrs_unverified_without_correction_and_shift_placeholder(self):
+        """Missing termwise correction is unverified while distribution shift stays explicit."""
 
         n = 90
         rng = np.random.default_rng(SEEDS.CANONICAL_SWEEP)
         df = pd.DataFrame(
             {
                 "reward": rng.normal(0.05, 0.02, n),
+                "reward_economic": rng.normal(0.05, 0.02, n),
                 "reward_idle": np.concatenate(
                     [
                         rng.normal(-0.01, 0.003, n // 2),
@@ -1543,10 +1528,19 @@ class TestPBRS(RewardSpaceTestBase):
                 "position": rng.choice([0.0, 0.5, 1.0], n),
                 "action": rng.integers(0, 3, n),
                 "reward_invalid": np.zeros(n),
+                "reward_shaping": np.zeros(n),
+                "reward_entry_additive": np.zeros(n),
+                "reward_exit_additive": np.zeros(n),
                 "duration_ratio": rng.uniform(0.2, 1.0, n),
                 "idle_ratio": rng.uniform(0.0, 0.8, n),
             }
         )
+        df.attrs["reward_params"] = {
+            "exit_potential_mode": "canonical",
+            "hold_potential_enabled": True,
+            "entry_additive_enabled": False,
+            "exit_additive_enabled": False,
+        }
         out_dir = self.output_path / "pbrs_absence_and_shift_placeholder"
         original_compute_summary_stats = reward_space_analysis._compute_summary_stats
 
@@ -1585,7 +1579,8 @@ class TestPBRS(RewardSpaceTestBase):
         report_path = out_dir / "statistical_analysis.md"
         self.assertTrue(report_path.exists(), "Report file missing for PBRS absence test")
         content = report_path.read_text(encoding="utf-8")
-        self.assertIn("_PBRS components not present in this analysis._", content)
+        self.assertIn("Algebraic conformance unverified", content)
+        self.assertIn("raw shaping sum is not a classifier", content)
         self.assertIn("_Not performed (no real episodes provided)._", content)
 
     def test_get_max_idle_duration_candles_negative_or_zero_fallback(self):

--- a/ReforceXY/reward_space_analysis/tests/robustness/test_robustness.py
+++ b/ReforceXY/reward_space_analysis/tests/robustness/test_robustness.py
@@ -10,9 +10,9 @@ import pytest
 from reward_space_analysis import (
     ATTENUATION_MODES,
     ATTENUATION_MODES_WITH_LEGACY,
+    MIN_LIQUIDATION_VALUE,
     Actions,
     Positions,
-    RewardContext,
     _get_exit_factor,
     simulate_samples,
 )
@@ -26,9 +26,6 @@ from ..constants import (
 )
 from ..helpers import (
     assert_diagnostic_warning,
-    assert_exit_factor_attenuation_modes,
-    assert_exit_mode_mathematical_validation,
-    assert_single_active_component_with_additives,
     calculate_reward_with_defaults,
     capture_warnings,
 )
@@ -40,67 +37,30 @@ pytestmark = pytest.mark.robustness
 class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
     """Robustness invariants, attenuation maths, parameter edges, scaling, warnings."""
 
-    # Owns invariant: robustness-decomposition-integrity-101 (robustness category)
-    def test_decomposition_integrity(self):
-        """reward must equal the single active core component under mutually exclusive scenarios (idle/hold/exit/invalid)."""
+    # Owns invariant: robustness-economic-decomposition-101 (robustness category)
+    def test_economic_decomposition_integrity(self):
+        """Total is exactly economic reward plus invalid penalty and canonical PBRS."""
         scenarios = [
-            {
-                "ctx": self.make_ctx(
-                    pnl=0.0,
-                    trade_duration=0,
-                    idle_duration=25,
-                    max_unrealized_profit=0.0,
-                    min_unrealized_profit=0.0,
-                    position=Positions.Neutral,
-                    action=Actions.Neutral,
-                ),
-                "active": "idle_penalty",
-            },
-            {
-                "ctx": self.make_ctx(
-                    pnl=0.0,
-                    trade_duration=150,
-                    idle_duration=0,
-                    max_unrealized_profit=0.0,
-                    min_unrealized_profit=0.0,
-                    position=Positions.Long,
-                    action=Actions.Neutral,
-                ),
-                "active": "hold_penalty",
-            },
-            {
-                "ctx": self.make_ctx(
-                    pnl=PARAMS.PROFIT_AIM,
-                    trade_duration=60,
-                    idle_duration=0,
-                    max_unrealized_profit=0.05,
-                    min_unrealized_profit=0.01,
-                    position=Positions.Long,
-                    action=Actions.Long_exit,
-                ),
-                "active": "exit_component",
-            },
-            {
-                "ctx": self.make_ctx(
-                    pnl=0.01,
-                    trade_duration=10,
-                    idle_duration=0,
-                    max_unrealized_profit=0.02,
-                    min_unrealized_profit=0.0,
-                    position=Positions.Short,
-                    action=Actions.Long_exit,
-                ),
-                "active": "invalid_penalty",
-            },
+            self.make_ctx(idle_duration=25),
+            self.make_ctx(
+                pnl=0.01,
+                position=Positions.Long,
+                action=Actions.Neutral,
+                previous_liquidation_value=0.99,
+            ),
+            self.make_ctx(
+                pnl=PARAMS.PROFIT_AIM,
+                position=Positions.Long,
+                action=Actions.Long_exit,
+            ),
+            self.make_ctx(
+                pnl=0.01,
+                position=Positions.Short,
+                action=Actions.Long_exit,
+            ),
         ]
-        for sc in scenarios:
-            ctx_obj = sc["ctx"]
-            active_label = sc["active"]
-            assert isinstance(ctx_obj, RewardContext), (
-                f"Expected RewardContext, got {type(ctx_obj)}"
-            )
-            assert isinstance(active_label, str), f"Expected str, got {type(active_label)}"
-            with self.subTest(active=active_label):
+        for context in scenarios:
+            with self.subTest(position=context.position, action=context.action):
                 params = self.base_params(
                     entry_additive_enabled=False,
                     exit_additive_enabled=False,
@@ -108,23 +68,18 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
                     potential_gamma=0.0,
                     check_invariants=False,
                 )
-                br = calculate_reward_with_defaults(ctx_obj, params)
-                # Relaxed tolerance: Accumulated floating-point errors across multiple
-                # reward component calculations (entry, hold, exit additives, and penalties)
-                assert_single_active_component_with_additives(
-                    self,
-                    br,
-                    active_label,
-                    TOLERANCE.IDENTITY_RELAXED,
-                    inactive_core=[
-                        "exit_component",
-                        "idle_penalty",
-                        "hold_penalty",
-                        "invalid_penalty",
-                    ],
+                br = calculate_reward_with_defaults(context, params, action_masking=False)
+                self.assertAlmostEqualFloat(
+                    br.total,
+                    br.economic_component + br.invalid_penalty + br.reward_shaping,
+                    tolerance=TOLERANCE.IDENTITY_STRICT,
                 )
+                self.assertEqual(br.entry_additive, 0.0)
+                self.assertEqual(br.exit_additive, 0.0)
+                self.assertEqual(br.idle_penalty, 0.0)
+                self.assertEqual(br.hold_penalty, 0.0)
 
-    # Owns invariant: robustness-exit-pnl-only-117 (robustness category)
+    # Owns invariant: robustness-episode-boundaries-117 (robustness category)
     def test_pnl_invariant_exit_only(self):
         """Invariant: PnL only non-zero while in position.
 
@@ -150,10 +105,20 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
             np.finfo(float).eps,
             msg="PnL invariant violation: neutral states must have pnl == 0",
         )
+        self.assertTrue((df["terminated"] == df["economic_ruin"]).all())
+        self.assertTrue(bool(df.iloc[-1]["terminated"] or df.iloc[-1]["truncated"]))
+        self.assertFalse(bool(df.iloc[-1]["terminated"] and df.iloc[-1]["truncated"]))
+        self.assertTrue(
+            np.allclose(
+                df["next_liquidation_value"].to_numpy()[:-1],
+                df["previous_liquidation_value"].to_numpy()[1:],
+                rtol=0.0,
+                atol=TOLERANCE.IDENTITY_STRICT,
+            )
+        )
 
-    def test_exit_factor_comprehensive(self):
-        """Comprehensive exit factor test: mathematical correctness and monotonic attenuation."""
-        # Part 1: Mathematical formulas validation
+    def test_legacy_exit_attenuation_does_not_change_economic_reward(self):
+        """Deprecated exit kernels are excluded from the economic component."""
         context = self.make_ctx(
             pnl=0.05,
             trade_duration=50,
@@ -163,45 +128,18 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
             position=Positions.Long,
             action=Actions.Long_exit,
         )
-        params = self.DEFAULT_PARAMS.copy()
-
-        # Relaxed tolerance: Exit factor calculations involve multiple steps
-        # (normalization, kernel application, potential transforms)
-        assert_exit_mode_mathematical_validation(
-            self,
-            context,
-            params,
-            PARAMS.BASE_FACTOR,
-            PARAMS.PROFIT_AIM,
-            PARAMS.RISK_REWARD_RATIO,
-            TOLERANCE.IDENTITY_RELAXED,
-        )
-
-        # Part 2: Monotonic attenuation validation
         modes = [*list(ATTENUATION_MODES), "plateau_linear"]
-        test_pnl = 0.05
-        test_context = self.make_ctx(
-            pnl=test_pnl,
-            trade_duration=50,
-            max_unrealized_profit=0.06,
-            min_unrealized_profit=0.0,
-        )
-        # Relaxed tolerance: Testing across multiple attenuation modes with different
-        # numerical characteristics (exponential, polynomial, rational functions)
-        assert_exit_factor_attenuation_modes(
-            self,
-            base_factor=PARAMS.BASE_FACTOR,
-            pnl=test_pnl,
-            pnl_target=PARAMS.PROFIT_AIM * PARAMS.RISK_REWARD_RATIO,
-            context=test_context,
-            attenuation_modes=modes,
-            base_params_fn=self.base_params,
-            tolerance_relaxed=TOLERANCE.IDENTITY_RELAXED,
-            risk_reward_ratio=PARAMS.RISK_REWARD_RATIO,
-        )
+        rewards = [
+            calculate_reward_with_defaults(
+                context, self.base_params(exit_attenuation_mode=mode)
+            ).economic_component
+            for mode in modes
+        ]
+        for reward in rewards[1:]:
+            self.assertAlmostEqualFloat(reward, rewards[0], tolerance=TOLERANCE.IDENTITY_STRICT)
 
-    def test_exit_factor_threshold_warning_and_non_capping(self):
-        """Warning emission without capping when exit_factor_threshold exceeded."""
+    def test_legacy_exit_threshold_does_not_cap_economic_reward(self):
+        """The removed exit threshold neither warns nor caps scaled log return."""
         params = self.base_params(exit_factor_threshold=10.0)
         params.pop("base_factor", None)
         context = self.make_ctx(
@@ -228,15 +166,7 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
         self.assertGreater(amplified.exit_component, baseline.exit_component)
         scale = amplified.exit_component / baseline.exit_component
         self.assertGreater(scale, 10.0)
-        runtime_warnings = [w for w in caught if issubclass(w.category, RuntimeWarning)]
-        self.assertTrue(runtime_warnings)
-        self.assertTrue(
-            any(
-                (">" in str(w.message) and "threshold" in str(w.message))
-                or "|exit_factor|=" in str(w.message)
-                for w in runtime_warnings
-            )
-        )
+        self.assertEqual([w for w in caught if issubclass(w.category, RuntimeWarning)], [])
 
     def test_negative_slope_sanitization(self):
         """Negative exit_linear_slope is sanitized to 1.0; resulting exit factors must match slope=1.0 within tolerance."""
@@ -305,8 +235,9 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
                 f"Alpha attenuation mismatch tau={tau} alpha={alpha} obs_ratio={observed_ratio} exp_ratio={expected_ratio}",
             )
 
+    # Owns invariant: robustness-economic-ruin-123
     def test_reward_calculation_extreme_parameters_stability(self):
-        """Reward calculation remains numerically stable with extreme parameter values.
+        """Extreme returns stay finite and economic ruin releases PBRS potential.
 
         Tests numerical stability and finite output when using extreme parameter
         values (win_reward_factor=1000, base_factor=10000) that might cause
@@ -335,6 +266,31 @@ class TestRewardRobustnessAndBoundaries(RewardSpaceTestBase):
         )
         br = calculate_reward_with_defaults(context, extreme_params, base_factor=10000.0)
         self.assertFinite(br.total, name="breakdown.total")
+        ruin_params = self.base_params(
+            hold_potential_enabled=True,
+            potential_gamma=0.95,
+        )
+        previous_potential = 0.42
+        ruin = calculate_reward_with_defaults(
+            self.make_ctx(
+                pnl=-1.5,
+                position=Positions.Long,
+                action=Actions.Neutral,
+            ),
+            ruin_params,
+            prev_potential=previous_potential,
+        )
+        self.assertTrue(ruin.economic_ruin)
+        self.assertTrue(ruin.terminated)
+        self.assertFalse(ruin.truncated)
+        self.assertEqual(ruin.reward_liquidation_value, MIN_LIQUIDATION_VALUE)
+        self.assertEqual(ruin.next_liquidation_value, MIN_LIQUIDATION_VALUE)
+        self.assertEqual(ruin.next_potential, 0.0)
+        self.assertAlmostEqualFloat(
+            ruin.reward_shaping,
+            -previous_potential,
+            tolerance=TOLERANCE.IDENTITY_STRICT,
+        )
 
     def test_exit_attenuation_modes_enumeration(self):
         """All exit attenuation modes produce finite rewards without errors.

--- a/ReforceXY/reward_space_analysis/tests/statistics/test_statistics.py
+++ b/ReforceXY/reward_space_analysis/tests/statistics/test_statistics.py
@@ -2,6 +2,7 @@
 """Statistical tests, distribution metrics, and bootstrap validation."""
 
 import unittest
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -72,15 +73,15 @@ class TestStatistics(RewardSpaceTestBase):
 
         df = self.make_stats_df(n=90, seed=SEEDS.BASE)
         # Force some columns constant
-        df.loc[:, "reward_hold"] = 0.0
+        df.loc[:, "reward_economic"] = 0.0
         df.loc[:, "idle_duration"] = 5.0
         stats_rel = _compute_relationship_stats(df)
         dropped = stats_rel["correlation_dropped"]
-        self.assertIn("reward_hold", dropped)
+        self.assertIn("reward_economic", dropped)
         self.assertIn("idle_duration", dropped)
         corr = stats_rel["correlation"]
         self.assertIsInstance(corr, pd.DataFrame)
-        self.assertNotIn("reward_hold", corr.columns)
+        self.assertNotIn("reward_economic", corr.columns)
         self.assertNotIn("idle_duration", corr.columns)
 
     def test_statistics_distribution_shift_metrics_degenerate_zero(self):
@@ -200,7 +201,21 @@ class TestStatistics(RewardSpaceTestBase):
                 "pnl_raw": np.zeros(n),
             }
         )
-        diagnostics = distribution_diagnostics(df_const)
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            diagnostics = distribution_diagnostics(df_const)
+        scipy_runtime_warnings = [
+            warning for warning in caught if warning.category is RuntimeWarning
+        ]
+        self.assertEqual(scipy_runtime_warnings, [])
+        for col in ("reward", "pnl"):
+            self.assertIs(diagnostics[f"{col}_shapiro_available"], False)
+            self.assertEqual(diagnostics[f"{col}_shapiro_reason"], "constant_distribution")
+            self.assertIs(diagnostics[f"{col}_anderson_available"], False)
+            self.assertEqual(diagnostics[f"{col}_anderson_reason"], "constant_distribution")
+            self.assertNotIn(f"{col}_shapiro_stat", diagnostics)
+            self.assertNotIn(f"{col}_shapiro_pval", diagnostics)
+            self.assertNotIn(f"{col}_is_normal_shapiro", diagnostics)
         # Mean and std for constant arrays
         for key in ["reward_mean", "reward_std", "pnl_mean", "pnl_std"]:
             if key in diagnostics:
@@ -221,7 +236,10 @@ class TestStatistics(RewardSpaceTestBase):
             )
         # All diagnostic values finite
         for k, v in diagnostics.items():
-            self.assertFinite(v, name=k)
+            if not k.endswith("_reason"):
+                self.assertFinite(v, name=k)
+        with self.assertRaisesRegex(AssertionError, "Shapiro-Wilk.*undefined"):
+            distribution_diagnostics(df_const, strict_diagnostics=True)
 
     def test_stats_distribution_diagnostics(self):
         """Distribution diagnostics."""
@@ -236,6 +254,12 @@ class TestStatistics(RewardSpaceTestBase):
                 key = f"{prefix}{suffix}"
                 if key in diagnostics:
                     self.assertFinite(diagnostics[key], name=key)
+
+        threshold_diagnostics = distribution_diagnostics(
+            pd.DataFrame({"reward": np.linspace(-1.0, 1.0, 5000)})
+        )
+        self.assertNotIn("reward_shapiro_available", threshold_diagnostics)
+        self.assertNotIn("reward_shapiro_pval", threshold_diagnostics)
 
     def test_statistical_hypothesis_tests_api_integration(self):
         """Test statistical_hypothesis_tests API integration with synthetic data."""
@@ -289,7 +313,7 @@ class TestStatistics(RewardSpaceTestBase):
                     f"Expected near-zero divergence after equal scaling (k={k}, v={v})",
                 )
 
-    # Non-owning smoke; ownership: robustness/test_robustness.py:43 (robustness-decomposition-integrity-101)
+    # Non-owning smoke; ownership: robustness/test_robustness.py:44 (robustness-economic-decomposition-101)
     @pytest.mark.smoke
     def test_stats_mean_decomposition_consistency(self):
         """Batch mean additivity."""

--- a/ReforceXY/reward_space_analysis/tests/test_base.py
+++ b/ReforceXY/reward_space_analysis/tests/test_base.py
@@ -42,8 +42,9 @@ def make_ctx(
     min_unrealized_profit: float = 0.0,
     position: Positions = Positions.Neutral,
     action: Actions = Actions.Neutral,
+    previous_liquidation_value: float = 1.0,
 ) -> RewardContext:
-    """Create a RewardContext with neutral defaults."""
+    """Create a RewardContext with neutral economic-state defaults."""
     return RewardContext(
         current_pnl=pnl,
         trade_duration=trade_duration,
@@ -52,6 +53,7 @@ def make_ctx(
         min_unrealized_profit=min_unrealized_profit,
         position=position,
         action=action,
+        previous_liquidation_value=previous_liquidation_value,
     )
 
 
@@ -95,6 +97,7 @@ class RewardSpaceTestBase(unittest.TestCase):
         min_unrealized_profit: float = 0.0,
         position: Positions = Positions.Neutral,
         action: Actions = Actions.Neutral,
+        previous_liquidation_value: float = 1.0,
     ) -> RewardContext:
         """Create a RewardContext with neutral defaults."""
         return make_ctx(
@@ -105,6 +108,7 @@ class RewardSpaceTestBase(unittest.TestCase):
             min_unrealized_profit=min_unrealized_profit,
             position=position,
             action=action,
+            previous_liquidation_value=previous_liquidation_value,
         )
 
     def base_params(self, **overrides) -> dict[str, Any]:
@@ -199,8 +203,9 @@ class RewardSpaceTestBase(unittest.TestCase):
 
         Returns
         -------
-        pd.DataFrame with columns: reward, reward_idle, reward_hold, reward_exit,
-        pnl, trade_duration, idle_duration, position. Guarantees: no NaN; reward_idle==0 where idle_duration==0.
+        A complete economic-reward analysis frame. ``reward_economic`` is the
+        scaled log change in the two liquidation-value columns and the legacy
+        idle/hold columns are retained as zero-valued compatibility diagnostics.
         """
         if seed is not None:
             RewardSpaceTestBase.seed_all(seed)
@@ -218,22 +223,53 @@ class RewardSpaceTestBase(unittest.TestCase):
             idle_duration = np.zeros(n)
         else:
             idle_duration = np.random.uniform(5, 60, n)
-        reward_idle = np.where(idle_duration > 0, np.random.normal(-1, 0.3, n), 0.0)
-        reward_hold = np.random.normal(-0.5, 0.2, n)
-        reward_exit = np.random.normal(0.8, 0.6, n)
+        reward_economic = reward
+        reward_invalid = np.zeros(n)
+        reward_shaping = np.zeros(n)
+        previous_liquidation_value = np.ones(n)
+        reward_liquidation_value = np.exp(reward_economic / PARAMS.BASE_FACTOR)
+        next_liquidation_value = reward_liquidation_value.copy()
+        reward_idle = np.zeros(n)
+        reward_hold = np.zeros(n)
         position = np.random.choice([0.0, 0.5, 1.0], n)
-        return pd.DataFrame(
+        action = np.random.choice([0, 1, 2, 3, 4], n)
+        reward_exit = np.where(np.isin(action, [2, 4]), reward_economic, 0.0)
+        truncated = np.zeros(n, dtype=bool)
+        if n:
+            truncated[-1] = True
+        df = pd.DataFrame(
             {
-                "reward": reward,
+                "reward": reward_economic + reward_invalid + reward_shaping,
+                "reward_economic": reward_economic,
+                "reward_invalid": reward_invalid,
                 "reward_idle": reward_idle,
                 "reward_hold": reward_hold,
                 "reward_exit": reward_exit,
+                "reward_shaping": reward_shaping,
+                "reward_entry_additive": np.zeros(n),
+                "reward_exit_additive": np.zeros(n),
+                "reward_base": reward_economic + reward_invalid,
+                "reward_pbrs_delta": np.zeros(n),
+                "reward_invariance_correction": np.zeros(n),
+                "prev_potential": np.zeros(n),
+                "next_potential": np.zeros(n),
+                "previous_liquidation_value": previous_liquidation_value,
+                "reward_liquidation_value": reward_liquidation_value,
+                "next_liquidation_value": next_liquidation_value,
+                "economic_log_return": reward_economic / PARAMS.BASE_FACTOR,
                 "pnl": pnl,
                 "trade_duration": trade_duration,
                 "idle_duration": idle_duration,
                 "position": position,
+                "action": action,
+                "pbrs_invariant": np.ones(n, dtype=bool),
+                "economic_ruin": np.zeros(n, dtype=bool),
+                "terminated": np.zeros(n, dtype=bool),
+                "truncated": truncated,
             }
         )
+        df.attrs["reward_params"] = self.base_params(base_factor=PARAMS.BASE_FACTOR)
+        return df
 
     def assertAlmostEqualFloat(
         self,


### PR DESCRIPTION
Atomic PR 8/10 of the reward_space_analysis economic-contract split (source: #120, unit u16).

**What**: Migrate the full tracked pytest suite to the new observable economic reward contract (14 files; no new test file added).
- `tests/test_base.py` (make_ctx gains previous_liquidation_value; make_stats_df emits the full economic frame); `components/test_additives.py` (canonical strict-reject / relaxed-suppress); `components/test_reward_components.py` (economic decomposition + native unified-fee primitive); `pbrs/test_pbrs.py` (termwise correction + discounted telescoping + native fee staging); `robustness/test_robustness.py` (economic decomposition/ruin/boundaries); `statistics/test_statistics.py` (reward_economic correlation + constant-dist Shapiro/Anderson strict); `integration/*` (algebraic-conformance lines, fee-aware liquidation calc, smoke additions); `cli/test_cli_params_and_csv.py` (economic CSV columns + manifest reward_contract); `api/test_api_helpers.py`; `helpers/assertions.py` + `helpers/test_internal_branches.py`; `test_reward_space_analysis_cli.py` alias help.

**Scope**: `reward_space_analysis/tests/**` + `test_reward_space_analysis_cli.py`.

**Stack position**: base `atomic/rsa-07-report-reframe`; 8 of 10.

Verified: full tracked suite green — 172 passed, 204 subtests passed (owner baseline 172/172).