### PR TITLE
docs(reward-space-analysis): rewrite analytical README for economic contract (9/10)

### DIFF
--- a/ReforceXY/reward_space_analysis/README.md
+++ b/ReforceXY/reward_space_analysis/README.md
@@ -1,645 +1,371 @@
 # Reward Space Analysis (ReforceXY)
 
-Deterministic synthetic sampling with diagnostics for reward shaping, penalties,
-PBRS invariance.
-
-## Key Capabilities
-
-- Scalable synthetic scenario generation (reproducible)
-- Reward component decomposition & bounds checks
-- PBRS modes: canonical, non_canonical, progressive_release, spike_cancel,
-  retain_previous
-- Feature importance & optional partial dependence
-- Statistical tests (hypothesis, bootstrap CIs, distribution diagnostics)
-- Real vs synthetic shift metrics
-- Manifest + parameter hash
-
-## Quick Start
-
-```shell
-# Install
-cd ReforceXY/reward_space_analysis
-uv sync --all-groups
-
-# Run a default analysis
-uv run python reward_space_analysis.py --num_samples 20000 --out_dir out
-
-# Run test suite (coverage ≥85% enforced)
-uv run pytest
-```
-
-Minimal selective test example:
-
-```shell
-uv run pytest -m pbrs -q
-```
-
-Full test documentation: [tests/README.md](./tests/README.md).
-
-## Table of Contents
-
-- [Key Capabilities](#key-capabilities)
-- [Quick Start](#quick-start)
-- [Prerequisites](#prerequisites)
-- [Common Use Cases](#common-use-cases)
-  - [1. Validate Reward Logic](#1-validate-reward-logic)
-  - [2. Parameter Sensitivity](#2-parameter-sensitivity)
-  - [3. Debug Anomalies](#3-debug-anomalies)
-  - [4. Real vs Synthetic](#4-real-vs-synthetic)
-- [CLI Parameters](#cli-parameters)
-  - [Simulation & Environment](#simulation--environment)
-  - [Hybrid Simulation Scalars](#hybrid-simulation-scalars)
-  - [Reward & Shaping](#reward--shaping)
-  - [Diagnostics & Validation](#diagnostics--validation)
-  - [Overrides](#overrides)
-  - [Reward Tunables Reference](#reward-tunables-reference)
-  - [Exit Attenuation Kernels](#exit-attenuation-kernels)
-  - [Transform Functions](#transform-functions)
-  - [Skipping Feature Analysis](#skipping-feature-analysis)
-  - [Reproducibility](#reproducibility)
-  - [Overrides vs --params](#overrides-vs--params)
-- [Examples](#examples)
-- [Outputs](#outputs)
-  - [Main Report (`statistical_analysis.md`)](#main-report-statistical_analysismd)
-  - [Data Exports](#data-exports)
-  - [Manifest (`manifest.json`)](#manifest-manifestjson)
-  - [Distribution Shift Metrics](#distribution-shift-metrics)
-- [Advanced Usage](#advanced-usage)
-  - [Parameter Sweeps](#parameter-sweeps)
-  - [PBRS Configuration](#pbrs-configuration)
-  - [Real Data Comparison](#real-data-comparison)
-  - [Batch Analysis](#batch-analysis)
-- [Testing](#testing)
-- [Troubleshooting](#troubleshooting)
-  - [No Output Files](#no-output-files)
-  - [Unexpected Reward Values](#unexpected-reward-values)
-  - [Slow Execution](#slow-execution)
-  - [Memory Errors](#memory-errors)
-
-## Prerequisites
-
-Requirements:
-
-- [Python 3.11+](https://www.python.org/downloads/)
-- ≥4GB RAM
-- [uv](https://docs.astral.sh/uv/getting-started/installation/) project manager
-
-Setup with uv:
-
-```shell
-cd ReforceXY/reward_space_analysis
-uv sync --all-groups
-```
-
-Run:
-
-```shell
-uv run python reward_space_analysis.py --num_samples 20000 --out_dir out
-```
-
-## Common Use Cases
-
-### 1. Validate Reward Logic
-
-```shell
-uv run python reward_space_analysis.py --num_samples 20000 --out_dir reward_space_outputs
-```
-
-See `statistical_analysis.md` (1–3): positive exit averages (long & short),
-negative invalid penalties, monotonic idle reduction, zero invariance failures.
-
-### 2. Parameter Sensitivity
-
-Single-run example:
-
-```shell
-uv run python reward_space_analysis.py \
-  --num_samples 30000 \
-  --params win_reward_factor=4.0 idle_penalty_ratio=1.5 \
-  --out_dir sensitivity_test
-```
-
-Compare reward distribution & component share deltas across runs.
-
-### 3. Debug Anomalies
-
-```shell
-uv run python reward_space_analysis.py \
-  --num_samples 50000 \
-  --out_dir debug_analysis
-```
-
-Focus: feature importance, shaping activation, invariance drift, extrema.
-
-### 4. Real vs Synthetic
-
-```shell
-uv run python reward_space_analysis.py \
-  --num_samples 100000 \
-  --real_episodes path/to/episode_rewards.pkl \
-  --out_dir real_vs_synthetic
-```
-
-Generates shift metrics for comparison (see Outputs section).
-
----
-
-## CLI Parameters
-
-### Simulation & Environment
-
-- **`--num_samples`** (int, default: 20000) – Synthetic scenarios. More = better
-  stats (slower). Recommended: 10k (quick), 50k (standard), 100k+ (deep).
-  (Simulation-only; not overridable via `--params`).
-- **`--seed`** (int, default: 42) – Master seed (reuse for identical runs).
-  (Simulation-only).
-- **`--trading_mode`** (spot|margin|futures, default: spot) – spot: no shorts;
-  margin/futures: shorts enabled. (Simulation-only).
-- **`--max_duration_ratio`** (float, default: 2.5) – Upper multiple for sampled
-  trade durations (idle derived). (Simulation-only; not in reward params; cannot
-  be set via `--params`).
-- **`--pnl_base_std`** (float, default: 0.02) – Base standard deviation for
-  synthetic PnL generation (pre-scaling). (Simulation-only).
-- **`--pnl_duration_vol_scale`** (float, default: 0.5) – Additional PnL
-  volatility scale proportional to trade duration ratio. (Simulation-only).
-- **`--real_episodes`** (path, optional) – Episodes pickle for real vs synthetic
-  distribution shift metrics. (Simulation-only; triggers additional outputs when
-  provided).
-- **`--unrealized_pnl`** (flag, default: false) – Simulate unrealized PnL
-  accrual during holds for potential Φ. (Simulation-only; affects PBRS
-  components).
-
-### Hybrid Simulation Scalars
-
-These parameters influence simulation behavior and reward computation. They can
-be overridden via `--params`.
-
-- **`--profit_aim`** (float, default: 0.03) – Profit target threshold (e.g.
-  0.03=3%).
-- **`--risk_reward_ratio`** (float, default: 2.0) – Risk-reward multiplier.
-- **`--action_masking`** (bool, default: true) – Simulate environment action
-  masking. Invalid actions receive penalties only if masking disabled.
-
-### Reward & Shaping
-
-- **`--base_factor`** (float, default: 100.0) – Base reward scale.
-- **`--win_reward_factor`** (float, default: 2.0) – Profit overshoot multiplier.
-
-**Duration penalties**: idle / hold scales & powers shape time-cost.
-
-**Exit attenuation**: kernel factors applied to exit duration ratio.
-
-**Efficiency weighting**: scales efficiency contribution.
-
-### Diagnostics & Validation
-
-- **`--check_invariants`** (bool, default: true) – Enable runtime invariant
-  checks (diagnostics become advisory if disabled). Toggle rarely; disabling may
-  hide reward drift or invariance violations.
-- **`--strict_validation`** (flag, default: true) – Enforce parameter bounds and
-  finite checks; raises instead of silent clamp/discard when enabled.
-- **`--strict_diagnostics`** (flag, default: false) – Fail-fast on degenerate
-  statistical diagnostics (zero-width CIs, undefined distribution metrics)
-  instead of graceful fallbacks.
-- **`--exit_factor_threshold`** (float, default: 1000.0) – Emits a warning if
-  the absolute value of the exit factor exceeds the threshold.
-- **`--pvalue_adjust`** (none|benjamini_hochberg, default: none) – Multiple
-  testing p-value adjustment method.
-- **`--bootstrap_resamples`** (int, default: 10000) – Bootstrap iterations for
-  confidence intervals; lower for speed (e.g. 500) during smoke tests.
-- **`--skip_feature_analysis`** / **`--skip_partial_dependence`** – Skip feature
-  importance or PD grids (see Skipping Feature Analysis section); influence
-  runtime only.
-- **`--rf_n_jobs`** / **`--perm_n_jobs`** (int, default: -1) – Parallel worker
-  counts for RandomForest and permutation importance (-1 = all cores).
-
-### Overrides
-
-- **`--out_dir`** (path, default: reward_space_outputs) – Output directory
-  (auto-created). (Simulation-only).
-- **`--params`** (k=v ...) – Bulk override reward tunables and hybrid simulation
-  scalars (`profit_aim`, `risk_reward_ratio`, `action_masking`). Conflicts:
-  individual flags vs `--params` ⇒ `--params` wins.
-
-### Reward Tunables Reference
-
-#### Core
-
-| Parameter        | Default | Description                 |
-| ---------------- | ------- | --------------------------- |
-| `base_factor`    | 100.0   | Base reward scale           |
-| `invalid_action` | -2.0    | Penalty for invalid actions |
-
-#### Exit Factor
-
-The exit factor is computed as:
-
-`exit_factor` = `base_factor` · `pnl_target_coefficient` ·
-`efficiency_coefficient` · `time_attenuation_coefficient`
-
-##### PnL Target
-
-| Parameter                       | Default | Description                   |
-| ------------------------------- | ------- | ----------------------------- |
-| `profit_aim`                    | 0.03    | Profit target threshold       |
-| `risk_reward_ratio`             | 2.0     | Risk/reward multiplier        |
-| `win_reward_factor`             | 2.0     | Profit target bonus factor    |
-| `pnl_amplification_sensitivity` | 2.0     | PnL amplification sensitivity |
-
-**Note:** In ReforceXY, `risk_reward_ratio` maps to `rr`.
-
-**Formula:**
-
-Let `pnl_target = profit_aim · risk_reward_ratio`,
-`pnl_ratio = pnl / pnl_target`.
-
-- If `pnl_target ≤ 0`: `pnl_target_coefficient = 1.0`
-- If `pnl_ratio > 1.0`:
-  `pnl_target_coefficient = 1.0 + win_reward_factor · tanh(pnl_amplification_sensitivity · (pnl_ratio - 1.0))`
-- If `pnl_ratio < -(1.0 / risk_reward_ratio)`:
-  `pnl_target_coefficient = 1.0 + (win_reward_factor · risk_reward_ratio) · tanh(pnl_amplification_sensitivity · (|pnl_ratio| - 1.0))`
-- Else: `pnl_target_coefficient = 1.0`
-
-##### Efficiency
-
-| Parameter           | Default | Description                    |
-| ------------------- | ------- | ------------------------------ |
-| `efficiency_weight` | 1.0     | Efficiency contribution weight |
-| `efficiency_center` | 0.5     | Efficiency pivot in [0,1]      |
-
-**Formula:**
-
-Let `max_u = max_unrealized_profit`, `min_u = min_unrealized_profit`,
-`range = max_u - min_u`, `ratio = (pnl - min_u)/range`,
-`min_range = max(1e-6, 0.01 · pnl_target)`. Then:
-
-- If `range < min_range`: `efficiency_coefficient = 1` (guard against division
-  explosion)
-- If `pnl > 0`:
-  `efficiency_coefficient = 1 + efficiency_weight · (ratio - efficiency_center)`
-- If `pnl < 0`:
-  `efficiency_coefficient = 1 + efficiency_weight · (efficiency_center - ratio)`
-- Else: `efficiency_coefficient = 1`
-
-##### Exit Attenuation
-
-| Parameter               | Default | Description                    |
-| ----------------------- | ------- | ------------------------------ |
-| `exit_attenuation_mode` | linear  | Kernel mode                    |
-| `exit_plateau`          | true    | Flat region before attenuation |
-| `exit_plateau_grace`    | 1.0     | Plateau grace ratio            |
-| `exit_linear_slope`     | 1.0     | Linear slope                   |
-| `exit_power_tau`        | 0.5     | Power kernel tau (0,1]         |
-| `exit_half_life`        | 0.5     | Half-life for half_life kernel |
-
-**Formula:**
-
-`time_attenuation_coefficient = kernel_function(duration_ratio)`
-
-where `kernel_function` depends on `exit_attenuation_mode`. See
-[Exit Attenuation Kernels](#exit-attenuation-kernels) for detailed formulas.
-
-#### Duration Penalties
-
-| Parameter                    | Default | Description                |
-| ---------------------------- | ------- | -------------------------- |
-| `max_trade_duration_candles` | 128     | Trade duration cap         |
-| `max_idle_duration_candles`  | None    | Fallback 4× trade duration |
-| `idle_penalty_ratio`         | 1.0     | Idle penalty ratio         |
-| `idle_penalty_power`         | 1.025   | Idle penalty exponent      |
-| `hold_penalty_ratio`         | 1.0     | Hold penalty ratio         |
-| `hold_penalty_power`         | 1.025   | Hold penalty exponent      |
-
-#### Validation
-
-| Parameter               | Default | Description                       |
-| ----------------------- | ------- | --------------------------------- |
-| `check_invariants`      | true    | Invariant enforcement (see above) |
-| `exit_factor_threshold` | 1000.0  | Warn on excessive factor          |
-
-#### PBRS (Potential-Based Reward Shaping)
-
-| Parameter                | Default   | Description                          |
-| ------------------------ | --------- | ------------------------------------ |
-| `potential_gamma`        | 0.95      | Discount factor γ for potential Φ    |
-| `exit_potential_mode`    | canonical | Potential release mode               |
-| `exit_potential_decay`   | 0.5       | Decay for progressive_release        |
-| `hold_potential_enabled` | false     | Enable hold potential Φ              |
-| `entry_fee_rate`         | 0.0       | Entry fee rate (`price · (1 + fee)`) |
-| `exit_fee_rate`          | 0.0       | Exit fee rate (`price / (1 + fee)`)  |
-
-PBRS invariance holds when: `exit_potential_mode=canonical`.
-
-In canonical mode, the entry/exit additive terms are suppressed even if the
-corresponding `*_additive_enabled` flags are set.
-
-Note: PBRS telescoping/zero-sum shaping is a property of coherent trajectories
-(episodes). `simulate_samples()` generates synthetic trajectories (state carried
-across samples) and does not apply any drift correction in post-processing.
-
-#### Hold Potential Transforms
-
-| Parameter                           | Default | Description          |
-| ----------------------------------- | ------- | -------------------- |
-| `hold_potential_ratio`              | 0.001   | Hold potential ratio |
-| `hold_potential_gain`               | 1.0     | Gain multiplier      |
-| `hold_potential_transform_pnl`      | tanh    | PnL transform        |
-| `hold_potential_transform_duration` | tanh    | Duration transform   |
-
-**Hold Potential Formula:**
-
-The hold potential combines PnL and duration signals with an asymmetric duration
-multiplier for loss-side holds:
-
-```
-Φ_hold(s) = scale · 0.5 · [T_pnl(g·r_pnl) + sign(r_pnl)·m_dur·T_dur(g·r_dur)]
-```
-
-where:
-
-- `r_pnl = pnl / pnl_target`
-- `r_dur = max(duration_ratio, 0)`
-- `scale = base_factor · hold_potential_ratio`
-- `g = hold_potential_gain`
-- `T_pnl`, `T_dur` = configured transforms
-- `m_dur = 1.0` if `r_pnl ≥ 0` (profit side)
-- `m_dur = risk_reward_ratio` if `r_pnl < 0` (loss side)
-
-The loss-side duration multiplier (`m_dur = risk_reward_ratio`) scales the
-duration penalty when holding losing positions, encouraging faster exits from
-losses compared to symmetric treatment.
-
-#### Entry Additive (Optional)
-
-| Parameter                           | Default | Description           |
-| ----------------------------------- | ------- | --------------------- |
-| `entry_additive_enabled`            | false   | Enable entry additive |
-| `entry_additive_ratio`              | 0.0625  | Ratio                 |
-| `entry_additive_gain`               | 1.0     | Gain                  |
-| `entry_additive_transform_pnl`      | tanh    | PnL transform         |
-| `entry_additive_transform_duration` | tanh    | Duration transform    |
-
-#### Exit Additive (Optional)
-
-| Parameter                          | Default | Description          |
-| ---------------------------------- | ------- | -------------------- |
-| `exit_additive_enabled`            | false   | Enable exit additive |
-| `exit_additive_ratio`              | 0.0625  | Ratio                |
-| `exit_additive_gain`               | 1.0     | Gain                 |
-| `exit_additive_transform_pnl`      | tanh    | PnL transform        |
-| `exit_additive_transform_duration` | tanh    | Duration transform   |
-
-### Exit Attenuation Kernels
-
-`r` = duration ratio and `grace` = `exit_plateau_grace`.
+This tool is the analytical clone of ReforceXY's pair-local economic reward. It
+generates deterministic synthetic trajectories, decomposes every transition,
+checks liquidation-value invariants, and produces statistical diagnostics.
+
+It does not validate `MyRLEnv`, MaskablePPO, FreqAI, Freqtrade's order engine,
+or live portfolio performance. Those require separate local runtime and dry-run
+validation.
+
+The active runtime contract is dry/live only, spot, `stake_amount="unlimited"`,
+and `add_state_info=true`. Stateful FreqAI backtesting is not supported by the
+current FreqAI API. The synthetic `trading_mode` option remains useful for
+analytical stress generation, but it must not be presented as runtime-parity
+validation.
+
+## Reward contract
+
+The base reward is the scaled change in a fee-aware liquidation value:
 
 ```text
-r* = 0            if exit_plateau and r ≤ grace
-r* = r - grace    if exit_plateau and r > grace
-r* = r            if not exit_plateau
+reward_economic = base_factor * log(
+    reward_liquidation_value / previous_liquidation_value
+)
 ```
 
-| Mode      | Formula                       | Monotonic | Notes                                       | Use Case                             |
-| --------- | ----------------------------- | --------- | ------------------------------------------- | ------------------------------------ |
-| legacy    | step: 1.5 if r\* ≤ 1 else 0.5 | No        | Non-monotonic legacy mode (not recommended) | Backward compatibility only          |
-| sqrt      | 1 / √(1 + r\*)                | Yes       | Sub-linear decay                            | Gentle long-trade penalty            |
-| linear    | 1 / (1 + slope · r\*)         | Yes       | slope = `exit_linear_slope`                 | Balanced duration penalty (default)  |
-| power     | (1 + r\*)^(-alpha)            | Yes       | alpha = -ln(tau)/ln(2); tau=1 ⇒ alpha=0     | Tunable decay rate via tau parameter |
-| half_life | 2^(-r\* / hl)                 | Yes       | hl = `exit_half_life`; r\*=hl ⇒ factor 0.5  | Time-based exponential discount      |
+The following causal transition clock belongs to `MyRLEnv`
+training/evaluation and to the causal analytical simulator:
 
-### Transform Functions
-
-| Transform  | Formula                          | Range   | Characteristics   | Use Case                      |
-| ---------- | -------------------------------- | ------- | ----------------- | ----------------------------- |
-| `tanh`     | tanh(x)                          | (-1, 1) | Smooth sigmoid    | Balanced transforms (default) |
-| `softsign` | x / (1 + \|x\|)                  | (-1, 1) | Linear near 0     | Less aggressive saturation    |
-| `arctan`   | (2/π) · arctan(x)                | (-1, 1) | Slower saturation | Wide dynamic range            |
-| `sigmoid`  | 2σ(x) - 1, σ(x) = 1/(1 + e^(-x)) | (-1, 1) | Standard sigmoid  | Generic shaping               |
-| `asinh`    | x / √(1 + x²)                    | (-1, 1) | Outlier robust    | Extreme stability             |
-| `clip`     | clip(x, -1, 1)                   | [-1, 1] | Hard clipping     | Preserve linearity            |
-
-### Skipping Feature Analysis
-
-Flags hierarchy:
-
-| Scenario                 | `--skip_feature_analysis` | `--skip_partial_dependence` | Feature Importance | Partial Dependence | Report Section 4   |
-| ------------------------ | ------------------------- | --------------------------- | ------------------ | ------------------ | ------------------ |
-| Default                  | ✗                         | ✗                           | Yes                | Yes                | Full               |
-| PD skipped               | ✗                         | ✓                           | Yes                | No                 | PD note            |
-| Feature analysis skipped | ✓                         | ✗                           | No                 | No                 | Marked "(skipped)" |
-| Both skipped             | ✓                         | ✓                           | No                 | No                 | Marked "(skipped)" |
-
-Auto-skip if `num_samples < 4`.
-
-### Reproducibility
-
-| Component                             | Controlled By                      | Notes                               |
-| ------------------------------------- | ---------------------------------- | ----------------------------------- |
-| Sample simulation                     | `--seed`                           | Drives action sampling & PnL noise  |
-| Statistical tests / bootstrap         | `--stats_seed` (fallback `--seed`) | Isolated RNG                        |
-| RandomForest & permutation importance | `--seed`                           | Identical splits and trees          |
-| Partial dependence grids              | Deterministic                      | Depends only on fitted model & data |
-
-Patterns:
-
-```shell
-uv run python reward_space_analysis.py --num_samples 50000 --seed 123 --stats_seed 9001 --out_dir run_stats1
-uv run python reward_space_analysis.py --num_samples 50000 --seed 123 --stats_seed 9002 --out_dir run_stats2
-# Fully deterministic
-uv run python reward_space_analysis.py --num_samples 50000 --seed 777
+```text
+state s[t-1] : features, position, PnL, and raw candle duration through close[t-1]
+action       : selected from s[t-1]
+fill         : open[t]
+mark         : close[t] while open; open[t] for an exit
+state s[t]   : features, position, PnL, and raw candle duration through close[t]
 ```
 
-### Overrides vs --params
+The transition table is:
 
-Direct flags and `--params` produce identical outcomes; conflicts resolved by
-bulk `--params` values.
+| Transition | Fill/mark used by reward | `next_liquidation_value` |
+| --- | --- | ---: |
+| Neutral self-loop | `1` | `1` |
+| Valid long/short entry | `1 + pnl_net(entry open[t], close[t])` | same value |
+| Hold an open position | `1 + pnl_net(entry open, close[t])` | same value |
+| Valid exit | `1 + pnl_net(entry open, exit open[t])` | `1` |
+| Invalid action while in position | `1 + pnl_net(entry open, close[t])` | same value |
 
-```shell
-uv run python reward_space_analysis.py --win_reward_factor 3.0 --idle_penalty_ratio 2.0 --num_samples 15000
-uv run python reward_space_analysis.py --params win_reward_factor=3.0 idle_penalty_ratio=2.0 --num_samples 15000
+This is not a universal dry/live pricing clock. During dry/live prediction,
+inherited Freqtrade state uses the current authoritative exit-side rate. That
+rate is asynchronous and is not guaranteed to equal `close[t]`.
+
+An invalid action may additionally receive `invalid_action` when action masking
+is disabled. `MaskablePPO` excludes invalid actions during training, evaluation,
+and inference. Non-maskable algorithms may select invalid actions and receive
+the separate invalid-action penalty; they are never supplied action masks.
+
+For a completed trade, the economic components telescope:
+
+```text
+sum(reward_economic) / base_factor = log(1 + realized_pnl_net)
 ```
 
-`--params` wins on conflicts.
+Across trades, this is a synthetic pair-local compounded return. It is not the
+global Freqtrade wallet equity.
 
-**Simulation** (not allowed in `--params`): `num_samples`, `seed`,
-`trading_mode`, `max_duration_ratio`, `out_dir`, `stats_seed`, `pnl_base_std`,
-`pnl_duration_vol_scale`, `real_episodes`, `unrealized_pnl`,
-`strict_diagnostics`, `strict_validation`, `bootstrap_resamples`,
-`skip_feature_analysis`, `skip_partial_dependence`, `rf_n_jobs`, `perm_n_jobs`,
-`pvalue_adjust`.
+## Cost accounting
 
-**Hybrid simulation/params** allowed in `--params`: `profit_aim`,
-`risk_reward_ratio`, `action_masking`.
+`fee_rate` is the single analytical fee input. Its default, `0.0015`, mirrors
+the spot, leverage-one `LocalTrade` used by the runtime:
 
-**Reward tunables** (tunable via either direct flag or `--params`) correspond to
-those listed under Reward Tunables Reference: Core, Duration Penalties, Exit
-Attenuation, Efficiency, Validation, PBRS, Hold/Entry/Exit Potential Transforms.
+```text
+long:
+  open_trade_value  = entry_open * (1 + fee_rate)
+  close_trade_value = mark * (1 - fee_rate)
+  pnl_net            = close_trade_value / open_trade_value - 1
 
-## Examples
+short:
+  open_trade_value  = entry_open * (1 - fee_rate)
+  close_trade_value = mark * (1 + fee_rate)
+  pnl_net            = 1 - close_trade_value / open_trade_value
+```
+
+Consequently the entry liquidation value already contains the complete
+simulated round-trip fee. The reward never subtracts another fee at entry or
+exit. `LocalTrade.calc_profit_ratio()` rounds the resulting PnL ratio to eight
+decimal places, which the analytical mirror reproduces.
+
+The causal simulator carries that native fee-aware PnL without an artificial
+clip. Synthetic trajectories can therefore contain moves beyond `±15%`; their
+PnL fields must remain finite.
+
+`MyRLEnv` creates one unregistered `LocalTrade` at entry, reuses it for every
+mark, and discards it at exit. It never calls `add_bt_trade()` and therefore
+does not add the object to Freqtrade's backtesting registries or a database. In
+the recorded benchmark under the pinned 2026.6 runtime, reusing a trade took
+approximately `4.31 µs` per mark over 200,000 calls, versus `10.13 µs` when
+recreating it for every mark (`2.35x` slower).
+
+The earlier BaseEnvironment approximation used `p / (1 + f)` instead of the
+native close value `p * (1 - f)`. Their absolute price difference is
+`p * f² / (1 + f)`; relative to `p * (1 - f)`, the difference is
+`f² / (1 - f²)`: approximately `1.000001 ppm` at `f=0.001`,
+`2.250005 ppm` at `f=0.0015`, and `100.010001 ppm` at `f=0.01`.
+That approximation remains available only in the non-promotable analytical
+PBRS compatibility mode.
+
+Included:
+
+- simulated entry fee;
+- simulated exit fee.
+
+Not modelled:
+
+- spread;
+- slippage;
+- funding;
+- latency;
+- market impact.
+
+This remains an analytical assumption. At runtime, `pack_env_dict(pair)`
+resolves the exchange fee for each pair unless an explicit top-level Freqtrade
+`fee` configuration is present; configured `0.0` is also authoritative. Exact
+analytical parity requires passing that effective fee to `fee_rate`. The
+manifest records the assumption and this parity requirement explicitly. Cost
+stress tests must alter the unified fee assumption or be performed in the
+external execution harness; they must not add another fee term to the reward.
+
+## Reward shaping and promotion
+
+The promotable ReforceXY runtime fails closed unless potential-based reward
+shaping and entry/exit additive bonuses are all disabled:
+
+```text
+hold_potential_enabled = false
+entry_additive_enabled = false
+exit_additive_enabled = false
+```
+
+The analytical tool retains canonical PBRS as a compatibility-only research
+mode:
+
+```text
+F(s, a, s') = gamma * Phi(s') - Phi(s)
+```
+
+Any analytical run with shaping enabled is explicitly non-promotable and does
+not represent the active runtime reward.
+
+Within this pair-local analytical contract, `economic_ruin` is a numerical
+boundary reached when the modelled value `1 + pnl_net` is non-positive. The
+value is floored to `1e-12` solely to keep the logarithmic reward finite, and
+the synthetic trajectory stops. This surrogate is not an exchange liquidation,
+margin call, bankruptcy, or wallet/portfolio outcome. A normal sample-limit or
+dataset end is a Gymnasium truncation so the value function can bootstrap. In
+the compatibility-only analytical PBRS mode, potential is released on
+termination and preserved on truncation. Entry and exit additive rewards are
+always suppressed. Strict mode rejects non-canonical modes and enabled
+additives; relaxed mode normalizes the mode to `canonical` and disables the
+additives explicitly.
+
+The report never uses the raw sum `sum(reward_shaping)` to classify algebraic
+conformance. For `gamma < 1`, canonical PBRS telescopes only after discounting:
+
+```text
+sum(gamma^t * F_t) = -Phi_0 + gamma^T * Phi_T
+```
+
+The discounted sum, boundary term, and residual are diagnostics. Algebraic
+classification requires both a canonical/no-additive configuration and a finite
+term-by-term `reward_shaping - reward_pbrs_delta` check within tolerance. If that
+correction column is absent, algebraic conformance is unverified, irrespective
+of any raw sum. On a true termination `Phi_T` must be zero; on a bootstrapable
+truncation it is preserved and the boundary term may be non-zero.
+
+These checks do not prove policy invariance. That theorem additionally requires
+the learner and shaping term to use the same discount factor, `Phi` to be a
+function of the learner's Markov-observable state (or a sufficient belief
+state), and the shaped and unshaped learning problems to retain identical
+termination and truncation boundaries. This report establishes neither those
+state-sufficiency assumptions nor learner-discount equality.
+
+`profit_aim`, `rr`/`risk_reward_ratio`, and duration parameters remain available
+only for the optional observable potential and FreqAI constructor compatibility.
+They do not alter `reward_economic`.
+
+## Deprecated parameters
+
+The following legacy reward parameters may still be accepted during migration,
+but they are diagnostics/no-ops for the economic component:
+
+- idle and hold penalty parameters;
+- exit attenuation parameters;
+- MFE/MAE efficiency parameters;
+- target amplification parameters;
+- entry and exit additive parameters;
+- asymmetric `entry_fee_rate` and `exit_fee_rate`.
+
+New analyses must use `fee_rate`. Legacy asymmetric fees cannot reproduce
+Freqtrade's accounting.
+
+The legacy `--unrealized_pnl` option and `unrealized_pnl` parameter override
+remain accepted only as deprecated compatibility aliases. They emit a warning,
+have no effect, and are omitted from operational reward and simulation
+metadata. Analytical trajectories are always fee-aware marked-to-liquidation.
+
+## Installation and quick start
 
 ```shell
-# Quick test with defaults
-uv run python reward_space_analysis.py --num_samples 10000
-# Full analysis with custom profit target
+cd ReforceXY/reward_space_analysis
+uv sync --all-groups
 uv run python reward_space_analysis.py \
-  --num_samples 50000 \
-  --profit_aim 0.05 \
-  --trading_mode futures \
-  --bootstrap_resamples 5000 \
-  --out_dir custom_analysis
-# PBRS potential shaping analysis
-uv run python reward_space_analysis.py \
-  --num_samples 40000 \
-  --params hold_potential_enabled=true exit_potential_mode=spike_cancel potential_gamma=0.95 \
-  --out_dir pbrs_test
-# Real vs synthetic comparison (see Common Use Cases #4)
-uv run python reward_space_analysis.py \
-  --num_samples 100000 \
-  --real_episodes path/to/episode_rewards.pkl \
-  --out_dir validation
+  --num_samples 20000 \
+  --params fee_rate=0.001 \
+  --out_dir reward_space_outputs
 ```
 
----
-
-## Outputs
-
-### Main Report (`statistical_analysis.md`)
-
-Includes: global stats, representativity, component + PBRS analysis, feature
-importance/PD, statistical validation (tests, CIs, diagnostics), optional shift
-metrics, summary.
-
-### Data Exports
-
-| File                       | Description                                          |
-| -------------------------- | ---------------------------------------------------- |
-| `reward_samples.csv`       | Raw synthetic samples                                |
-| `feature_importance.csv`   | Feature importance rankings                          |
-| `partial_dependence_*.csv` | Partial dependence data                              |
-| `manifest.json`            | Runtime manifest (simulation + reward params + hash) |
-
-### Manifest (`manifest.json`)
-
-| Field                   | Type              | Description                       |
-| ----------------------- | ----------------- | --------------------------------- |
-| `generated_at`          | string (ISO 8601) | Generation timestamp (not hashed) |
-| `num_samples`           | int               | Synthetic samples count           |
-| `seed`                  | int               | Master random seed                |
-| `pnl_target`            | float             | Profit target                     |
-| `pvalue_adjust_method`  | string            | Multiple testing correction mode  |
-| `parameter_adjustments` | object            | Bound clamp adjustments (if any)  |
-| `reward_params`         | object            | Final reward params               |
-| `simulation_params`     | object            | All simulation inputs             |
-| `params_hash`           | string (sha256)   | Deterministic run hash            |
-
-Two runs match iff `params_hash` identical.
-
-### Distribution Shift Metrics
-
-| Metric            | Definition                            | Notes                         |
-| ----------------- | ------------------------------------- | ----------------------------- |
-| `*_kl_divergence` | KL(synth‖real) = Σ p_s log(p_s / p_r) | 0 ⇒ identical histograms      |
-| `*_js_distance`   | √(0.5 KL(p_s‖m) + 0.5 KL(p_r‖m))      | Symmetric, [0,1]              |
-| `*_wasserstein`   | 1D Earth Mover's Distance             | Units of feature              |
-| `*_ks_statistic`  | KS two-sample statistic               | [0,1]; higher ⇒ divergence    |
-| `*_ks_pvalue`     | KS test p-value                       | High ⇒ cannot reject equality |
-
-Implementation: 50-bin hist; add ε=1e-10; constants ⇒ zero divergence & KS
-p=1.0.
-
----
-
-## Advanced Usage
-
-### Parameter Sweeps
-
-Loop multiple values:
-
-```shell
-for factor in 1.5 2.0 2.5 3.0; do
-  uv run python reward_space_analysis.py \
-    --num_samples 20000 \
-    --params win_reward_factor=$factor \
-    --out_dir analysis_factor_$factor
-done
-```
-
-Combine with other overrides cautiously; use distinct `out_dir` per
-configuration.
-
-### PBRS Configuration
-
-Canonical mode enforces terminal release (Φ terminal ≈ 0) and suppresses
-entry/exit additive terms.
-
-Non-canonical exit modes can introduce non-zero terminal shaping; enable
-additives only when you want those extra terms to contribute.
-
-### Real Data Comparison
+For a faster smoke run:
 
 ```shell
 uv run python reward_space_analysis.py \
-  --num_samples 100000 \
-  --real_episodes path/to/episode_rewards.pkl \
-  --out_dir real_vs_synthetic
+  --num_samples 1000 \
+  --bootstrap_resamples 200 \
+  --skip_feature_analysis \
+  --out_dir reward_space_smoke
 ```
 
-Shift metrics: lower divergence preferred (except p-value: higher ⇒ cannot
-reject equality).
+## Relevant parameters
 
-### Batch Analysis
+### Reward
 
-(Alternate sweep variant)
+| Parameter | Default | Meaning |
+| --- | ---: | --- |
+| `base_factor` | `100.0` | Positive scale for log returns |
+| `fee_rate` | `0.0015` | Analytical spot `LocalTrade` fee assumption |
+| `invalid_action` | `-2.0` | Additional unmasked invalid-action penalty |
+| `hold_potential_enabled` | `false` | Enable non-promotable analytical PBRS |
+| `potential_gamma` | `0.95` | PBRS discount factor |
+| `exit_potential_mode` | `canonical` | Only supported PBRS mode |
 
-```shell
-while read target; do
-  uv run python reward_space_analysis.py \
-    --num_samples 30000 \
-    --params profit_aim=$target \
-    --out_dir pt_${target}
-done <<EOF
-0.02
-0.03
-0.05
-EOF
-```
+`base_factor` must be strictly positive. A positive scaling does not change the
+ordering of unshaped economic returns.
 
----
+### Simulation
 
-## Testing
+| Parameter | Default | Meaning |
+| --- | ---: | --- |
+| `--num_samples` | `20000` | Number of trajectory transitions |
+| `--seed` | `42` | Market/action RNG seed |
+| `--trading_mode` | `spot` | Spot disables short actions |
+| `--max_duration_ratio` | `2.5` | Synthetic duration cap multiplier |
+| `--pnl_base_std` | `0.02` | Base transition volatility split across gap and intrabar returns |
+| `--pnl_duration_vol_scale` | `0.5` | Duration-dependent volatility scale |
+| `--action_masking` | enabled | Simulate masked action selection |
+| `--real_episodes` | unset | Optional real transition pickle |
+| `--stats_seed` | `--seed` | Separate statistics seed |
 
-Quick validation:
+Explicit `--params KEY=VALUE` overrides direct tunable flags.
+When masking is disabled, the generator samples invalid actions with a fixed 5%
+stress probability so the separate invalid-action penalty remains observable.
+Durations remain raw candle-row counts; they are not normalized. With missing
+OHLC candles, this differs from live UTC elapsed duration and is a known
+runtime-parity limitation.
+
+Direct compatibility calls that construct `RewardContext` without `next_pnl`
+retain the legacy analytical fallback and are non-promotable. The causal
+simulator always supplies `next_pnl` and `next_trade_duration`; only that path
+duplicates the `MyRLEnv` training/evaluation transition clock. It does not
+duplicate Freqtrade's asynchronous dry/live pricing clock or establish
+same-close numerical observation parity.
+
+## Output schema
+
+### `reward_samples.csv`
+
+The economic contract is observable through:
+
+| Column | Meaning |
+| --- | --- |
+| `reward` | Economic + invalid penalty + canonical PBRS |
+| `reward_economic` | Scaled net log-liquidation return |
+| `reward_invalid` | Separate invalid-action penalty |
+| `reward_shaping` | Canonical PBRS delta |
+| `pnl` | Fee-aware PnL observable at the previous close |
+| `next_pnl` | Fee-aware PnL at the causal fill/mark |
+| `previous_close` | Close used by the state that selected the action |
+| `fill_open` | Next open where the action is filled |
+| `mark_close` | Close used for a position retained after the fill |
+| `previous_liquidation_value` | Stored value before the transition |
+| `reward_liquidation_value` | Value used to calculate this reward |
+| `next_liquidation_value` | Value carried to the next transition |
+| `economic_log_return` | `reward_economic / base_factor` |
+| `cumulative_pair_log_return` | Sum of economic log returns |
+| `synthetic_pair_equity` | Exponential of the cumulative log return |
+| `economic_ruin` | Modelled `1 + pnl_net` was non-positive before numerical flooring |
+| `terminated` | True only for economic ruin |
+| `truncated` | True when the requested sample limit ends normally |
+| `drawdown_breached` | Unavailable (`NaN`) in the pair-local simulator |
+| `drawdown_breached_available` | Always false for analytical samples |
+
+The legacy `reward_idle`, `reward_hold`, `reward_entry_additive`, and
+`reward_exit_additive` columns remain zero-valued schema compatibility fields.
+`reward_exit` is a diagnostic view of the economic component on valid exits; it
+is not a separate reward term.
+
+### `manifest.json`
+
+The manifest contains:
+
+- `reward_contract`: versioned name, exact formula, and PBRS status;
+- `cost_accounting`: unified fee and explicit included/excluded costs;
+- `episode_boundaries`: termination, truncation, PBRS, and drawdown semantics;
+- `compatibility_only`: legacy target and deprecated parameter inventory;
+- final reward and simulation parameters;
+- parameter adjustments and deterministic parameter hash.
+
+The generation timestamp is not included in the hash.
+
+### Other artifacts
+
+- `statistical_analysis.md`: reward, component, PBRS, and statistical report;
+- `feature_importance.csv`: optional model-based diagnostic;
+- `partial_dependence_*.csv`: optional partial-dependence diagnostics.
+
+Feature importance describes the synthetic generator. It is not evidence that a
+feature is predictive in live trading.
+
+## Validation invariants
+
+The simulator fails fast when:
+
+- actions and positions are incompatible;
+- `pnl` or `next_pnl` is non-finite;
+- neutral states contain a trade PnL;
+- carried liquidation values are non-finite or non-positive; a newly reached
+  economic-ruin value is first clamped to `1e-12` by the explicit terminal path;
+- a liquidation value is not carried to the next transition;
+- `reward_economic` differs from the log-liquidation formula;
+- total reward differs from economic + invalid + PBRS components.
+- termination does not correspond exactly to economic ruin;
+- a trajectory continues after termination or lacks a final truncation.
+
+Shapiro-Wilk and Anderson-Darling normality tests are undefined for constant
+distributions. Relaxed diagnostics report them as
+`N/A (constant distribution)` without invoking SciPy; `--strict_diagnostics`
+fails fast instead.
+
+The exact runtime comparison against `MyRLEnv` belongs in a local harness outside
+the repository. Existing analytical tests can be run with:
 
 ```shell
 uv run pytest
 ```
 
-Selective example:
+See [tests/README.md](./tests/README.md) for the existing suite. Its success
+validates this analytical implementation only, not the real FreqAI environment.
 
-```shell
-uv run pytest -m pbrs -q
-```
+## Reproducibility
 
-Coverage threshold enforced: 85% (`--cov-fail-under=85` in `pyproject.toml`).
-Full coverage, invariants, markers, smoke policy, and maintenance workflow:
-[tests/README.md](./tests/README.md).
-
----
+Use identical `--seed`, `--stats_seed`, inputs, and reward parameters. Retain the
+manifest and input data hash for every comparison. Parameter sweeps must use a
+different output directory per cell and the same seed set across candidates.
 
 ## Troubleshooting
 
-### No Output Files
-
-Check permissions, disk space, working directory.
-
-### Unexpected Reward Values
-
-Run tests; inspect overrides; confirm trading mode, PBRS settings, clamps.
-
-### Slow Execution
-
-Lower samples; skip PD/feature analysis; reduce resamples; ensure SSD.
-
-### Memory Errors
-
-Reduce samples; ensure 64‑bit Python; batch processing; add RAM/swap.
+- Pair-local numerical ruin: the modelled value is floored to `1e-12`, terminal
+  PBRS is applied, and the trajectory stops. This is not an exchange
+  liquidation event; inspect the price/PnL path before interpreting it.
+- Unexpected fee loss at entry: the liquidation mark pre-charges the simulated
+  round-trip fee by design.
+- Non-canonical PBRS error: remove the legacy mode and use `canonical`.
+- Slow run: reduce samples/bootstrap resamples or skip feature analysis.


### PR DESCRIPTION
Atomic PR 9/10 of the reward_space_analysis economic-contract split (source: #120, unit u17).

**What**: Rewrite the analytical README to document the economic reward contract.
- Reward-contract formula + causal clock table + transition table; cost-accounting long/short fee equations + LocalTrade benchmark; canonical PBRS + promotion gating; deprecated parameters; output schema (reward_samples.csv columns, manifest sections); validation invariants; algebraic-vs-policy-invariance caveat.

**Scope**: `ReforceXY/reward_space_analysis/README.md`.

**Stack position**: base `atomic/rsa-08-tests`; 9 of 10. Documents B1-B7.