### PR TITLE
feat(reward): fee-aware pair-local net-log-liquidation reward (1/9)

### DIFF
--- a/ReforceXY/.basedpyright/diagnostics.json
+++ b/ReforceXY/.basedpyright/diagnostics.json
@@ -553,83 +553,103 @@
     },
     {
       "endCharacter": 51,
-      "endLine": 612,
+      "endLine": 610,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 26,
-      "startLine": 612
+      "startLine": 610
     },
     {
       "endCharacter": 51,
-      "endLine": 612,
+      "endLine": 610,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 26,
-      "startLine": 612
+      "startLine": 610
     },
     {
       "endCharacter": 60,
-      "endLine": 616,
+      "endLine": 614,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 616
+      "startLine": 614
     },
     {
       "endCharacter": 60,
-      "endLine": 616,
+      "endLine": 614,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 616
+      "startLine": 614
     },
     {
       "endCharacter": 22,
-      "endLine": 687,
+      "endLine": 685,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"train_env\" for class \"ReforceXY*\"\n  Expression of type \"VecEnv\" cannot be assigned to attribute \"train_env\" of class \"ReforceXY\"\n    Type \"VecEnv\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n      \"VecEnv\" is not assignable to \"VecMonitor\"\n      \"VecEnv\" is not assignable to \"SubprocVecEnv\"\n      \"VecEnv\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 687
+      "startLine": 685
     },
     {
       "endCharacter": 37,
-      "endLine": 687,
+      "endLine": 685,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"eval_env\" for class \"ReforceXY*\"\n  Expression of type \"VecEnv\" cannot be assigned to attribute \"eval_env\" of class \"ReforceXY\"\n    Type \"VecEnv\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n      \"VecEnv\" is not assignable to \"VecMonitor\"\n      \"VecEnv\" is not assignable to \"SubprocVecEnv\"\n      \"VecEnv\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 29,
-      "startLine": 687
+      "startLine": 685
     },
     {
       "endCharacter": 38,
-      "endLine": 962,
+      "endLine": 960,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"obj\" of type \"Sized\" in function \"len\"\n  Type \"Any | None\" is not assignable to type \"Sized\"\n    \"None\" is incompatible with protocol \"Sized\"\n      \"__len__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 30,
-      "startLine": 962
+      "startLine": 960
     },
     {
       "endCharacter": 36,
-      "endLine": 966,
+      "endLine": 964,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"obj\" of type \"Sized\" in function \"len\"\n  Type \"Any | None\" is not assignable to type \"Sized\"\n    \"None\" is incompatible with protocol \"Sized\"\n      \"__len__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 29,
-      "startLine": 966
+      "startLine": 964
+    },
+    {
+      "endCharacter": 80,
+      "endLine": 967,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 52,
+      "startLine": 967
+    },
+    {
+      "endCharacter": 78,
+      "endLine": 968,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 50,
+      "startLine": 968
     },
     {
       "endCharacter": 80,
@@ -642,93 +662,83 @@
       "startLine": 969
     },
     {
-      "endCharacter": 78,
-      "endLine": 970,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 50,
-      "startLine": 970
-    },
-    {
-      "endCharacter": 80,
-      "endLine": 971,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 52,
-      "startLine": 971
-    },
-    {
       "endCharacter": 83,
-      "endLine": 1039,
+      "endLine": 1037,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"timeframe\" of type \"str\" in function \"steps_to_days\"\n  Type \"Any | None\" is not assignable to type \"str\"\n    \"None\" is not assignable to \"str\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 55,
-      "startLine": 1039
+      "startLine": 1037
     },
     {
       "endCharacter": 52,
-      "endLine": 1070,
+      "endLine": 1068,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\" cannot be assigned to parameter \"eval_env\" of type \"BaseEnvironment\" in function \"get_callbacks\"\n  Type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\" is not assignable to type \"BaseEnvironment\"\n    \"SubprocVecEnv\" is not assignable to \"BaseEnvironment\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 1070
+      "startLine": 1068
     },
     {
       "endCharacter": 50,
-      "endLine": 1231,
+      "endLine": 1229,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"NDArray[float32]\" cannot be assigned to parameter \"x\" of type \"float32\" in function \"append\"\n  \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"floating[_32Bit]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 1231
+      "startLine": 1229
     },
     {
       "endCharacter": 32,
-      "endLine": 1956,
+      "endLine": 1954,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"best_trial_params\" is possibly unbound",
       "rule": "reportPossiblyUnboundVariable",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 1956
+      "startLine": 1954
     },
     {
       "endCharacter": 12,
-      "endLine": 1965,
+      "endLine": 1963,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Parameter declaration \"seed\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1965
+      "startLine": 1963
     },
     {
       "endCharacter": 16,
-      "endLine": 1966,
+      "endLine": 1964,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Parameter declaration \"env_info\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 1966
+      "startLine": 1964
     },
     {
       "endCharacter": 47,
-      "endLine": 2011,
+      "endLine": 2009,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 38,
+      "startLine": 2009
+    },
+    {
+      "endCharacter": 45,
+      "endLine": 2011,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
+      "rule": "reportArgumentType",
+      "severity": "error",
+      "startCharacter": 36,
       "startLine": 2011
     },
     {
@@ -738,798 +748,728 @@
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
-      "startCharacter": 36,
+      "startCharacter": 37,
       "startLine": 2013
     },
     {
-      "endCharacter": 45,
+      "endCharacter": 43,
       "endLine": 2015,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
       "rule": "reportArgumentType",
       "severity": "error",
-      "startCharacter": 37,
+      "startCharacter": 35,
       "startLine": 2015
     },
     {
-      "endCharacter": 43,
-      "endLine": 2017,
+      "endCharacter": 22,
+      "endLine": 2056,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"list[() -> BaseEnvironment]\" cannot be assigned to parameter \"env_fns\" of type \"list[() -> Env[Unknown, Unknown]]\" in function \"__init__\"\n  \"list[() -> BaseEnvironment]\" is not assignable to \"list[() -> Env[Unknown, Unknown]]\"\n    Type parameter \"_T@list\" is invariant, but \"() -> BaseEnvironment\" is not the same as \"() -> Env[Unknown, Unknown]\"\n    Consider switching from \"list\" to \"Sequence\" which is covariant",
-      "rule": "reportArgumentType",
+      "message": "Operator \"*\" not supported for \"None\"",
+      "rule": "reportOptionalOperand",
       "severity": "error",
-      "startCharacter": 35,
-      "startLine": 2017
+      "startCharacter": 15,
+      "startLine": 2056
     },
     {
-      "endCharacter": 22,
+      "endCharacter": 96,
       "endLine": 2058,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
-      "startCharacter": 15,
+      "startCharacter": 89,
       "startLine": 2058
     },
     {
-      "endCharacter": 96,
-      "endLine": 2060,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Operator \"*\" not supported for \"None\"",
-      "rule": "reportOptionalOperand",
-      "severity": "error",
-      "startCharacter": 89,
-      "startLine": 2060
-    },
-    {
       "endCharacter": 23,
-      "endLine": 2063,
+      "endLine": 2061,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 16,
-      "startLine": 2063
+      "startLine": 2061
     },
     {
       "endCharacter": 98,
-      "endLine": 2065,
+      "endLine": 2063,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 91,
-      "startLine": 2065
+      "startLine": 2063
     },
     {
       "endCharacter": 44,
+      "endLine": 2075,
+      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
+      "message": "Operator \"*\" not supported for types \"Any | None\" and \"Any | int | None\"\n  Operator \"*\" not supported for types \"None\" and \"None\"\n  Operator \"*\" not supported for types \"None\" and \"int\"",
+      "rule": "reportOperatorIssue",
+      "severity": "error",
+      "startCharacter": 15,
+      "startLine": 2075
+    },
+    {
+      "endCharacter": 133,
       "endLine": 2077,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \"*\" not supported for types \"Any | None\" and \"Any | int | None\"\n  Operator \"*\" not supported for types \"None\" and \"None\"\n  Operator \"*\" not supported for types \"None\" and \"int\"",
       "rule": "reportOperatorIssue",
       "severity": "error",
-      "startCharacter": 15,
+      "startCharacter": 106,
       "startLine": 2077
     },
     {
-      "endCharacter": 133,
-      "endLine": 2079,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Operator \"*\" not supported for types \"Any | None\" and \"Any | int | None\"\n  Operator \"*\" not supported for types \"None\" and \"None\"\n  Operator \"*\" not supported for types \"None\" and \"int\"",
-      "rule": "reportOperatorIssue",
-      "severity": "error",
-      "startCharacter": 106,
-      "startLine": 2079
-    },
-    {
       "endCharacter": 30,
-      "endLine": 2082,
+      "endLine": 2080,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Operator \">\" not supported for \"None\"",
       "rule": "reportOptionalOperand",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 2082
+      "startLine": 2080
     },
     {
       "endCharacter": 47,
-      "endLine": 2126,
+      "endLine": 2124,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"VecEnv\" cannot be assigned to parameter \"eval_env\" of type \"BaseEnvironment\" in function \"get_callbacks\"\n  \"VecEnv\" is not assignable to \"BaseEnvironment\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 2126
+      "startLine": 2124
     },
     {
       "endCharacter": 46,
-      "endLine": 2183,
+      "endLine": 2181,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"is_pruned\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 2183
+      "startLine": 2181
     },
     {
       "endCharacter": 57,
-      "endLine": 2186,
+      "endLine": 2184,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"best_mean_reward\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 41,
-      "startLine": 2186
+      "startLine": 2184
     },
     {
       "endCharacter": 37,
-      "endLine": 2196,
+      "endLine": 2194,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"train_env\" for class \"ReforceXY*\"\n  Type \"None\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n    \"None\" is not assignable to \"VecMonitor\"\n    \"None\" is not assignable to \"SubprocVecEnv\"\n    \"None\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 33,
-      "startLine": 2196
+      "startLine": 2194
     },
     {
       "endCharacter": 36,
-      "endLine": 2201,
+      "endLine": 2199,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Cannot assign to attribute \"eval_env\" for class \"ReforceXY*\"\n  Type \"None\" is not assignable to type \"VecMonitor | SubprocVecEnv | Env[Unknown, Unknown]\"\n    \"None\" is not assignable to \"VecMonitor\"\n    \"None\" is not assignable to \"SubprocVecEnv\"\n    \"None\" is not assignable to \"Env[Unknown, Unknown]\"",
       "rule": "reportAttributeAccessIssue",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 2201
-    },
-    {
-      "endCharacter": 7,
-      "endLine": 2233,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Declaration \"MyRLEnv\" is obscured by a declaration of the same name",
-      "rule": "reportRedeclaration",
-      "severity": "error",
-      "startCharacter": 0,
-      "startLine": 2233
+      "startLine": 2199
     },
     {
       "endCharacter": 34,
-      "endLine": 2245,
+      "endLine": 2294,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Declaration \"_last_closed_position\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 2245
+      "startLine": 2294
     },
     {
       "endCharacter": 36,
-      "endLine": 2246,
+      "endLine": 2295,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Declaration \"_last_closed_trade_tick\" is obscured by a declaration of the same name",
       "rule": "reportRedeclaration",
       "severity": "error",
       "startCharacter": 13,
-      "startLine": 2246
+      "startLine": 2295
     },
     {
       "endCharacter": 13,
-      "endLine": 3082,
+      "endLine": 2639,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"reset\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"tuple[DataFrame, dict[Unknown, Unknown]]\", override returns type \"tuple[NDArray[float32], dict[str, Any]]\"\n    \"tuple[NDArray[float32], dict[str, Any]]\" is not assignable to \"tuple[DataFrame, dict[Unknown, Unknown]]\"\n      Tuple entry 1 is incorrect type\n        \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3082
-    },
-    {
-      "endCharacter": 26,
-      "endLine": 3104,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Type \"tuple[DataFrame, dict[Unknown, Unknown]]\" is not assignable to return type \"tuple[NDArray[float32], dict[str, Any]]\"\n  \"DataFrame\" is not assignable to \"ndarray[_AnyShape, dtype[float32]]\"",
-      "rule": "reportReturnType",
-      "severity": "error",
-      "startCharacter": 15,
-      "startLine": 3104
-    },
-    {
-      "endCharacter": 55,
-      "endLine": 3433,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 44,
-      "startLine": 3433
-    },
-    {
-      "endCharacter": 55,
-      "endLine": 3433,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 44,
-      "startLine": 3433
-    },
-    {
-      "endCharacter": 59,
-      "endLine": 3457,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 48,
-      "startLine": 3457
-    },
-    {
-      "endCharacter": 59,
-      "endLine": 3457,
-      "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
-      "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
-      "rule": "reportArgumentType",
-      "severity": "error",
-      "startCharacter": 48,
-      "startLine": 3457
+      "startLine": 2639
     },
     {
       "endCharacter": 24,
-      "endLine": 3502,
+      "endLine": 2765,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"_get_observation\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"DataFrame\", override returns type \"NDArray[float32]\"\n    \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3502
+      "startLine": 2765
     },
     {
       "endCharacter": 53,
-      "endLine": 3570,
+      "endLine": 2859,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"name\" is not a known attribute of \"None\"",
       "rule": "reportOptionalMemberAccess",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 3570
+      "startLine": 2859
     },
     {
       "endCharacter": 12,
-      "endLine": 3604,
+      "endLine": 2863,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"step\" overrides class \"Base5ActionRLEnv\" in an incompatible manner\n  Return type mismatch: base method returns type \"tuple[DataFrame, float, bool, Literal[False], dict[str, Unknown]]\", override returns type \"tuple[NDArray[float32], float, bool, bool, dict[str, Any]]\"\n    \"tuple[NDArray[float32], float, bool, bool, dict[str, Any]]\" is not assignable to \"tuple[DataFrame, float, bool, Literal[False], dict[str, Unknown]]\"\n      Tuple entry 1 is incorrect type\n        \"ndarray[_AnyShape, dtype[float32]]\" is not assignable to \"DataFrame\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3604
+      "startLine": 2863
     },
     {
       "endCharacter": 20,
-      "endLine": 3717,
+      "endLine": 3041,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Method \"action_masks\" overrides class \"BaseEnvironment\" in an incompatible manner\n  Return type mismatch: base method returns type \"list[bool]\", override returns type \"NDArray[bool_]\"\n    \"ndarray[_AnyShape, dtype[bool_]]\" is not assignable to \"list[bool]\"",
       "rule": "reportIncompatibleMethodOverride",
       "severity": "error",
       "startCharacter": 8,
-      "startLine": 3717
+      "startLine": 3041
     },
     {
       "endCharacter": 65,
-      "endLine": 3910,
+      "endLine": 3181,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Type \"Any | None\" is not assignable to return type \"float\"\n  Type \"Any | None\" is not assignable to type \"float\"\n    \"None\" is not assignable to \"float\"",
       "rule": "reportReturnType",
       "severity": "error",
       "startCharacter": 15,
-      "startLine": 3910
+      "startLine": 3181
     },
     {
       "endCharacter": 40,
-      "endLine": 3949,
+      "endLine": 3220,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "\"Figure\" is not exported from module \"matplotlib.pyplot\"",
       "rule": "reportPrivateImportUsage",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 3949
+      "startLine": 3220
     },
     {
       "endCharacter": 54,
-      "endLine": 4447,
+      "endLine": 3718,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 4447
+      "startLine": 3718
     },
     {
       "endCharacter": 54,
-      "endLine": 4447,
+      "endLine": 3718,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 45,
-      "startLine": 4447
+      "startLine": 3718
     },
     {
       "endCharacter": 50,
-      "endLine": 4459,
+      "endLine": 3730,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"object\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"object\" is not assignable to type \"ConvertibleToFloat\"\n    \"object\" is not assignable to \"str\"\n    \"object\" is incompatible with protocol \"Buffer\"\n      \"__buffer__\" is not present\n    \"object\" is incompatible with protocol \"SupportsFloat\"\n      \"__float__\" is not present\n    \"object\" is incompatible with protocol \"SupportsIndex\"\n      \"__index__\" is not present",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 37,
-      "startLine": 4459
+      "startLine": 3730
     },
     {
       "endCharacter": 72,
-      "endLine": 4470,
+      "endLine": 3741,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 70,
-      "startLine": 4470
+      "startLine": 3741
     },
     {
       "endCharacter": 72,
-      "endLine": 4470,
+      "endLine": 3741,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 70,
-      "startLine": 4470
+      "startLine": 3741
     },
     {
       "endCharacter": 73,
-      "endLine": 4479,
+      "endLine": 3750,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 71,
-      "startLine": 4479
+      "startLine": 3750
     },
     {
       "endCharacter": 73,
-      "endLine": 4479,
+      "endLine": 3750,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"float | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"float | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 71,
-      "startLine": 4479
+      "startLine": 3750
     },
     {
       "endCharacter": 58,
-      "endLine": 4488,
+      "endLine": 3759,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 4488
+      "startLine": 3759
     },
     {
       "endCharacter": 58,
-      "endLine": 4488,
+      "endLine": 3759,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 56,
-      "startLine": 4488
+      "startLine": 3759
     },
     {
       "endCharacter": 50,
-      "endLine": 4712,
+      "endLine": 3983,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Mapping[Unknown, Unknown]\" cannot be assigned to parameter \"src\" of type \"dict[str, Any]\" in function \"deepmerge\"\n  \"Mapping[Unknown, Unknown]\" is not assignable to \"dict[str, Any]\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4712
+      "startLine": 3983
     },
     {
       "endCharacter": 20,
-      "endLine": 4889,
+      "endLine": 4160,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 4889
+      "startLine": 4160
     },
     {
       "endCharacter": 20,
-      "endLine": 4889,
+      "endLine": 4160,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 18,
-      "startLine": 4889
+      "startLine": 4160
     },
     {
       "endCharacter": 59,
-      "endLine": 4894,
+      "endLine": 4165,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4894
+      "startLine": 4165
     },
     {
       "endCharacter": 59,
-      "endLine": 4894,
+      "endLine": 4165,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4894
+      "startLine": 4165
     },
     {
       "endCharacter": 65,
-      "endLine": 4895,
+      "endLine": 4166,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4895
+      "startLine": 4166
     },
     {
       "endCharacter": 65,
-      "endLine": 4895,
+      "endLine": 4166,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4895
+      "startLine": 4166
     },
     {
       "endCharacter": 57,
-      "endLine": 4896,
+      "endLine": 4167,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4896
+      "startLine": 4167
     },
     {
       "endCharacter": 57,
-      "endLine": 4896,
+      "endLine": 4167,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4896
+      "startLine": 4167
     },
     {
       "endCharacter": 63,
-      "endLine": 4898,
+      "endLine": 4169,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4898
+      "startLine": 4169
     },
     {
       "endCharacter": 63,
-      "endLine": 4898,
+      "endLine": 4169,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4898
+      "startLine": 4169
     },
     {
       "endCharacter": 61,
-      "endLine": 4900,
+      "endLine": 4171,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 4900
+      "startLine": 4171
     },
     {
       "endCharacter": 61,
-      "endLine": 4900,
+      "endLine": 4171,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 32,
-      "startLine": 4900
+      "startLine": 4171
     },
     {
       "endCharacter": 67,
-      "endLine": 4901,
+      "endLine": 4172,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 4901
+      "startLine": 4172
     },
     {
       "endCharacter": 67,
-      "endLine": 4901,
+      "endLine": 4172,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 36,
-      "startLine": 4901
+      "startLine": 4172
     },
     {
       "endCharacter": 73,
-      "endLine": 4902,
+      "endLine": 4173,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4902
+      "startLine": 4173
     },
     {
       "endCharacter": 73,
-      "endLine": 4902,
+      "endLine": 4173,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4902
+      "startLine": 4173
     },
     {
       "endCharacter": 61,
-      "endLine": 4903,
+      "endLine": 4174,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 33,
-      "startLine": 4903
+      "startLine": 4174
     },
     {
       "endCharacter": 61,
-      "endLine": 4903,
+      "endLine": 4174,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 33,
-      "startLine": 4903
+      "startLine": 4174
     },
     {
       "endCharacter": 76,
-      "endLine": 4907,
+      "endLine": 4178,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4907
+      "startLine": 4178
     },
     {
       "endCharacter": 76,
-      "endLine": 4907,
+      "endLine": 4178,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4907
+      "startLine": 4178
     },
     {
       "endCharacter": 89,
-      "endLine": 4909,
+      "endLine": 4180,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 52,
-      "startLine": 4909
+      "startLine": 4180
     },
     {
       "endCharacter": 89,
-      "endLine": 4909,
+      "endLine": 4180,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 52,
-      "startLine": 4909
+      "startLine": 4180
     },
     {
       "endCharacter": 83,
-      "endLine": 4910,
+      "endLine": 4181,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4910
+      "startLine": 4181
     },
     {
       "endCharacter": 83,
-      "endLine": 4910,
+      "endLine": 4181,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4910
+      "startLine": 4181
     },
     {
       "endCharacter": 57,
-      "endLine": 4935,
+      "endLine": 4206,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4935
+      "startLine": 4206
     },
     {
       "endCharacter": 57,
-      "endLine": 4935,
+      "endLine": 4206,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 31,
-      "startLine": 4935
+      "startLine": 4206
     },
     {
       "endCharacter": 65,
-      "endLine": 4936,
+      "endLine": 4207,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4936
+      "startLine": 4207
     },
     {
       "endCharacter": 65,
-      "endLine": 4936,
+      "endLine": 4207,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 34,
-      "startLine": 4936
+      "startLine": 4207
     },
     {
       "endCharacter": 67,
-      "endLine": 4938,
+      "endLine": 4209,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 4938
+      "startLine": 4209
     },
     {
       "endCharacter": 67,
-      "endLine": 4938,
+      "endLine": 4209,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 35,
-      "startLine": 4938
+      "startLine": 4209
     },
     {
       "endCharacter": 87,
-      "endLine": 4941,
+      "endLine": 4212,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4941
+      "startLine": 4212
     },
     {
       "endCharacter": 87,
-      "endLine": 4941,
+      "endLine": 4212,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4941
+      "startLine": 4212
     },
     {
       "endCharacter": 93,
-      "endLine": 4942,
+      "endLine": 4213,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4942
+      "startLine": 4213
     },
     {
       "endCharacter": 93,
-      "endLine": 4942,
+      "endLine": 4213,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 49,
-      "startLine": 4942
+      "startLine": 4213
     },
     {
       "endCharacter": 89,
-      "endLine": 4943,
+      "endLine": 4214,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 47,
-      "startLine": 4943
+      "startLine": 4214
     },
     {
       "endCharacter": 89,
-      "endLine": 4943,
+      "endLine": 4214,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToFloat\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToFloat\"\n    Type \"None\" is not assignable to type \"ConvertibleToFloat\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsFloat\"\n        \"__float__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 47,
-      "startLine": 4943
+      "startLine": 4214
     },
     {
       "endCharacter": 89,
-      "endLine": 4944,
+      "endLine": 4215,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4944
+      "startLine": 4215
     },
     {
       "endCharacter": 89,
-      "endLine": 4944,
+      "endLine": 4215,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 46,
-      "startLine": 4944
+      "startLine": 4215
     },
     {
       "endCharacter": 75,
-      "endLine": 4945,
+      "endLine": 4216,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4945
+      "startLine": 4216
     },
     {
       "endCharacter": 75,
-      "endLine": 4945,
+      "endLine": 4216,
       "file": "ReforceXY/user_data/freqaimodels/ReforceXY.py",
       "message": "Argument of type \"Any | None\" cannot be assigned to parameter \"x\" of type \"ConvertibleToInt\" in function \"__new__\"\n  Type \"Any | None\" is not assignable to type \"ConvertibleToInt\"\n    Type \"None\" is not assignable to type \"ConvertibleToInt\"\n      \"None\" is not assignable to \"str\"\n      \"None\" is incompatible with protocol \"Buffer\"\n        \"__buffer__\" is not present\n      \"None\" is incompatible with protocol \"SupportsInt\"\n        \"__int__\" is not present\n      \"None\" is incompatible with protocol \"SupportsIndex\"\n  ...",
       "rule": "reportArgumentType",
       "severity": "error",
       "startCharacter": 39,
-      "startLine": 4945
+      "startLine": 4216
     },
     {
       "endCharacter": 33,

--- a/ReforceXY/user_data/config-template.json
+++ b/ReforceXY/user_data/config-template.json
@@ -116,7 +116,7 @@
     // "live_retrain_hours": 0.5,
     "backtest_period_days": 2,
     "write_metrics_to_disk": false,
-    "identifier": "ReforceXY-PPO",
+    "identifier": "ReforceXY-PPO-causal-net-log-v1",
     "fit_live_predictions_candles": 864,
     "data_kitchen_thread_count": 4, // set to number of CPU threads / 4
     "track_performance": false,
@@ -162,9 +162,10 @@
       "model_reward_parameters": {
         "rr": 2.0,
         "profit_aim": 0.025,
-        "win_reward_factor": 2.0,
+        "base_factor": 100.0,
         "max_trade_duration_candles": 96, // Maximum trade duration in candles
-        "idle_penalty_ratio": 0.0
+        "hold_potential_enabled": false,
+        "exit_potential_mode": "canonical"
       },
       "train_cycles": 25,
       "add_state_info": true,

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -32,7 +32,6 @@ import optunahub
 import pandas as pd
 import torch as th
 from freqtrade.enums import TradingMode
-from freqtrade.persistence import LocalTrade
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.RL.Base5ActionRLEnv import Actions, Base5ActionRLEnv, Positions
@@ -41,6 +40,7 @@ from freqtrade.freqai.RL.BaseReinforcementLearningModel import (
     BaseReinforcementLearningModel,
 )
 from freqtrade.freqai.tensorboard.TensorboardCallback import TensorboardCallback
+from freqtrade.persistence import LocalTrade
 from freqtrade.strategy import timeframe_to_minutes
 from gymnasium.spaces import Box
 from matplotlib.lines import Line2D
@@ -283,10 +283,6 @@ class ReforceXY(BaseReinforcementLearningModel):
     DEFAULT_EFFICIENCY_CENTER: Final[float] = 0.5
 
     DEFAULT_INVALID_ACTION: Final[float] = -2.0
-    DEFAULT_IDLE_PENALTY_RATIO: Final[float] = 1.0
-    DEFAULT_IDLE_PENALTY_POWER: Final[float] = 1.025
-    DEFAULT_HOLD_PENALTY_RATIO: Final[float] = 1.0
-    DEFAULT_HOLD_PENALTY_POWER: Final[float] = 1.025
 
     DEFAULT_CHECK_INVARIANTS: Final[bool] = True
     DEFAULT_EXIT_FACTOR_THRESHOLD: Final[float] = 1_000.0
@@ -2265,13 +2261,11 @@ class MyRLEnv(Base5ActionRLEnv):
         rl_config = config.get("freqai", {}).get("rl_config", {})
         if not rl_config.get("add_state_info", False):
             raise ValueError(
-                "Env: add_state_info=True is required by the pair-local "
-                "economic reward contract"
+                "Env: add_state_info=True is required by the pair-local economic reward contract"
             )
         if config.get("trading_mode") != "spot":
             raise ValueError(
-                "Env: trading_mode='spot' is required until leveraged PnL has "
-                "Freqtrade parity"
+                "Env: trading_mode='spot' is required until leveraged PnL has Freqtrade parity"
             )
         if config.get("stake_amount") != "unlimited":
             raise ValueError(
@@ -2298,7 +2292,7 @@ class MyRLEnv(Base5ActionRLEnv):
         self.action_masking: bool = self.rl_config.get("action_masking", False)
 
         # === INTERNAL STATE ===
-        self._last_closed_position: Optional[Positions] = None
+        self._last_closed_position: Positions | None = None
         self._last_closed_trade_tick: int = 0
         self._max_unrealized_profit: float = -np.inf
         self._min_unrealized_profit: float = np.inf
@@ -2346,14 +2340,11 @@ class MyRLEnv(Base5ActionRLEnv):
         self.max_idle_duration_candles: int = int(
             model_reward_parameters.get(
                 "max_idle_duration_candles",
-                ReforceXY.DEFAULT_IDLE_DURATION_MULTIPLIER
-                * self.max_trade_duration_candles,
+                ReforceXY.DEFAULT_IDLE_DURATION_MULTIPLIER * self.max_trade_duration_candles,
             )
         )
         # === PBRS COMMON PARAMETERS ===
-        self._potential_gamma = float(
-            model_reward_parameters.get("potential_gamma", 0.95)
-        )
+        self._potential_gamma = float(model_reward_parameters.get("potential_gamma", 0.95))
 
         # === EXIT POTENTIAL MODE ===
         # exit_potential_mode options:
@@ -2368,9 +2359,7 @@ class MyRLEnv(Base5ActionRLEnv):
             )  # "canonical"
         )
         if self._exit_potential_mode != ReforceXY._EXIT_POTENTIAL_MODES[0]:
-            raise ValueError(
-                f"PBRS [{self.id}]: only exit_potential_mode='canonical' is supported"
-            )
+            raise ValueError(f"PBRS [{self.id}]: only exit_potential_mode='canonical' is supported")
         self._exit_potential_decay: float = float(
             model_reward_parameters.get(
                 "exit_potential_decay", ReforceXY.DEFAULT_EXIT_POTENTIAL_DECAY
@@ -2393,13 +2382,13 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._entry_additive_transform_pnl: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "entry_additive_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._entry_additive_transform_duration: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "entry_additive_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
@@ -2421,24 +2410,21 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._hold_potential_transform_pnl: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "hold_potential_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._hold_potential_transform_duration: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "hold_potential_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         if self._hold_potential_enabled and (
-            not np.isfinite(self._potential_gamma)
-            or not (0.0 < self._potential_gamma <= 1.0)
+            not np.isfinite(self._potential_gamma) or not (0.0 < self._potential_gamma <= 1.0)
         ):
-            raise ValueError(
-                f"PBRS [{self.id}]: potential_gamma must be finite and in (0, 1]"
-            )
+            raise ValueError(f"PBRS [{self.id}]: potential_gamma must be finite and in (0, 1]")
         # === EXIT ADDITIVE (non-PBRS additive term) ===
         self._exit_additive_enabled: bool = bool(
             model_reward_parameters.get(
@@ -2451,18 +2437,16 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._exit_additive_gain: float = float(
-            model_reward_parameters.get(
-                "exit_additive_gain", ReforceXY.DEFAULT_EXIT_ADDITIVE_GAIN
-            )
+            model_reward_parameters.get("exit_additive_gain", ReforceXY.DEFAULT_EXIT_ADDITIVE_GAIN)
         )
         self._exit_additive_transform_pnl: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "exit_additive_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._exit_additive_transform_duration: TransformFunction = cast(
-            TransformFunction,
+            "TransformFunction",
             model_reward_parameters.get(
                 "exit_additive_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
@@ -2482,9 +2466,7 @@ class MyRLEnv(Base5ActionRLEnv):
         if self._hold_potential_enabled and (
             not np.isfinite(self._pnl_target) or self._pnl_target <= 0
         ):
-            raise ValueError(
-                f"PBRS [{self.id}]: profit_aim * rr must be finite and positive"
-            )
+            raise ValueError(f"PBRS [{self.id}]: profit_aim * rr must be finite and positive")
 
     def _get_next_position(self, action: int) -> Positions:
         if action == Actions.Long_enter.value and self._position == Positions.Neutral:
@@ -2533,13 +2515,9 @@ class MyRLEnv(Base5ActionRLEnv):
     def _assert_local_trade_synchronized(self) -> LocalTrade:
         """Return the active native trade after checking environment alignment."""
         if self._position not in (Positions.Long, Positions.Short):
-            raise RuntimeError(
-                f"Env [{self.id}]: LocalTrade requested while position is neutral"
-            )
+            raise RuntimeError(f"Env [{self.id}]: LocalTrade requested while position is neutral")
         if self._last_trade_tick is None or self._local_trade is None:
-            raise RuntimeError(
-                f"Env [{self.id}]: open position has no synchronized LocalTrade"
-            )
+            raise RuntimeError(f"Env [{self.id}]: open position has no synchronized LocalTrade")
         if not (0 <= self._last_trade_tick <= self._current_tick < len(self.prices)):
             raise RuntimeError(
                 f"Env [{self.id}]: LocalTrade entry/current ticks are out of bounds "
@@ -2639,9 +2617,7 @@ class MyRLEnv(Base5ActionRLEnv):
             self.total_features = signal_features
 
         self.shape = (self.window_size, self.total_features)
-        self.observation_space = Box(
-            low=-np.inf, high=np.inf, shape=self.shape, dtype=np.float32
-        )
+        self.observation_space = Box(low=-np.inf, high=np.inf, shape=self.shape, dtype=np.float32)
 
     def _is_valid(self, action: int) -> bool:
         return ReforceXY.get_action_masks(self.can_short, self._position)[action]
@@ -2651,17 +2627,17 @@ class MyRLEnv(Base5ActionRLEnv):
         df: DataFrame,
         prices: DataFrame,
         window_size: int,
-        reward_kwargs: Dict[str, Any],
+        reward_kwargs: dict[str, Any],
         starting_point=True,
     ) -> None:
         """
         Resets the environment when the agent fails
         """
-        self._local_trade: Optional[LocalTrade] = None
+        self._local_trade: LocalTrade | None = None
         super().reset_env(df, prices, window_size, reward_kwargs, starting_point)
         self._set_observation_space()
 
-    def reset(self, seed=None, **kwargs) -> Tuple[NDArray[np.float32], Dict[str, Any]]:
+    def reset(self, seed=None, **kwargs) -> tuple[NDArray[np.float32], dict[str, Any]]:
         """Reset one tick before the first executable open.
 
         A feature window ending at ``start_tick - 1`` produces the signal that
@@ -2671,7 +2647,7 @@ class MyRLEnv(Base5ActionRLEnv):
         _, history = super().reset(seed, **kwargs)
         self._current_tick = self._start_tick - 1
         self._position_history = (self._current_tick * [None]) + [self._position]
-        self._last_closed_position: Optional[Positions] = None
+        self._last_closed_position: Positions | None = None
         self._local_trade = None
         self._last_closed_trade_tick: int = 0
         self._max_unrealized_profit = -np.inf
@@ -2698,7 +2674,16 @@ class MyRLEnv(Base5ActionRLEnv):
         self._last_exit_reward = 0.0
         return self._get_observation(), history
 
-    def calculate_reward(
+    def calculate_reward(self, action: int) -> float:
+        """Compute the reward from the environment's current observable state."""
+        return self._calculate_economic_reward(
+            action,
+            previous_position=self._position,
+            transition_pnl=float(self.get_unrealized_profit()),
+            action_valid=self._is_valid(action),
+        )
+
+    def _calculate_economic_reward(
         self,
         action: int,
         *,
@@ -2730,23 +2715,17 @@ class MyRLEnv(Base5ActionRLEnv):
         if not self.action_masking and not action_valid:
             self.tensorboard_log("invalid", category="actions")
             invalid_penalty = float(
-                model_reward_parameters.get(
-                    "invalid_action", ReforceXY.DEFAULT_INVALID_ACTION
-                )
+                model_reward_parameters.get("invalid_action", ReforceXY.DEFAULT_INVALID_ACTION)
             )
             if not np.isfinite(invalid_penalty):
-                raise ValueError(
-                    f"Env [{self.id}]: invalid_action reward must be finite"
-                )
+                raise ValueError(f"Env [{self.id}]: invalid_action reward must be finite")
             self._last_invalid_penalty = invalid_penalty
 
         base_factor = float(
             model_reward_parameters.get("base_factor", ReforceXY.DEFAULT_BASE_FACTOR)
         )
         if not np.isfinite(base_factor) or base_factor <= 0.0:
-            raise ValueError(
-                f"Env [{self.id}]: base_factor must be finite and positive"
-            )
+            raise ValueError(f"Env [{self.id}]: base_factor must be finite and positive")
         self._reward_scale = base_factor
 
         position_was_open = previous_position in (Positions.Long, Positions.Short)
@@ -2755,18 +2734,13 @@ class MyRLEnv(Base5ActionRLEnv):
             reward_liquidation_value = self._liquidation_value_from_pnl(
                 transition_pnl, context="transition liquidation"
             )
-            next_liquidation_value = (
-                reward_liquidation_value if position_is_open else 1.0
-            )
+            next_liquidation_value = reward_liquidation_value if position_is_open else 1.0
         else:
             reward_liquidation_value = 1.0
             next_liquidation_value = 1.0
 
         previous_liquidation_value = self._previous_liquidation_value
-        if (
-            not np.isfinite(previous_liquidation_value)
-            or previous_liquidation_value <= 0.0
-        ):
+        if not np.isfinite(previous_liquidation_value) or previous_liquidation_value <= 0.0:
             raise RuntimeError(
                 f"Env [{self.id}]: previous liquidation value is invalid at "
                 f"tick={self._current_tick}: {previous_liquidation_value!r}"
@@ -2796,12 +2770,8 @@ class MyRLEnv(Base5ActionRLEnv):
         features_window_array = features_window.to_numpy(dtype=np.float32, copy=False)
         if features_window_array.shape[0] < self.window_size:
             pad_size = self.window_size - features_window_array.shape[0]
-            pad_array = np.zeros(
-                (pad_size, features_window_array.shape[1]), dtype=np.float32
-            )
-            features_window_array = np.concatenate(
-                [pad_array, features_window_array], axis=0
-            )
+            pad_array = np.zeros((pad_size, features_window_array.shape[1]), dtype=np.float32)
+            features_window_array = np.concatenate([pad_array, features_window_array], axis=0)
         if self.add_state_info:
             observations = np.concatenate(
                 [
@@ -2872,7 +2842,7 @@ class MyRLEnv(Base5ActionRLEnv):
         self._max_unrealized_profit = -np.inf
         self._min_unrealized_profit = np.inf
 
-    def execute_trade(self, action: int, *, exit_pnl: float = 0.0) -> Optional[str]:
+    def execute_trade(self, action: int, *, exit_pnl: float = 0.0) -> str | None:
         """
         Execute trade based on the given action
         """
@@ -2891,17 +2861,13 @@ class MyRLEnv(Base5ActionRLEnv):
 
         return None
 
-    def step(
-        self, action: int
-    ) -> Tuple[NDArray[np.float32], float, bool, bool, Dict[str, Any]]:
+    def step(self, action: int) -> tuple[NDArray[np.float32], float, bool, bool, dict[str, Any]]:
         """Fill at the next open, mark at its close, then expose the next state."""
         previous_position = self._position
         pre_pnl = float(self.get_unrealized_profit())
         previous_liquidation_value = self._previous_liquidation_value
         observable_liquidation_value = (
-            1.0 + pre_pnl
-            if previous_position in (Positions.Long, Positions.Short)
-            else 1.0
+            1.0 + pre_pnl if previous_position in (Positions.Long, Positions.Short) else 1.0
         )
         if (
             not np.isfinite(observable_liquidation_value)
@@ -2949,7 +2915,7 @@ class MyRLEnv(Base5ActionRLEnv):
             if self._position in (Positions.Long, Positions.Short)
             else exit_pnl
         )
-        reward = self.calculate_reward(
+        reward = self._calculate_economic_reward(
             action,
             previous_position=previous_position,
             transition_pnl=transition_pnl,
@@ -3000,9 +2966,7 @@ class MyRLEnv(Base5ActionRLEnv):
             "delta_pnl": round(delta_pnl, 5),
             "max_pnl": round(self.get_max_unrealized_profit(), 5),
             "min_pnl": round(self.get_min_unrealized_profit(), 5),
-            "most_recent_return": round(
-                self._last_economic_reward / self._reward_scale, 5
-            ),
+            "most_recent_return": round(self._last_economic_reward / self._reward_scale, 5),
             "most_recent_profit": round(self.get_most_recent_profit(), 5),
             "total_profit": round(self._total_profit, 5),
             "total_unrealized_profit": round(self._total_unrealized_profit, 5),
@@ -3028,9 +2992,7 @@ class MyRLEnv(Base5ActionRLEnv):
             "idle_duration": idle_duration,
             "idle_ratio": (idle_duration / max_idle_duration),
             "trade_duration": trade_duration,
-            "duration_ratio": (
-                trade_duration / max(1, self.max_trade_duration_candles)
-            ),
+            "duration_ratio": (trade_duration / max(1, self.max_trade_duration_candles)),
             "trade_count": len(self.trade_history) // 2,
         }
         self._update_history(info)
@@ -3042,9 +3004,7 @@ class MyRLEnv(Base5ActionRLEnv):
             info,
         )
 
-    def append_trade_history(
-        self, trade_type: str, price: float, profit: float
-    ) -> None:
+    def append_trade_history(self, trade_type: str, price: float, profit: float) -> None:
         self.trade_history.append(
             {
                 "tick": self._current_tick,
@@ -3135,9 +3095,11 @@ class MyRLEnv(Base5ActionRLEnv):
         return self._max_unrealized_profit
 
     def _update_max_unrealized_profit(self, pnl: float) -> None:
-        if self._position in (Positions.Long, Positions.Short):
-            if pnl > self._max_unrealized_profit:
-                self._max_unrealized_profit = pnl
+        if (
+            self._position in (Positions.Long, Positions.Short)
+            and pnl > self._max_unrealized_profit
+        ):
+            self._max_unrealized_profit = pnl
 
     def get_min_unrealized_profit(self) -> float:
         """
@@ -3152,9 +3114,11 @@ class MyRLEnv(Base5ActionRLEnv):
         return self._min_unrealized_profit
 
     def _update_min_unrealized_profit(self, pnl: float) -> None:
-        if self._position in (Positions.Long, Positions.Short):
-            if pnl < self._min_unrealized_profit:
-                self._min_unrealized_profit = pnl
+        if (
+            self._position in (Positions.Long, Positions.Short)
+            and pnl < self._min_unrealized_profit
+        ):
+            self._min_unrealized_profit = pnl
 
     def _update_portfolio_log_returns(self):
         self.portfolio_log_returns[self._current_tick] = (
@@ -3234,9 +3198,7 @@ class MyRLEnv(Base5ActionRLEnv):
         if self.trade_history:
             _trade_history_df = DataFrame(self.trade_history)
             if "tick" in _trade_history_df.columns:
-                _rollout_history = merge(
-                    _rollout_history, _trade_history_df, on="tick", how="left"
-                )
+                _rollout_history = merge(_rollout_history, _trade_history_df, on="tick", how="left")
 
         try:
             history = merge(
@@ -3295,12 +3257,7 @@ class MyRLEnv(Base5ActionRLEnv):
 
             ticks = history.get("tick")
             history_open = history.get("open")
-            if (
-                ticks is None
-                or len(ticks) == 0
-                or history_open is None
-                or len(history_open) == 0
-            ):
+            if ticks is None or len(ticks) == 0 or history_open is None or len(history_open) == 0:
                 return fig
 
             axs[0].plot(ticks, history_open, linewidth=1, color="orchid", zorder=1)

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -2261,10 +2261,12 @@ class MyRLEnv(Base5ActionRLEnv):
 
     def __init__(self, *args, **kwargs):
         config = kwargs.get("config", {})
-        if kwargs.get("live", False) is not True:
+        live = bool(kwargs.get("live", False))
+        rl_config = config.get("freqai", {}).get("rl_config", {})
+        if not rl_config.get("add_state_info", False):
             raise ValueError(
-                "Env: the stateful pair-local economic reward contract is not "
-                "supported in FreqAI backtesting; live=True is required"
+                "Env: add_state_info=True is required by the pair-local "
+                "economic reward contract"
             )
         if config.get("trading_mode") != "spot":
             raise ValueError(
@@ -2276,12 +2278,22 @@ class MyRLEnv(Base5ActionRLEnv):
                 "Env: stake_amount='unlimited' is required by the compounded "
                 "net liquidation reward contract"
             )
+        # Upstream BaseEnvironment refuses add_state_info outside dry/live
+        # because its inference path reads Freqtrade runtime state. This env
+        # computes state info from env-internal simulated values only (no
+        # wallet/order authority), so in backtesting construct the base with
+        # the flag disabled and restore it before the observation space is
+        # built. The reward equation itself is mode-independent.
+        backtest_state_info = not live
+        if backtest_state_info:
+            base_config = copy.deepcopy(config)
+            base_config["freqai"]["rl_config"]["add_state_info"] = False
+            kwargs = {**kwargs, "config": base_config}
         super().__init__(*args, **kwargs)
-        if getattr(self, "add_state_info", False) is not True:
-            raise ValueError(
-                f"Env [{self.id}]: add_state_info=True is required by the "
-                "pair-local economic reward contract"
-            )
+        if backtest_state_info:
+            self.config = config
+            self.rl_config = rl_config
+        self.add_state_info = True
         self._set_observation_space()
         self.action_masking: bool = self.rl_config.get("action_masking", False)
 

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -31,6 +31,8 @@ import numpy as np
 import optunahub
 import pandas as pd
 import torch as th
+from freqtrade.enums import TradingMode
+from freqtrade.persistence import LocalTrade
 from freqtrade.freqai.data_drawer import FreqaiDataDrawer
 from freqtrade.freqai.data_kitchen import FreqaiDataKitchen
 from freqtrade.freqai.RL.Base5ActionRLEnv import Actions, Base5ActionRLEnv, Positions
@@ -2231,22 +2233,70 @@ def make_env(
     return _init
 
 
-MyRLEnv: type[BaseEnvironment]
-
-
 class MyRLEnv(Base5ActionRLEnv):
-    """Env."""
+    """Spot-only pair-local environment with compounded net liquidation rewards."""
+
+    _MIN_LIQUIDATION_VALUE: Final[float] = 1e-12
+    _IGNORED_LEGACY_REWARD_PARAMETERS: Final[frozenset[str]] = frozenset(
+        {
+            "check_invariants",
+            "efficiency_center",
+            "efficiency_weight",
+            "exit_attenuation_mode",
+            "exit_factor_threshold",
+            "exit_half_life",
+            "exit_linear_slope",
+            "exit_plateau",
+            "exit_plateau_grace",
+            "exit_power_tau",
+            "hold_penalty_power",
+            "hold_penalty_ratio",
+            "idle_penalty_power",
+            "idle_penalty_ratio",
+            "pnl_amplification_sensitivity",
+            "win_reward_factor",
+        }
+    )
+    _warned_legacy_reward_parameters: ClassVar[set[str]] = set()
 
     def __init__(self, *args, **kwargs):
+        config = kwargs.get("config", {})
+        if kwargs.get("live", False) is not True:
+            raise ValueError(
+                "Env: the stateful pair-local economic reward contract is not "
+                "supported in FreqAI backtesting; live=True is required"
+            )
+        if config.get("trading_mode") != "spot":
+            raise ValueError(
+                "Env: trading_mode='spot' is required until leveraged PnL has "
+                "Freqtrade parity"
+            )
+        if config.get("stake_amount") != "unlimited":
+            raise ValueError(
+                "Env: stake_amount='unlimited' is required by the compounded "
+                "net liquidation reward contract"
+            )
         super().__init__(*args, **kwargs)
+        if getattr(self, "add_state_info", False) is not True:
+            raise ValueError(
+                f"Env [{self.id}]: add_state_info=True is required by the "
+                "pair-local economic reward contract"
+            )
         self._set_observation_space()
         self.action_masking: bool = self.rl_config.get("action_masking", False)
 
         # === INTERNAL STATE ===
-        self._last_closed_position: Positions | None = None
+        self._last_closed_position: Optional[Positions] = None
         self._last_closed_trade_tick: int = 0
         self._max_unrealized_profit: float = -np.inf
         self._min_unrealized_profit: float = np.inf
+        self._previous_liquidation_value: float = 1.0
+        self._reward_liquidation_value: float = 1.0
+        self._next_liquidation_value: float = 1.0
+        self._last_economic_reward: float = 0.0
+        self._reward_scale: float = ReforceXY.DEFAULT_BASE_FACTOR
+        self._expected_next_position: Positions = self._position
+        self._economic_ruin: bool = False
         self._last_potential: float = 0.0
         # === PBRS INSTRUMENTATION ===
         self._last_prev_potential: float = 0.0
@@ -2264,6 +2314,17 @@ class MyRLEnv(Base5ActionRLEnv):
         model_reward_parameters: Mapping[str, Any] = self.rl_config.get(
             "model_reward_parameters", {}
         )
+        ignored_parameters = self._IGNORED_LEGACY_REWARD_PARAMETERS.intersection(
+            model_reward_parameters
+        ).difference(self._warned_legacy_reward_parameters)
+        if ignored_parameters:
+            logger.warning(
+                "Env [%s]: legacy reward parameters have no effect under the "
+                "economic reward contract: %s",
+                self.id,
+                ", ".join(sorted(ignored_parameters)),
+            )
+            self._warned_legacy_reward_parameters.update(ignored_parameters)
         self.max_trade_duration_candles: int = int(
             model_reward_parameters.get(
                 "max_trade_duration_candles",
@@ -2273,17 +2334,14 @@ class MyRLEnv(Base5ActionRLEnv):
         self.max_idle_duration_candles: int = int(
             model_reward_parameters.get(
                 "max_idle_duration_candles",
-                ReforceXY.DEFAULT_IDLE_DURATION_MULTIPLIER * self.max_trade_duration_candles,
+                ReforceXY.DEFAULT_IDLE_DURATION_MULTIPLIER
+                * self.max_trade_duration_candles,
             )
         )
         # === PBRS COMMON PARAMETERS ===
-        self._potential_gamma = float(model_reward_parameters.get("potential_gamma", 0.95))
-        if np.isclose(self._potential_gamma, 0.0):
-            logger.warning(
-                "PBRS [%s]: potential_gamma=0 detected; PBRS delta will be -Φ(s) "
-                "instead of γΦ(s')-Φ(s). This may cause unexpected reward behavior.",
-                self.id,
-            )
+        self._potential_gamma = float(
+            model_reward_parameters.get("potential_gamma", 0.95)
+        )
 
         # === EXIT POTENTIAL MODE ===
         # exit_potential_mode options:
@@ -2297,15 +2355,10 @@ class MyRLEnv(Base5ActionRLEnv):
                 "exit_potential_mode", ReforceXY._EXIT_POTENTIAL_MODES[0]
             )  # "canonical"
         )
-        if self._exit_potential_mode not in ReforceXY._EXIT_POTENTIAL_MODES_SET:
-            logger.warning(
-                "PBRS [%s]: exit_potential_mode=%r invalid; defaulting to %r. Valid: %s",
-                self.id,
-                self._exit_potential_mode,
-                ReforceXY._EXIT_POTENTIAL_MODES[0],
-                ", ".join(ReforceXY._EXIT_POTENTIAL_MODES),
+        if self._exit_potential_mode != ReforceXY._EXIT_POTENTIAL_MODES[0]:
+            raise ValueError(
+                f"PBRS [{self.id}]: only exit_potential_mode='canonical' is supported"
             )
-            self._exit_potential_mode = ReforceXY._EXIT_POTENTIAL_MODES[0]  # "canonical"
         self._exit_potential_decay: float = float(
             model_reward_parameters.get(
                 "exit_potential_decay", ReforceXY.DEFAULT_EXIT_POTENTIAL_DECAY
@@ -2328,13 +2381,13 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._entry_additive_transform_pnl: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "entry_additive_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._entry_additive_transform_duration: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "entry_additive_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
@@ -2356,17 +2409,24 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._hold_potential_transform_pnl: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "hold_potential_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._hold_potential_transform_duration: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "hold_potential_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
+        if self._hold_potential_enabled and (
+            not np.isfinite(self._potential_gamma)
+            or not (0.0 < self._potential_gamma <= 1.0)
+        ):
+            raise ValueError(
+                f"PBRS [{self.id}]: potential_gamma must be finite and in (0, 1]"
+            )
         # === EXIT ADDITIVE (non-PBRS additive term) ===
         self._exit_additive_enabled: bool = bool(
             model_reward_parameters.get(
@@ -2379,59 +2439,40 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         )
         self._exit_additive_gain: float = float(
-            model_reward_parameters.get("exit_additive_gain", ReforceXY.DEFAULT_EXIT_ADDITIVE_GAIN)
+            model_reward_parameters.get(
+                "exit_additive_gain", ReforceXY.DEFAULT_EXIT_ADDITIVE_GAIN
+            )
         )
         self._exit_additive_transform_pnl: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "exit_additive_transform_pnl", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
         self._exit_additive_transform_duration: TransformFunction = cast(
-            "TransformFunction",
+            TransformFunction,
             model_reward_parameters.get(
                 "exit_additive_transform_duration", ReforceXY._TRANSFORM_FUNCTIONS[0]
             ),  # "tanh"
         )
-        # === PBRS INVARIANCE CHECKS ===
-        # "canonical"
-        if self._exit_potential_mode == ReforceXY._EXIT_POTENTIAL_MODES[0]:
-            if self._entry_additive_enabled or self._exit_additive_enabled:
-                logger.warning(
-                    "PBRS [%s]: canonical mode, additive disabled (use exit_potential_mode=%s to enable)",
-                    self.id,
-                    ReforceXY._EXIT_POTENTIAL_MODES[1],
-                )
-                self._entry_additive_enabled = False
-                self._exit_additive_enabled = False
-        # "non_canonical"
-        elif self._exit_potential_mode == ReforceXY._EXIT_POTENTIAL_MODES[1] and (
-            self._entry_additive_enabled or self._exit_additive_enabled
+        if (
+            self._hold_potential_enabled
+            or self._entry_additive_enabled
+            or self._exit_additive_enabled
         ):
-            logger.warning("PBRS [%s]: non-canonical mode, additive enabled", self.id)
-
-        if MyRLEnv.is_unsupported_pbrs_config(
-            self._hold_potential_enabled, getattr(self, "add_state_info", False)
-        ):
-            logger.warning(
-                "PBRS [%s]: hold_potential_enabled=True requires add_state_info=True, enabling",
-                self.id,
+            raise ValueError(
+                f"Env [{self.id}]: reward shaping must remain disabled for the "
+                "promotable pair-local economic reward contract"
             )
-            self.add_state_info = True
-            self._set_observation_space()
 
         # === PNL TARGET ===
         self._pnl_target = float(self.profit_aim * self.rr)
-        if self._pnl_target <= 0:
-            logger.warning(
-                "PBRS [%s]: pnl_target=%.6f must be > 0 (profit_aim=%.4f, rr=%.4f); "
-                "defaulting to 0.01",
-                self.id,
-                self._pnl_target,
-                self.profit_aim,
-                self.rr,
+        if self._hold_potential_enabled and (
+            not np.isfinite(self._pnl_target) or self._pnl_target <= 0
+        ):
+            raise ValueError(
+                f"PBRS [{self.id}]: profit_aim * rr must be finite and positive"
             )
-            self._pnl_target = 0.01
 
     def _get_next_position(self, action: int) -> Positions:
         if action == Actions.Long_enter.value and self._position == Positions.Neutral:
@@ -2448,605 +2489,132 @@ class MyRLEnv(Base5ActionRLEnv):
             return Positions.Neutral
         return self._position
 
-    def _get_entry_unrealized_profit(self, next_position: Positions) -> float:
-        current_open = self.prices.iloc[self._current_tick].open
-        if not isinstance(current_open, (int, float, np.floating)) or not np.isfinite(current_open):
-            return 0.0
+    def _validated_price(self, value: Any, *, context: str) -> float:
+        """Return a finite positive price or fail the current training trial."""
+        try:
+            price = float(value)
+        except (TypeError, ValueError) as exc:
+            raise ValueError(
+                f"Env [{self.id}]: {context} price is not numeric at "
+                f"tick={self._current_tick}: {value!r}"
+            ) from exc
+        if not np.isfinite(price) or price <= 0.0:
+            raise ValueError(
+                f"Env [{self.id}]: {context} price must be finite and positive at "
+                f"tick={self._current_tick}: {price!r}"
+            )
+        return price
 
-        next_pnl = 0.0
-        if next_position == Positions.Long:
-            current_price = self.add_exit_fee(current_open)
-            last_trade_price = self.add_entry_fee(current_open)
-            if not np.isclose(last_trade_price, 0.0) and np.isfinite(last_trade_price):
-                next_pnl = (current_price - last_trade_price) / last_trade_price
-        elif next_position == Positions.Short:
-            current_price = self.add_entry_fee(current_open)
-            last_trade_price = self.add_exit_fee(current_open)
-            if not np.isclose(last_trade_price, 0.0) and np.isfinite(last_trade_price):
-                next_pnl = (last_trade_price - current_price) / last_trade_price
+    def _liquidation_value_from_pnl(self, pnl: float, *, context: str) -> float:
+        """Convert net unrealized PnL to a finite liquidation value."""
+        if not np.isfinite(pnl):
+            raise ValueError(
+                f"Env [{self.id}]: {context} PnL is not finite at "
+                f"tick={self._current_tick}: {pnl!r}"
+            )
+        liquidation_value = 1.0 + float(pnl)
+        if liquidation_value <= 0.0:
+            self._economic_ruin = True
+            return self._MIN_LIQUIDATION_VALUE
+        return liquidation_value
 
-        if not np.isfinite(next_pnl):
-            return 0.0
-        return float(next_pnl)
+    def _assert_local_trade_synchronized(self) -> LocalTrade:
+        """Return the active native trade after checking environment alignment."""
+        if self._position not in (Positions.Long, Positions.Short):
+            raise RuntimeError(
+                f"Env [{self.id}]: LocalTrade requested while position is neutral"
+            )
+        if self._last_trade_tick is None or self._local_trade is None:
+            raise RuntimeError(
+                f"Env [{self.id}]: open position has no synchronized LocalTrade"
+            )
+        if not (0 <= self._last_trade_tick <= self._current_tick < len(self.prices)):
+            raise RuntimeError(
+                f"Env [{self.id}]: LocalTrade entry/current ticks are out of bounds "
+                f"(entry={self._last_trade_tick}, current={self._current_tick})"
+            )
 
-    def _get_next_transition_state(
-        self,
-        action: int,
-        trade_duration: float,
-        current_pnl: float,
-    ) -> tuple[Positions, int, float]:
-        """Compute next transition state tuple (next_position, next_duration, next_pnl).
-
-        Parameters
-        ----------
-        action : int
-            Action taken by the agent.
-        trade_duration : float
-            Trade duration at current tick.
-        current_pnl : float
-            Unrealized PnL at current tick.
-
-        Returns
-        -------
-        tuple[Positions, int, float]
-            (next_position, next_trade_duration, next_pnl) for the transition s -> s'.
-        """
-        next_position = self._get_next_position(action)
-
-        # Entry: Neutral -> Long/Short
-        if self._position == Positions.Neutral and next_position in (
-            Positions.Long,
-            Positions.Short,
-        ):
-            return next_position, 0, self._get_entry_unrealized_profit(next_position)
-
-        # Exit: Long/Short -> Neutral
+        entry_open = self._validated_price(
+            self.prices.iloc[self._last_trade_tick].open,
+            context="entry open",
+        )
+        expected_short = self._position == Positions.Short
         if (
-            self._position in (Positions.Long, Positions.Short)
-            and next_position == Positions.Neutral
+            self._local_trade.pair != self.pair
+            or self._local_trade.trading_mode != TradingMode.SPOT
+            or self._local_trade.leverage != 1.0
+            or self._local_trade.is_short != expected_short
+            or not np.isclose(
+                self._local_trade.open_rate,
+                entry_open,
+                rtol=0.0,
+                atol=1e-12,
+            )
+            or not np.isclose(
+                self._local_trade.fee_open,
+                self.fee,
+                rtol=0.0,
+                atol=1e-15,
+            )
+            or self._local_trade.fee_close is None
+            or not np.isclose(
+                self._local_trade.fee_close,
+                self.fee,
+                rtol=0.0,
+                atol=1e-15,
+            )
         ):
-            return next_position, 0, 0.0
+            raise RuntimeError(
+                f"Env [{self.id}]: LocalTrade is out of sync with position or "
+                f"entry tick={self._last_trade_tick}"
+            )
+        return self._local_trade
 
-        # Hold: Long/Short -> Long/Short
-        if self._position in (Positions.Long, Positions.Short) and next_position in (
-            Positions.Long,
-            Positions.Short,
-        ):
-            return next_position, int(trade_duration), current_pnl
+    def _get_liquidation_pnl(self, mark_price: float) -> float:
+        """Mark the reusable native LocalTrade without registering it."""
+        mark_price = self._validated_price(mark_price, context="liquidation mark")
+        pnl = self._assert_local_trade_synchronized().calc_profit_ratio(mark_price)
 
-        # Neutral self-loop
-        return next_position, 0, 0.0
+        if not np.isfinite(pnl):
+            raise ValueError(
+                f"Env [{self.id}]: liquidation PnL is not finite at "
+                f"tick={self._current_tick}: {pnl!r}"
+            )
+        return float(pnl)
+
+    def get_unrealized_profit(self) -> float:
+        """Mark the observable position state to the current candle close."""
+        if self._position == Positions.Neutral or self._last_trade_tick is None:
+            return 0.0
+        close_price = self._validated_price(
+            self.prices.iloc[self._current_tick].close,
+            context="current close",
+        )
+        return self._get_liquidation_pnl(close_price)
 
     @staticmethod
-    def _loss_duration_multiplier(pnl_ratio: float, risk_reward_ratio: float) -> float:
-        if not np.isfinite(pnl_ratio) or pnl_ratio >= 0.0:
-            return 1.0
-        if not np.isfinite(risk_reward_ratio) or risk_reward_ratio <= 0.0:
-            return 1.0
-        return float(risk_reward_ratio)
-
-    def _compute_pnl_duration_signal(
-        self,
-        *,
-        enabled: bool,
-        require_position: bool,
-        position: Positions,
-        pnl: float,
-        pnl_target: float,
-        duration_ratio: float,
-        scale: float,
-        gain: float,
-        transform_pnl: TransformFunction,
-        transform_duration: TransformFunction,
-        risk_reward_ratio: float | None = None,
-    ) -> float:
-        """Generic bounded bi-component signal combining PnL and duration."""
-        if not enabled:
-            return 0.0
-        if require_position and position not in (Positions.Long, Positions.Short):
-            return 0.0
-
-        duration_ratio = max(0.0, duration_ratio)
-
-        try:
-            pnl_ratio = pnl / pnl_target
-        except Exception:
-            return 0.0
-
-        duration_multiplier = 1.0
-        if risk_reward_ratio is not None:
-            duration_multiplier = MyRLEnv._loss_duration_multiplier(
-                pnl_ratio,
-                risk_reward_ratio,
-            )
-        if not np.isfinite(duration_multiplier) or duration_multiplier < 0.0:
-            duration_multiplier = 1.0
-
-        pnl_term = self._potential_transform(transform_pnl, gain * pnl_ratio)
-        dur_term = self._potential_transform(transform_duration, gain * duration_ratio)
-        pnl_sign = np.sign(pnl_ratio) if not np.isclose(pnl_ratio, 0.0) else 0.0
-        value = scale * 0.5 * (pnl_term + pnl_sign * duration_multiplier * dur_term)
-        return float(value) if np.isfinite(value) else 0.0
-
-    def _compute_hold_potential(
-        self,
-        position: Positions,
-        pnl: float,
-        pnl_target: float,
-        duration_ratio: float,
-        scale: float,
-    ) -> float:
-        """Compute PBRS potential Φ(s) for position holding states.
-
-        See ``_compute_pbrs_components`` for PBRS documentation.
-        """
-        return self._compute_pnl_duration_signal(
-            enabled=self._hold_potential_enabled,
-            require_position=True,
-            position=position,
-            pnl=pnl,
-            pnl_target=pnl_target,
-            duration_ratio=duration_ratio,
-            scale=scale,
-            gain=self._hold_potential_gain,
-            transform_pnl=self._hold_potential_transform_pnl,
-            transform_duration=self._hold_potential_transform_duration,
-            risk_reward_ratio=self.rr,
-        )
-
-    def _compute_exit_additive(
-        self,
-        pnl: float,
-        pnl_target: float,
-        duration_ratio: float,
-        scale: float,
-    ) -> float:
-        """Compute exit additive reward for position exit transitions.
-
-        See ``_compute_pbrs_components`` for PBRS documentation.
-        """
-        return self._compute_pnl_duration_signal(
-            enabled=self._exit_additive_enabled,
-            require_position=False,
-            position=Positions.Neutral,
-            pnl=pnl,
-            pnl_target=pnl_target,
-            duration_ratio=duration_ratio,
-            scale=scale,
-            gain=self._exit_additive_gain,
-            transform_pnl=self._exit_additive_transform_pnl,
-            transform_duration=self._exit_additive_transform_duration,
-        )
-
-    def _compute_entry_additive(
-        self,
-        pnl: float,
-        pnl_target: float,
-        duration_ratio: float,
-        scale: float,
-    ) -> float:
-        """Compute entry additive reward for position entry transitions.
-
-        See ``_compute_pbrs_components`` for PBRS documentation.
-        """
-        return self._compute_pnl_duration_signal(
-            enabled=self._entry_additive_enabled,
-            require_position=False,
-            position=Positions.Neutral,
-            pnl=pnl,
-            pnl_target=pnl_target,
-            duration_ratio=duration_ratio,
-            scale=scale,
-            gain=self._entry_additive_gain,
-            transform_pnl=self._entry_additive_transform_pnl,
-            transform_duration=self._entry_additive_transform_duration,
-        )
-
-    def _potential_transform(self, name: TransformFunction, x: float) -> float:
-        """Apply bounded transform function for potential and additive computations.
-
-        Provides numerical stability by mapping unbounded inputs to bounded outputs
-        using various smooth activation functions. Used in both PBRS potentials
-        and additive reward calculations.
-
-        Parameters
-        ----------
-        name : str
-            Transform function name: one of ReforceXY._TRANSFORM_FUNCTIONS
-        x : float
-            Input value to transform
-
-        Returns
-        -------
-        float
-            Bounded output in [-1, 1]
-        """
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[0]:  # "tanh"
-            return math.tanh(x)
-
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[1]:  # "softsign"
-            ax = abs(x)
-            return x / (1.0 + ax)
-
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[2]:  # "arctan"
-            return (2.0 / math.pi) * math.atan(x)
-
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[3]:  # "sigmoid"
-            try:
-                if x >= 0:
-                    exp_neg_x = math.exp(-x)
-                    sigma_x = 1.0 / (1.0 + exp_neg_x)
-                else:
-                    exp_x = math.exp(x)
-                    sigma_x = exp_x / (exp_x + 1.0)
-                return 2.0 * sigma_x - 1.0
-            except OverflowError:
-                return 1.0 if x > 0 else -1.0
-
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[4]:  # "asinh"
-            return x / math.hypot(1.0, x)
-
-        if name == ReforceXY._TRANSFORM_FUNCTIONS[5]:  # "clip"
-            return min(max(-1.0, x), 1.0)
-
-        logger.warning(
-            "PBRS [%s]: potential_transform=%r invalid; defaulting to %r. Valid: %s",
-            self.id,
-            name,
-            ReforceXY._TRANSFORM_FUNCTIONS[0],
-            ", ".join(ReforceXY._TRANSFORM_FUNCTIONS),
-        )
-        return math.tanh(x)
-
-    def _compute_exit_potential(self, prev_potential: float, gamma: float) -> float:
-        """Compute next potential Φ(s') for exit transitions based on exit potential mode.
-
-        See ``_compute_pbrs_components`` for PBRS documentation.
-        """
-        mode = self._exit_potential_mode
-        # "canonical" or "non_canonical"
-        if mode == ReforceXY._EXIT_POTENTIAL_MODES[0] or mode == ReforceXY._EXIT_POTENTIAL_MODES[1]:
-            return 0.0
-        # "progressive_release"
-        if mode == ReforceXY._EXIT_POTENTIAL_MODES[2]:
-            decay = self._exit_potential_decay
-            if not np.isfinite(decay) or decay < 0.0:
-                decay = 0.0
-            if decay > 1.0:
-                decay = 1.0
-            next_potential = prev_potential * (1.0 - decay)
-        # "spike_cancel"
-        elif mode == ReforceXY._EXIT_POTENTIAL_MODES[3]:
-            if gamma <= 0.0 or not np.isfinite(gamma):
-                next_potential = prev_potential
-            else:
-                next_potential = prev_potential / gamma
-        # "retain_previous"
-        elif mode == ReforceXY._EXIT_POTENTIAL_MODES[4]:
-            next_potential = prev_potential
-        else:
-            next_potential = 0.0
-        if not np.isfinite(next_potential):
-            next_potential = 0.0
-        return next_potential
-
     def is_pbrs_invariant_mode(self) -> bool:
-        """Return True if current configuration preserves PBRS policy invariance.
+        """Return whether the configuration meets necessary canonical PBRS conditions.
 
-        PBRS policy invariance (Ng et al. 1999) requires:
+        This check covers only:
         1. Canonical exit mode: Φ(terminal) = 0
         2. No path-dependent additives: entry_additive = exit_additive = 0
 
-        When True, the shaped policy π'(s) is guaranteed to be equivalent to
-        the policy π(s) learned with base rewards only.
+        A True result is not sufficient proof of policy invariance. Such a proof
+        additionally requires the learner and shaping term to use the same gamma,
+        Φ to depend on a Markov-observable state (or sufficient belief state), and
+        unchanged termination and truncation boundaries.
 
         Returns
         -------
         bool
-            True if configuration preserves theoretical PBRS invariance
+            True if the necessary canonical configuration conditions hold.
         """
         return self._exit_potential_mode == ReforceXY._EXIT_POTENTIAL_MODES[0] and not (
             self._entry_additive_enabled or self._exit_additive_enabled
         )  # "canonical"
 
     @staticmethod
-    def is_unsupported_pbrs_config(hold_potential_enabled: bool, add_state_info: bool) -> bool:
-        """Return True if PBRS potential relies on hidden state.
-
-        Case: hold_potential enabled while auxiliary state info (pnl, trade_duration) is excluded
-        from the observation space (add_state_info=False). In that situation, Φ(s) uses hidden
-        variables and PBRS becomes informative, voiding the strict policy invariance guarantee.
-        """
-        return hold_potential_enabled and not add_state_info
-
-    def _compute_pbrs_components(
-        self,
-        *,
-        action: int,
-        trade_duration: float,
-        max_trade_duration: float,
-        current_pnl: float,
-        pnl_target: float,
-        hold_potential_scale: float,
-        entry_additive_scale: float,
-        exit_additive_scale: float,
-    ) -> tuple[float, float, float]:
-        """Compute potential-based reward shaping (PBRS) components.
-
-        This method computes the PBRS shaping terms.
-
-        Canonical PBRS Formula
-        ----------------------
-        R'(s,a,s') = R(s,a,s') + Δ(s,a,s')
-
-        Non-Canonical PBRS Formula
-        --------------------------
-        R'(s,a,s') = R(s,a,s') + Δ(s,a,s') + entry_additive + exit_additive
-
-        where:
-            Δ(s,a,s') = γ·Φ(s') - Φ(s)  (PBRS shaping term)
-
-        Notation
-        --------
-        **States & Actions:**
-            s     : current state
-            s'    : next state
-            a     : action
-
-        **Reward Components:**
-            R(s,a,s')     : base reward
-            R'(s,a,s')    : shaped reward
-            Δ(s,a,s')     : PBRS shaping term = γ·Φ(s') - Φ(s)
-
-        **Potential Function:**
-            Φ(s)          : potential at state s
-            γ             : discount factor for shaping (gamma)
-
-        **State Variables:**
-            r_pnl         : pnl / pnl_target (PnL ratio)
-            r_dur         : duration / max_duration (duration ratio, max 0)
-            scale         : scale parameter
-            g             : gain parameter
-            T_x           : transform function (tanh, softsign, etc.)
-
-        **Hold Potential Formula:**
-            m_dur = 1.0 if r_pnl >= 0 else loss_duration_multiplier(r_pnl, rr)
-            Φ(s) = scale · 0.5 · [T_pnl(g·r_pnl) + sign(r_pnl)·m_dur·T_dur(g·r_dur)]
-
-        PBRS Theory & Compliance
-        ------------------------
-        - Ng et al. 1999: potential-based shaping preserves optimal policy
-        - Wiewiora et al. 2003: terminal states must have Φ(terminal) = 0
-        - Invariance holds ONLY in canonical mode with additives disabled
-        - Theorem: Canonical + no additives ⇒ Σ_t γ^t·Δ_t = 0 over episodes
-
-        Architecture & Transitions
-        --------------------------
-        **Three mutually exclusive transition types:**
-
-        1. **Entry** (Neutral → Long/Short):
-           - Φ(s) = 0 (neutral state has no potential)
-           - Φ(s') = hold_potential(s')
-           - Δ(s,a,s') = γ·Φ(s') - 0 = γ·Φ(s')
-           - Optional entry additive (breaks invariance)
-
-        2. **Hold** (Long/Short → Long/Short):
-           - Φ(s) = hold_potential(s)
-           - Φ(s') = hold_potential(s')
-           - Δ(s,a,s') = γ·Φ(s') - Φ(s)
-           - Φ(s') reflects updated PnL and duration
-
-        3. **Exit** (Long/Short → Neutral):
-           - Φ(s) = hold_potential(s)
-           - Φ(s') depends on exit_potential_mode:
-             * **canonical**: Φ(s') = 0 → Δ = -Φ(s)
-             * **heuristic**: Φ(s') = f(Φ(s)) → Δ = γ·Φ(s') - Φ(s)
-           - Optional exit additive (breaks invariance)
-
-        Exit Potential Modes
-        --------------------
-        **canonical** (PBRS-compliant):
-            Φ(s') = 0
-            Δ = γ·0 - Φ(s) = -Φ(s)
-            Additives disabled automatically
-
-        **non_canonical**:
-            Φ(s') = 0
-            Δ = -Φ(s)
-            Additives allowed (breaks invariance)
-
-        **progressive_release** (heuristic):
-            Φ(s') = Φ(s)·(1 - d)  where d = decay_factor
-            Δ = γ·Φ(s)·(1-d) - Φ(s)
-
-        **spike_cancel** (heuristic):
-            Φ(s') = Φ(s)/γ
-            Δ = γ·(Φ(s)/γ) - Φ(s) = 0
-
-        **retain_previous** (heuristic):
-            Φ(s') = Φ(s)
-            Δ = γ·Φ(s) - Φ(s) = (γ-1)·Φ(s)
-
-        Additive Terms (Non-PBRS)
-        --------------------------
-        Entry and exit additives are **optional bonuses** that break PBRS invariance:
-        - Entry additive: applied on Neutral→Long/Short transitions
-        - Exit additive: applied on Long/Short→Neutral transitions
-        - These do NOT persist in Φ(s) storage
-
-        Invariance & Validation
-        -----------------------
-        **Theoretical Guarantee:**
-            Canonical + no additives ⇒ Σ_t γ^t·Δ_t = 0
-            (Φ(start) = Φ(end) = 0)
-
-        **Deviations from Theory:**
-            - Heuristic exit modes violate invariance
-            - Entry/exit additives break policy invariance
-            - Non-canonical modes introduce path dependence
-
-        **Robustness:**
-            - All transforms bounded: |T_x| ≤ 1
-            - Validation: |Φ(s)| ≤ scale
-            - Bounds: |Δ(s,a,s')| ≤ (1+γ)·scale
-            - Terminal enforcement: Φ(s) = 0 when terminated
-
-        Implementation Details
-        ----------------------
-        This method wraps the core PBRS logic for use in the RL environment:
-        - Reads Φ(s) from self._last_potential (previous state potential)
-        - Reads γ from self._potential_gamma
-        - Reads configuration from self._exit_potential_mode, self._entry_additive_enabled, etc.
-        - Computes next_position, next_duration_ratio, is_entry, is_exit internally
-        - Stores Φ(s') to self._last_potential for next step
-        - Updates diagnostic accumulators (_total_reward_shaping, _total_entry_additive, etc.)
-
-        Parameters
-        ----------
-        action : int
-            Action taken: determines transition type (entry/hold/exit)
-        trade_duration : float
-            Trade duration at current tick.
-            This is the duration for state s'.
-        max_trade_duration : float
-            Maximum allowed trade duration (for normalization)
-        current_pnl : float
-            Unrealized PnL at current tick.
-            This is the PnL for state s'.
-        pnl_target : float
-            Target PnL for ratio normalization: r_pnl = pnl / pnl_target
-        hold_potential_scale : float
-            Magnitude scale for hold potential (= hold_potential_ratio * base_factor)
-        entry_additive_scale : float
-            Magnitude scale for entry additive (= entry_additive_ratio * base_factor)
-        exit_additive_scale : float
-            Magnitude scale for exit additive (= exit_additive_ratio * base_factor)
-
-        Returns
-        -------
-        tuple[float, float, float]
-            (reward_shaping, entry_additive, exit_additive)
-
-            - reward_shaping: Δ(s,a,s') = γ·Φ(s') - Φ(s), the PBRS shaping term
-            - entry_additive: optional non-PBRS entry bonus (0.0 if disabled or not entry)
-            - exit_additive: optional non-PBRS exit bonus (0.0 if disabled or not exit)
-
-        Notes
-        -----
-        **State Management:**
-        - Current Φ(s): read from self._last_potential
-        - Next Φ(s'): computed and stored to self._last_potential
-        - Transition type: inferred from self._position and action
-
-        **Configuration Sources:**
-        - γ: self._potential_gamma
-        - Exit mode: self._exit_potential_mode
-        - Additives: self._entry_additive_enabled, self._exit_additive_enabled
-        - Transforms: self._hold_potential_transform_pnl, etc.
-
-        **Recommendations:**
-        - Use canonical mode for policy-invariant shaping
-        - Monitor Σ_t γ^t·Δ_t ≈ 0 per episode in canonical mode
-        - Disable additives to preserve theoretical PBRS guarantees
-        """
-        prev_potential = float(self._last_potential)
-
-        if not self._hold_potential_enabled and not (
-            self._entry_additive_enabled or self._exit_additive_enabled
-        ):
-            logger.debug("PBRS [%s]: all PBRS features disabled, returning zeros", self.id)
-            self._last_prev_potential = float(prev_potential)
-            self._last_next_potential = float(prev_potential)
-            self._last_entry_additive = 0.0
-            self._last_exit_additive = 0.0
-            self._last_reward_shaping = 0.0
-            return 0.0, 0.0, 0.0
-
-        next_position, next_trade_duration, next_pnl = self._get_next_transition_state(
-            action=action, trade_duration=trade_duration, current_pnl=current_pnl
-        )
-        if max_trade_duration <= 0:
-            next_duration_ratio = 0.0
-        else:
-            next_duration_ratio = next_trade_duration / max_trade_duration
-
-        is_entry = self._position == Positions.Neutral and next_position in (
-            Positions.Long,
-            Positions.Short,
-        )
-        is_exit = (
-            self._position in (Positions.Long, Positions.Short)
-            and next_position == Positions.Neutral
-        )
-        is_hold = self._position in (
-            Positions.Long,
-            Positions.Short,
-        ) and next_position in (Positions.Long, Positions.Short)
-
-        gamma = self._potential_gamma
-
-        reward_shaping = 0.0
-        entry_additive = 0.0
-        exit_additive = 0.0
-        next_potential = prev_potential
-
-        if is_entry or is_hold:
-            if self._hold_potential_enabled:
-                next_potential = self._compute_hold_potential(
-                    next_position,
-                    next_pnl,
-                    pnl_target,
-                    next_duration_ratio,
-                    hold_potential_scale,
-                )
-                reward_shaping = gamma * next_potential - prev_potential
-            else:
-                next_potential = 0.0
-                reward_shaping = 0.0
-
-            if is_entry and self._entry_additive_enabled and not self.is_pbrs_invariant_mode():
-                entry_additive = self._compute_entry_additive(
-                    next_pnl,
-                    pnl_target,
-                    next_duration_ratio,
-                    entry_additive_scale,
-                )
-                self._total_entry_additive += float(entry_additive)
-
-        elif is_exit:
-            if (
-                self._exit_potential_mode == ReforceXY._EXIT_POTENTIAL_MODES[0]  # "canonical"
-            ) or (
-                self._exit_potential_mode == ReforceXY._EXIT_POTENTIAL_MODES[1]  # "non_canonical"
-            ):
-                next_potential = 0.0
-                reward_shaping = -prev_potential
-            else:
-                next_potential = self._compute_exit_potential(prev_potential, gamma)
-                reward_shaping = gamma * next_potential - prev_potential
-
-            if self._exit_additive_enabled and not self.is_pbrs_invariant_mode():
-                duration_ratio = trade_duration / max(1, max_trade_duration)
-                exit_additive = self._compute_exit_additive(
-                    current_pnl, pnl_target, duration_ratio, exit_additive_scale
-                )
-                self._total_exit_additive += float(exit_additive)
-
-        else:
-            # Neutral self-loop
-            next_potential = prev_potential
-            reward_shaping = 0.0
-
-        self._last_potential = float(next_potential)
-        self._last_prev_potential = float(prev_potential)
-        self._last_next_potential = float(self._last_potential)
-        self._last_entry_additive = float(entry_additive)
-        self._last_exit_additive = float(exit_additive)
-        self._last_reward_shaping = float(reward_shaping)
-        self._total_reward_shaping += float(reward_shaping)
-
-        return float(reward_shaping), float(entry_additive), float(exit_additive)
-
     def _set_observation_space(self) -> None:
         """
         Set the observation space
@@ -3061,7 +2629,9 @@ class MyRLEnv(Base5ActionRLEnv):
             self.total_features = signal_features
 
         self.shape = (self.window_size, self.total_features)
-        self.observation_space = Box(low=-np.inf, high=np.inf, shape=self.shape, dtype=np.float32)
+        self.observation_space = Box(
+            low=-np.inf, high=np.inf, shape=self.shape, dtype=np.float32
+        )
 
     def _is_valid(self, action: int) -> bool:
         return ReforceXY.get_action_masks(self.can_short, self._position)[action]
@@ -3071,24 +2641,38 @@ class MyRLEnv(Base5ActionRLEnv):
         df: DataFrame,
         prices: DataFrame,
         window_size: int,
-        reward_kwargs: dict[str, Any],
+        reward_kwargs: Dict[str, Any],
         starting_point=True,
     ) -> None:
         """
         Resets the environment when the agent fails
         """
+        self._local_trade: Optional[LocalTrade] = None
         super().reset_env(df, prices, window_size, reward_kwargs, starting_point)
         self._set_observation_space()
 
-    def reset(self, seed=None, **kwargs) -> tuple[NDArray[np.float32], dict[str, Any]]:
+    def reset(self, seed=None, **kwargs) -> Tuple[NDArray[np.float32], Dict[str, Any]]:
+        """Reset one tick before the first executable open.
+
+        A feature window ending at ``start_tick - 1`` produces the signal that
+        executes at ``prices.iloc[start_tick].open`` on the first call to
+        :meth:`step`.  This mirrors the prediction/strategy candle alignment.
         """
-        Reset is called at the beginning of every episode
-        """
-        observation, history = super().reset(seed, **kwargs)
-        self._last_closed_position: Positions | None = None
+        _, history = super().reset(seed, **kwargs)
+        self._current_tick = self._start_tick - 1
+        self._position_history = (self._current_tick * [None]) + [self._position]
+        self._last_closed_position: Optional[Positions] = None
+        self._local_trade = None
         self._last_closed_trade_tick: int = 0
         self._max_unrealized_profit = -np.inf
         self._min_unrealized_profit = np.inf
+        self._previous_liquidation_value = 1.0
+        self._reward_liquidation_value = 1.0
+        self._next_liquidation_value = 1.0
+        self._last_economic_reward = 0.0
+        self._reward_scale = ReforceXY.DEFAULT_BASE_FACTOR
+        self._expected_next_position = self._position
+        self._economic_ruin = False
         self._last_potential = 0.0
         self._last_prev_potential = 0.0
         self._last_next_potential = 0.0
@@ -3102,413 +2686,112 @@ class MyRLEnv(Base5ActionRLEnv):
         self._last_idle_penalty = 0.0
         self._last_hold_penalty = 0.0
         self._last_exit_reward = 0.0
-        return observation, history
+        return self._get_observation(), history
 
-    def _compute_time_attenuation_coefficient(
+    def calculate_reward(
         self,
-        duration_ratio: float,
-        model_reward_parameters: Mapping[str, Any],
+        action: int,
+        *,
+        previous_position: Positions,
+        transition_pnl: float,
+        action_valid: bool,
     ) -> float:
-        """
-        Calculate time-based attenuation coefficient using configurable strategy
-        (legacy/sqrt/linear/power/half_life). Optionally apply plateau grace period.
-        """
-        if duration_ratio < 0.0:
-            duration_ratio = 0.0
+        """Compute the causal pair-local net liquidation log-return.
 
-        exit_attenuation_mode = str(
-            model_reward_parameters.get(
-                "exit_attenuation_mode", ReforceXY._EXIT_ATTENUATION_MODES[2]
-            )  # "linear"
-        )
-        exit_plateau = bool(
-            model_reward_parameters.get("exit_plateau", ReforceXY.DEFAULT_EXIT_PLATEAU)
-        )
-        exit_plateau_grace = float(
-            model_reward_parameters.get("exit_plateau_grace", ReforceXY.DEFAULT_EXIT_PLATEAU_GRACE)
-        )
-        if exit_plateau_grace < 0.0:
-            logger.warning(
-                "PBRS [%s]: exit_plateau_grace=%.2f invalid; defaulting to 0.0",
-                self.id,
-                exit_plateau_grace,
-            )
-            exit_plateau_grace = 0.0
-
-        def _legacy(dr: float, p: Mapping[str, Any]) -> float:
-            return 1.5 if dr <= 1.0 else 0.5
-
-        def _sqrt(dr: float, p: Mapping[str, Any]) -> float:
-            return 1.0 / math.sqrt(1.0 + dr)
-
-        def _linear(dr: float, p: Mapping[str, Any]) -> float:
-            slope = float(p.get("exit_linear_slope", ReforceXY.DEFAULT_EXIT_LINEAR_SLOPE))
-            if slope < 0.0:
-                logger.warning(
-                    "PBRS [%s]: exit_linear_slope=%.2f invalid; defaulting to 1.0",
-                    self.id,
-                    slope,
-                )
-                slope = 1.0
-            return 1.0 / (1.0 + slope * dr)
-
-        def _power(dr: float, p: Mapping[str, Any]) -> float:
-            tau = p.get("exit_power_tau")
-            if isinstance(tau, (int, float)):
-                tau = float(tau)
-                alpha = -math.log(tau) / ReforceXY._LOG_2 if 0.0 < tau <= 1.0 else 1.0
-            else:
-                alpha = 1.0
-            return 1.0 / math.pow(1.0 + dr, alpha)
-
-        def _half_life(dr: float, p: Mapping[str, Any]) -> float:
-            hl = float(p.get("exit_half_life", ReforceXY.DEFAULT_EXIT_HALF_LIFE))
-            if np.isclose(hl, 0.0) or hl < 0.0:
-                return 1.0
-            return math.pow(2.0, -dr / hl)
-
-        strategies: dict[str, Callable[[float, Mapping[str, Any]], float]] = {
-            ReforceXY._EXIT_ATTENUATION_MODES[0]: _legacy,
-            ReforceXY._EXIT_ATTENUATION_MODES[1]: _sqrt,
-            ReforceXY._EXIT_ATTENUATION_MODES[2]: _linear,
-            ReforceXY._EXIT_ATTENUATION_MODES[3]: _power,
-            ReforceXY._EXIT_ATTENUATION_MODES[4]: _half_life,
-        }
-
-        if exit_plateau:
-            if duration_ratio <= exit_plateau_grace:
-                effective_dr = 0.0
-            else:
-                effective_dr = duration_ratio - exit_plateau_grace
-        else:
-            effective_dr = duration_ratio
-
-        strategy_fn = strategies.get(exit_attenuation_mode)
-        if strategy_fn is None:
-            logger.warning(
-                "PBRS [%s]: exit_attenuation_mode=%r invalid; defaulting to %r. Valid: %s",
-                self.id,
-                exit_attenuation_mode,
-                ReforceXY._EXIT_ATTENUATION_MODES[2],  # "linear"
-                ", ".join(ReforceXY._EXIT_ATTENUATION_MODES),
-            )
-            strategy_fn = _linear
-
-        try:
-            time_attenuation_coefficient = strategy_fn(effective_dr, model_reward_parameters)
-        except Exception as e:
-            logger.warning(
-                "PBRS [%s]: exit_attenuation_mode=%r failed (%r); defaulting to %r (effective_dr=%.5f)",
-                self.id,
-                exit_attenuation_mode,
-                e,
-                ReforceXY._EXIT_ATTENUATION_MODES[2],  # "linear"
-                effective_dr,
-                exc_info=True,
-            )
-            time_attenuation_coefficient = _linear(effective_dr, model_reward_parameters)
-
-        return time_attenuation_coefficient
-
-    def _get_exit_factor(
-        self,
-        base_factor: float,
-        pnl: float,
-        duration_ratio: float,
-        model_reward_parameters: Mapping[str, Any],
-    ) -> float:
-        """
-        Compute exit factor: base_factor · time_attenuation_coefficient · pnl_target_coefficient · efficiency_coefficient.
-        """
-        if not (np.isfinite(base_factor) and np.isfinite(pnl) and np.isfinite(duration_ratio)):
-            return 0.0
-
-        time_attenuation_coefficient = self._compute_time_attenuation_coefficient(
-            duration_ratio,
-            model_reward_parameters,
-        )
-        pnl_target_coefficient = self._compute_pnl_target_coefficient(
-            pnl, self._pnl_target, model_reward_parameters
-        )
-        efficiency_coefficient = self._compute_efficiency_coefficient(pnl, model_reward_parameters)
-
-        exit_factor = (
-            base_factor
-            * time_attenuation_coefficient
-            * pnl_target_coefficient
-            * efficiency_coefficient
-        )
-
-        check_invariants = model_reward_parameters.get(
-            "check_invariants", ReforceXY.DEFAULT_CHECK_INVARIANTS
-        )
-        check_invariants = check_invariants if isinstance(check_invariants, bool) else True
-        if check_invariants:
-            if not np.isfinite(exit_factor):
-                logger.warning(
-                    "PBRS [%s]: exit_factor=%.5f non-finite; defaulting to 0.0",
-                    self.id,
-                    exit_factor,
-                )
-                return 0.0
-            if efficiency_coefficient < 0.0:
-                logger.warning(
-                    "PBRS [%s]: efficiency_coefficient=%.5f negative",
-                    self.id,
-                    efficiency_coefficient,
-                )
-            if exit_factor < 0.0 and pnl >= 0.0:
-                logger.warning(
-                    "PBRS [%s]: exit_factor=%.5f negative with pnl=%.5f positive; defaulting to 0.0",
-                    self.id,
-                    exit_factor,
-                    pnl,
-                )
-                exit_factor = 0.0
-            exit_factor_threshold = float(
-                model_reward_parameters.get(
-                    "exit_factor_threshold", ReforceXY.DEFAULT_EXIT_FACTOR_THRESHOLD
-                )
-            )
-            if exit_factor_threshold > 0 and abs(exit_factor) > exit_factor_threshold:
-                logger.warning(
-                    "PBRS [%s]: |exit_factor|=%.5f exceeds exit_factor_threshold=%.5f",
-                    self.id,
-                    abs(exit_factor),
-                    exit_factor_threshold,
-                )
-
-        return exit_factor
-
-    def _compute_pnl_target_coefficient(
-        self, pnl: float, pnl_target: float, model_reward_parameters: Mapping[str, Any]
-    ) -> float:
-        """
-        Compute PnL target coefficient (typically 0.5-2.0) using tanh on PnL/target ratio.
-        """
-        pnl_target_coefficient = 1.0
-
-        if pnl_target > 0.0:
-            pnl_amplification_sensitivity = float(
-                model_reward_parameters.get(
-                    "pnl_amplification_sensitivity",
-                    ReforceXY.DEFAULT_PNL_AMPLIFICATION_SENSITIVITY,
-                )
-            )
-            pnl_ratio = pnl / pnl_target
-
-            if abs(pnl_ratio) > 1.0:
-                base_pnl_target_coefficient = math.tanh(
-                    pnl_amplification_sensitivity * (abs(pnl_ratio) - 1.0)
-                )
-                win_reward_factor = float(
-                    model_reward_parameters.get(
-                        "win_reward_factor", ReforceXY.DEFAULT_WIN_REWARD_FACTOR
-                    )
-                )
-
-                if pnl_ratio > 1.0:
-                    pnl_target_coefficient = 1.0 + win_reward_factor * base_pnl_target_coefficient
-                elif pnl_ratio < -(1.0 / self.rr):
-                    loss_penalty_factor = win_reward_factor * self.rr
-                    pnl_target_coefficient = 1.0 + loss_penalty_factor * base_pnl_target_coefficient
-
-        return pnl_target_coefficient
-
-    def _compute_efficiency_coefficient(
-        self, pnl: float, model_reward_parameters: Mapping[str, Any]
-    ) -> float:
-        """
-        Compute exit efficiency coefficient (typically 0.5-1.5) based on exit timing quality.
-        """
-        efficiency_weight = float(
-            model_reward_parameters.get("efficiency_weight", ReforceXY.DEFAULT_EFFICIENCY_WEIGHT)
-        )
-        efficiency_center = float(
-            model_reward_parameters.get("efficiency_center", ReforceXY.DEFAULT_EFFICIENCY_CENTER)
-        )
-
-        efficiency_coefficient = 1.0
-        if efficiency_weight != 0.0 and not np.isclose(pnl, 0.0):
-            max_pnl = max(self.get_max_unrealized_profit(), pnl)
-            min_pnl = min(self.get_min_unrealized_profit(), pnl)
-            range_pnl = max_pnl - min_pnl
-            # Guard against division explosion when max_pnl ≈ min_pnl
-            min_meaningful_range = max(
-                ReforceXY.DEFAULT_EFFICIENCY_MIN_RANGE_EPSILON,
-                ReforceXY.DEFAULT_EFFICIENCY_MIN_RANGE_FRACTION * self._pnl_target,
-            )
-            if np.isfinite(range_pnl) and range_pnl >= min_meaningful_range:
-                efficiency_ratio = (pnl - min_pnl) / range_pnl
-                if pnl > 0.0:
-                    efficiency_coefficient = 1.0 + efficiency_weight * (
-                        efficiency_ratio - efficiency_center
-                    )
-                elif pnl < 0.0:
-                    efficiency_coefficient = 1.0 + efficiency_weight * (
-                        efficiency_center - efficiency_ratio
-                    )
-
-        return efficiency_coefficient
-
-    def calculate_reward(self, action: int) -> float:
-        """Compute per-step reward and apply potential-based reward shaping (PBRS).
-
-        Reward Pipeline:
-            1. Invalid action penalty
-            2. Idle penalty
-            3. Hold overtime penalty
-            4. Exit reward
-            5. Default fallback (0.0 if no specific reward)
-            6. PBRS computation and application: R'(s,a,s') = R(s,a,s') + Δ(s,a,s') + entry_additive + exit_additive
-
-        The final shaped reward is what the RL agent receives for learning.
-        In canonical PBRS mode, the learned policy is theoretically equivalent
-        to training on base rewards only (policy invariance).
-
-        Parameters
-        ----------
-        action : int
-            Action index taken by the agent
-
-        Returns
-        -------
-        float
-            Shaped reward R'(s,a,s') = R(s,a,s') + Δ(s,a,s') + entry_additive + exit_additive
-
-            Implementation: base_reward + reward_shaping + entry_additive + exit_additive
-
-            where:
-            - R(s,a,s') / base_reward: Base reward (invalid/idle/hold penalty or exit reward)
-            - Δ(s,a,s') / reward_shaping: PBRS delta term = γ·Φ(s') - Φ(s)
-            - entry_additive: Optional entry bonus (breaks PBRS invariance)
-            - exit_additive: Optional exit bonus (breaks PBRS invariance)
+        ``previous_liquidation_value`` is the liquidation value visible in the
+        observation that selected ``action``. ``transition_pnl`` is marked at the
+        current close when a position remains open, or at the current open when
+        the action exits. No separate wallet or order accounting is introduced.
         """
         model_reward_parameters = self.rl_config.get("model_reward_parameters", {})
-        base_reward: float | None = None
 
         self._last_invalid_penalty = 0.0
         self._last_idle_penalty = 0.0
         self._last_hold_penalty = 0.0
         self._last_exit_reward = 0.0
+        self._last_potential = 0.0
+        self._last_prev_potential = 0.0
+        self._last_next_potential = 0.0
+        self._last_reward_shaping = 0.0
+        self._last_entry_additive = 0.0
+        self._last_exit_additive = 0.0
 
-        # 1. Invalid action
-        if not self.action_masking and not self._is_valid(action):
+        invalid_penalty = 0.0
+        if not self.action_masking and not action_valid:
             self.tensorboard_log("invalid", category="actions")
-            base_reward = float(
-                model_reward_parameters.get("invalid_action", ReforceXY.DEFAULT_INVALID_ACTION)
+            invalid_penalty = float(
+                model_reward_parameters.get(
+                    "invalid_action", ReforceXY.DEFAULT_INVALID_ACTION
+                )
             )
-            self._last_invalid_penalty = float(base_reward)
+            if not np.isfinite(invalid_penalty):
+                raise ValueError(
+                    f"Env [{self.id}]: invalid_action reward must be finite"
+                )
+            self._last_invalid_penalty = invalid_penalty
 
-        max_trade_duration = max(1, self.max_trade_duration_candles)
-        trade_duration = self.get_trade_duration()
-        duration_ratio = trade_duration / max_trade_duration
         base_factor = float(
             model_reward_parameters.get("base_factor", ReforceXY.DEFAULT_BASE_FACTOR)
         )
-        idle_factor = base_factor * (self.profit_aim / self.rr)
-        hold_factor = idle_factor
+        if not np.isfinite(base_factor) or base_factor <= 0.0:
+            raise ValueError(
+                f"Env [{self.id}]: base_factor must be finite and positive"
+            )
+        self._reward_scale = base_factor
 
-        # 2. Idle penalty
+        position_was_open = previous_position in (Positions.Long, Positions.Short)
+        position_is_open = self._position in (Positions.Long, Positions.Short)
+        if position_was_open or position_is_open:
+            reward_liquidation_value = self._liquidation_value_from_pnl(
+                transition_pnl, context="transition liquidation"
+            )
+            next_liquidation_value = (
+                reward_liquidation_value if position_is_open else 1.0
+            )
+        else:
+            reward_liquidation_value = 1.0
+            next_liquidation_value = 1.0
+
+        previous_liquidation_value = self._previous_liquidation_value
         if (
-            base_reward is None
-            and action == Actions.Neutral.value
-            and self._position == Positions.Neutral
+            not np.isfinite(previous_liquidation_value)
+            or previous_liquidation_value <= 0.0
         ):
-            max_idle_duration = max(1, self.max_idle_duration_candles)
-            idle_penalty_ratio = float(
-                model_reward_parameters.get(
-                    "idle_penalty_ratio", ReforceXY.DEFAULT_IDLE_PENALTY_RATIO
-                )
+            raise RuntimeError(
+                f"Env [{self.id}]: previous liquidation value is invalid at "
+                f"tick={self._current_tick}: {previous_liquidation_value!r}"
             )
-            idle_penalty_power = float(
-                model_reward_parameters.get(
-                    "idle_penalty_power", ReforceXY.DEFAULT_IDLE_PENALTY_POWER
-                )
-            )
-            idle_duration = self.get_idle_duration()
-            idle_duration_ratio = idle_duration / max(1, max_idle_duration)
-            base_reward = (
-                -idle_factor * idle_penalty_ratio * idle_duration_ratio**idle_penalty_power
-            )
-            self._last_idle_penalty = float(base_reward)
 
-        # 3. Hold overtime penalty
-        if (
-            base_reward is None
-            and self._position in (Positions.Short, Positions.Long)
-            and action == Actions.Neutral.value
-        ):
-            hold_penalty_ratio = float(
-                model_reward_parameters.get(
-                    "hold_penalty_ratio", ReforceXY.DEFAULT_HOLD_PENALTY_RATIO
-                )
-            )
-            hold_penalty_power = float(
-                model_reward_parameters.get(
-                    "hold_penalty_power", ReforceXY.DEFAULT_HOLD_PENALTY_POWER
-                )
-            )
-            if duration_ratio < 1.0:
-                base_reward = 0.0
-            else:
-                base_reward = (
-                    -hold_factor * hold_penalty_ratio * (duration_ratio - 1.0) ** hold_penalty_power
-                )
-                self._last_hold_penalty = float(base_reward)
-
-        # 4. Exit rewards
-        pnl: float = self.get_unrealized_profit()
-        if (
-            base_reward is None
-            and action == Actions.Long_exit.value
-            and self._position == Positions.Long
-        ):
-            base_reward = pnl * self._get_exit_factor(
-                base_factor, pnl, duration_ratio, model_reward_parameters
-            )
-            self._last_exit_reward = float(base_reward)
-        if (
-            base_reward is None
-            and action == Actions.Short_exit.value
-            and self._position == Positions.Short
-        ):
-            base_reward = pnl * self._get_exit_factor(
-                base_factor, pnl, duration_ratio, model_reward_parameters
-            )
-            self._last_exit_reward = float(base_reward)
-
-        # 5. Default
-        if base_reward is None:
-            base_reward = 0.0
-
-        # 6. Potential-based reward shaping
-        hold_potential_scale = self._hold_potential_ratio * base_factor
-        entry_additive_scale = self._entry_additive_ratio * base_factor
-        exit_additive_scale = self._exit_additive_ratio * base_factor
-
-        reward_shaping, entry_additive, exit_additive = self._compute_pbrs_components(
-            action=action,
-            trade_duration=trade_duration,
-            max_trade_duration=max_trade_duration,
-            current_pnl=pnl,
-            pnl_target=self._pnl_target,
-            hold_potential_scale=hold_potential_scale,
-            entry_additive_scale=entry_additive_scale,
-            exit_additive_scale=exit_additive_scale,
+        economic_reward = base_factor * (
+            math.log(reward_liquidation_value) - math.log(previous_liquidation_value)
         )
+        if not np.isfinite(economic_reward):
+            raise RuntimeError(
+                f"Env [{self.id}]: economic reward is not finite at "
+                f"tick={self._current_tick}: {economic_reward!r}"
+            )
 
-        return base_reward + reward_shaping + entry_additive + exit_additive
+        self._reward_liquidation_value = reward_liquidation_value
+        self._next_liquidation_value = next_liquidation_value
+        self._last_economic_reward = float(economic_reward)
+        if position_was_open and not position_is_open:
+            self._last_exit_reward = float(economic_reward)
+
+        return float(economic_reward + invalid_penalty)
 
     def _get_observation(self) -> NDArray[np.float32]:
-        start_idx = max(self._start_tick, self._current_tick - self.window_size)
-        end_idx = min(self._current_tick, len(self.signal_features))
+        end_idx = min(self._current_tick + 1, len(self.signal_features))
+        start_idx = max(0, end_idx - self.window_size)
         features_window = self.signal_features.iloc[start_idx:end_idx]
         features_window_array = features_window.to_numpy(dtype=np.float32, copy=False)
         if features_window_array.shape[0] < self.window_size:
             pad_size = self.window_size - features_window_array.shape[0]
-            pad_array = np.zeros((pad_size, features_window_array.shape[1]), dtype=np.float32)
-            features_window_array = np.concatenate([pad_array, features_window_array], axis=0)
+            pad_array = np.zeros(
+                (pad_size, features_window_array.shape[1]), dtype=np.float32
+            )
+            features_window_array = np.concatenate(
+                [pad_array, features_window_array], axis=0
+            )
         if self.add_state_info:
             observations = np.concatenate(
                 [
@@ -3541,19 +2824,45 @@ class MyRLEnv(Base5ActionRLEnv):
     def _enter_trade(self, action: int) -> None:
         self._position = self._get_position(action)
         self._last_trade_tick = self._current_tick
+        entry_open = self._validated_price(
+            self.prices.iloc[self._last_trade_tick].open,
+            context="entry open",
+        )
+        self._local_trade = LocalTrade(
+            pair=self.pair,
+            open_rate=entry_open,
+            amount=1.0,
+            stake_amount=entry_open,
+            fee_open=float(self.fee),
+            fee_close=float(self.fee),
+            is_short=self._position == Positions.Short,
+            leverage=1.0,
+            trading_mode=TradingMode.SPOT,
+            open_date=datetime.fromtimestamp(0, timezone.utc),
+            is_open=True,
+        )
+        self._assert_local_trade_synchronized()
         self._max_unrealized_profit = -np.inf
         self._min_unrealized_profit = np.inf
 
-    def _exit_trade(self) -> None:
-        self._update_total_profit()
+    def _exit_trade(self, exit_pnl: float) -> None:
+        self._assert_local_trade_synchronized()
+        exit_liquidation_value = self._liquidation_value_from_pnl(
+            exit_pnl,
+            context="exit liquidation",
+        )
+        # stake_amount='unlimited' is enforced in __init__, so BaseEnvironment always
+        # sets compound_trades=True; the non-compound branch is unreachable.
+        self._total_profit *= exit_liquidation_value
         self._last_closed_position = self._position
         self._position = Positions.Neutral
         self._last_trade_tick = None
+        self._local_trade = None
         self._last_closed_trade_tick = self._current_tick
         self._max_unrealized_profit = -np.inf
         self._min_unrealized_profit = np.inf
 
-    def execute_trade(self, action: int) -> str | None:
+    def execute_trade(self, action: int, *, exit_pnl: float = 0.0) -> Optional[str]:
         """
         Execute trade based on the given action
         """
@@ -3567,53 +2876,86 @@ class MyRLEnv(Base5ActionRLEnv):
 
         # Exit trade based on action
         if action in (Actions.Long_exit.value, Actions.Short_exit.value):
-            self._exit_trade()
+            self._exit_trade(exit_pnl)
             return f"{self._last_closed_position.name}_exit"
 
         return None
 
-    def _apply_terminal_pbrs_correction(self, reward: float) -> float:
-        if not (
-            self._hold_potential_enabled
-            or self._entry_additive_enabled
-            or self._exit_additive_enabled
+    def step(
+        self, action: int
+    ) -> Tuple[NDArray[np.float32], float, bool, bool, Dict[str, Any]]:
+        """Fill at the next open, mark at its close, then expose the next state."""
+        previous_position = self._position
+        pre_pnl = float(self.get_unrealized_profit())
+        previous_liquidation_value = self._previous_liquidation_value
+        observable_liquidation_value = (
+            1.0 + pre_pnl
+            if previous_position in (Positions.Long, Positions.Short)
+            else 1.0
+        )
+        if (
+            not np.isfinite(observable_liquidation_value)
+            or observable_liquidation_value <= 0.0
+            or not np.isclose(
+                previous_liquidation_value,
+                observable_liquidation_value,
+                rtol=1e-10,
+                atol=1e-12,
+            )
         ):
-            self._last_potential = 0.0
-            self._last_next_potential = 0.0
-            self._last_reward_shaping = 0.0
-            return reward
+            raise RuntimeError(
+                f"Env [{self.id}]: reward carry does not match the observable "
+                f"liquidation value at tick={self._current_tick}: "
+                f"carry={previous_liquidation_value!r}, "
+                f"observable={observable_liquidation_value!r}"
+            )
 
-        prev_potential = self._last_prev_potential
-        computed_reward_shaping = self._last_reward_shaping
-        terminal_reward_shaping = -prev_potential
-        reward_shaping_delta = terminal_reward_shaping - computed_reward_shaping
-        last_next_potential = self._last_next_potential
-
-        if np.isclose(computed_reward_shaping, terminal_reward_shaping) and np.isclose(
-            last_next_potential, 0.0
-        ):
-            self._last_potential = 0.0
-            self._last_next_potential = 0.0
-            return reward
-
-        self._last_potential = 0.0
-        self._last_next_potential = 0.0
-        self._last_reward_shaping = terminal_reward_shaping
-        self._total_reward_shaping += reward_shaping_delta
-        return reward + reward_shaping_delta
-
-    def step(self, action: int) -> tuple[NDArray[np.float32], float, bool, bool, dict[str, Any]]:
-        """
-        Take a step in the environment based on the provided action
-        """
+        action_valid = self._is_valid(action)
+        self._expected_next_position = self._get_next_position(action)
         self._current_tick += 1
-        self._update_unrealized_total_profit()
-        pre_pnl = self.get_unrealized_profit()
+        fill_open = self._validated_price(self.current_price(), context="fill open")
+        mark_close = self._validated_price(
+            self.prices.iloc[self._current_tick].close,
+            context="mark close",
+        )
+
+        exit_pnl = 0.0
+        if (
+            previous_position in (Positions.Long, Positions.Short)
+            and self._expected_next_position == Positions.Neutral
+        ):
+            exit_pnl = self._get_liquidation_pnl(fill_open)
+
+        trade_type = self.execute_trade(action, exit_pnl=exit_pnl)
+        if self._position != self._expected_next_position:
+            raise RuntimeError(
+                f"Env [{self.id}]: action transition mismatch at "
+                f"tick={self._current_tick}: expected={self._expected_next_position.name}, "
+                f"actual={self._position.name}"
+            )
+
+        transition_pnl = (
+            self._get_liquidation_pnl(mark_close)
+            if self._position in (Positions.Long, Positions.Short)
+            else exit_pnl
+        )
+        reward = self.calculate_reward(
+            action,
+            previous_position=previous_position,
+            transition_pnl=transition_pnl,
+            action_valid=action_valid,
+        )
+
+        self._total_unrealized_profit = (
+            self._total_profit * self._reward_liquidation_value
+            if self._position in (Positions.Long, Positions.Short)
+            else self._total_profit
+        )
+        self._previous_liquidation_value = self._next_liquidation_value
         self._update_portfolio_log_returns()
-        reward = self.calculate_reward(action)
-        trade_type = self.execute_trade(action)
         if trade_type is not None:
-            self.append_trade_history(trade_type, self.current_price(), pre_pnl)
+            trade_pnl = exit_pnl if self._position == Positions.Neutral else 0.0
+            self.append_trade_history(trade_type, fill_open, trade_pnl)
         elif action != Actions.Neutral.value:
             logger.warning(
                 "Env [%s]: invalid action=%s (%d) in position=%s at tick=%d",
@@ -3625,9 +2967,7 @@ class MyRLEnv(Base5ActionRLEnv):
             )
         self._position_history.append(self._position)
         terminated = self.is_terminated()
-        if terminated:
-            reward = self._apply_terminal_pbrs_correction(reward)
-            self._last_potential = 0.0
+        truncated = self.is_truncated()
         self.total_reward += reward
         pnl = self.get_unrealized_profit()
         self._update_max_unrealized_profit(pnl)
@@ -3636,18 +2976,32 @@ class MyRLEnv(Base5ActionRLEnv):
         max_idle_duration = max(1, self.max_idle_duration_candles)
         idle_duration = self.get_idle_duration()
         trade_duration = self.get_trade_duration()
+        drawdown_breached = bool(
+            self._total_profit < self.max_drawdown
+            or self._total_unrealized_profit < self.max_drawdown
+        )
         info = {
             "tick": self._current_tick,
             "position": float(self._position.value),
             "action": action,
             "pre_pnl": round(pre_pnl, 5),
             "pnl": round(pnl, 5),
+            "transition_pnl": round(transition_pnl, 5),
             "delta_pnl": round(delta_pnl, 5),
             "max_pnl": round(self.get_max_unrealized_profit(), 5),
             "min_pnl": round(self.get_min_unrealized_profit(), 5),
-            "most_recent_return": round(self.get_most_recent_return(), 5),
+            "most_recent_return": round(
+                self._last_economic_reward / self._reward_scale, 5
+            ),
             "most_recent_profit": round(self.get_most_recent_profit(), 5),
             "total_profit": round(self._total_profit, 5),
+            "total_unrealized_profit": round(self._total_unrealized_profit, 5),
+            "reward_economic": round(self._last_economic_reward, 5),
+            "previous_liquidation_value": round(previous_liquidation_value, 8),
+            "reward_liquidation_value": round(self._reward_liquidation_value, 8),
+            "next_liquidation_value": round(self._next_liquidation_value, 8),
+            "economic_ruin": self._economic_ruin,
+            "drawdown_breached": drawdown_breached,
             "prev_potential": round(self._last_prev_potential, 5),
             "next_potential": round(self._last_next_potential, 5),
             "reward_entry_additive": round(self._last_entry_additive, 5),
@@ -3664,7 +3018,9 @@ class MyRLEnv(Base5ActionRLEnv):
             "idle_duration": idle_duration,
             "idle_ratio": (idle_duration / max_idle_duration),
             "trade_duration": trade_duration,
-            "duration_ratio": (trade_duration / max(1, self.max_trade_duration_candles)),
+            "duration_ratio": (
+                trade_duration / max(1, self.max_trade_duration_candles)
+            ),
             "trade_count": len(self.trade_history) // 2,
         }
         self._update_history(info)
@@ -3672,11 +3028,13 @@ class MyRLEnv(Base5ActionRLEnv):
             self._get_observation(),
             reward,
             terminated,
-            self.is_truncated(),
+            truncated,
             info,
         )
 
-    def append_trade_history(self, trade_type: str, price: float, profit: float) -> None:
+    def append_trade_history(
+        self, trade_type: str, price: float, profit: float
+    ) -> None:
         self.trade_history.append(
             {
                 "tick": self._current_tick,
@@ -3687,14 +3045,10 @@ class MyRLEnv(Base5ActionRLEnv):
         )
 
     def is_terminated(self) -> bool:
-        return (
-            self._current_tick == self._end_tick
-            or self._total_profit < self.max_drawdown
-            or self._total_unrealized_profit < self.max_drawdown
-        )
+        return self._economic_ruin
 
     def is_truncated(self) -> bool:
-        return False
+        return self._current_tick >= self._end_tick and not self.is_terminated()
 
     def is_tradesignal(self, action: int) -> bool:
         """
@@ -3752,6 +3106,12 @@ class MyRLEnv(Base5ActionRLEnv):
             return self._current_tick - self._start_tick
         return self._current_tick - self._last_closed_trade_tick
 
+    def get_trade_duration(self) -> int:
+        """Return the raw count of completed candle marks since entry."""
+        if self._position == Positions.Neutral or self._last_trade_tick is None:
+            return 0
+        return self._current_tick - self._last_trade_tick + 1
+
     def get_max_unrealized_profit(self) -> float:
         """
         Get the maximum unrealized profit if the agent is in a trade
@@ -3765,11 +3125,9 @@ class MyRLEnv(Base5ActionRLEnv):
         return self._max_unrealized_profit
 
     def _update_max_unrealized_profit(self, pnl: float) -> None:
-        if (
-            self._position in (Positions.Long, Positions.Short)
-            and pnl > self._max_unrealized_profit
-        ):
-            self._max_unrealized_profit = pnl
+        if self._position in (Positions.Long, Positions.Short):
+            if pnl > self._max_unrealized_profit:
+                self._max_unrealized_profit = pnl
 
     def get_min_unrealized_profit(self) -> float:
         """
@@ -3784,75 +3142,14 @@ class MyRLEnv(Base5ActionRLEnv):
         return self._min_unrealized_profit
 
     def _update_min_unrealized_profit(self, pnl: float) -> None:
-        if (
-            self._position in (Positions.Long, Positions.Short)
-            and pnl < self._min_unrealized_profit
-        ):
-            self._min_unrealized_profit = pnl
-
-    def get_most_recent_return(self) -> float:
-        """
-        Calculate tick-to-tick log-return for the current position.
-
-        Entry fees are applied on position transitions only (Neutral/opposite → current).
-
-        Returns
-        -------
-        float
-            Log-return: ln(current/previous)
-            - Long: positive when price rises
-            - Short: positive when price falls
-            - 0.0 if no trade, neutral position, or invalid prices
-        """
-        if self._last_trade_tick is None:
-            return 0.0
-        if self._position == Positions.Neutral:
-            return 0.0
-
-        elif self._position == Positions.Long:
-            current_price = self.current_price()
-            previous_price = self.previous_price()
-            previous_tick = self.previous_tick()
-            if (
-                self._position_history[previous_tick] == Positions.Short
-                or self._position_history[previous_tick] == Positions.Neutral
-            ):
-                previous_price = self.add_entry_fee(previous_price)
-
-            if (
-                previous_price <= 0.0
-                or not np.isfinite(previous_price)
-                or current_price <= 0.0
-                or not np.isfinite(current_price)
-            ):
-                return 0.0
-
-            return np.log(current_price) - np.log(previous_price)
-
-        elif self._position == Positions.Short:
-            current_price = self.current_price()
-            previous_price = self.previous_price()
-            previous_tick = self.previous_tick()
-            if (
-                self._position_history[previous_tick] == Positions.Long
-                or self._position_history[previous_tick] == Positions.Neutral
-            ):
-                previous_price = self.add_exit_fee(previous_price)
-
-            if (
-                previous_price <= 0.0
-                or not np.isfinite(previous_price)
-                or current_price <= 0.0
-                or not np.isfinite(current_price)
-            ):
-                return 0.0
-
-            return np.log(previous_price) - np.log(current_price)
-
-        return 0.0
+        if self._position in (Positions.Long, Positions.Short):
+            if pnl < self._min_unrealized_profit:
+                self._min_unrealized_profit = pnl
 
     def _update_portfolio_log_returns(self):
-        self.portfolio_log_returns[self._current_tick] = self.get_most_recent_return()
+        self.portfolio_log_returns[self._current_tick] = (
+            self._last_economic_reward / self._reward_scale
+        )
 
     def get_most_recent_profit(self) -> float:
         """
@@ -3905,7 +3202,7 @@ class MyRLEnv(Base5ActionRLEnv):
         return 0.0
 
     def previous_tick(self) -> int:
-        return max(self._current_tick - 1, self._start_tick)
+        return max(self._current_tick - 1, self._start_tick - 1)
 
     def previous_price(self) -> float:
         return self.prices.iloc[self.previous_tick()].get("open")
@@ -3927,7 +3224,9 @@ class MyRLEnv(Base5ActionRLEnv):
         if self.trade_history:
             _trade_history_df = DataFrame(self.trade_history)
             if "tick" in _trade_history_df.columns:
-                _rollout_history = merge(_rollout_history, _trade_history_df, on="tick", how="left")
+                _rollout_history = merge(
+                    _rollout_history, _trade_history_df, on="tick", how="left"
+                )
 
         try:
             history = merge(
@@ -3986,7 +3285,12 @@ class MyRLEnv(Base5ActionRLEnv):
 
             ticks = history.get("tick")
             history_open = history.get("open")
-            if ticks is None or len(ticks) == 0 or history_open is None or len(history_open) == 0:
+            if (
+                ticks is None
+                or len(ticks) == 0
+                or history_open is None
+                or len(history_open) == 0
+            ):
                 return fig
 
             axs[0].plot(ticks, history_open, linewidth=1, color="orchid", zorder=1)

--- a/ReforceXY/user_data/freqaimodels/ReforceXY.py
+++ b/ReforceXY/user_data/freqaimodels/ReforceXY.py
@@ -2592,7 +2592,6 @@ class MyRLEnv(Base5ActionRLEnv):
         )
         return self._get_liquidation_pnl(close_price)
 
-    @staticmethod
     def is_pbrs_invariant_mode(self) -> bool:
         """Return whether the configuration meets necessary canonical PBRS conditions.
 
@@ -2614,7 +2613,6 @@ class MyRLEnv(Base5ActionRLEnv):
             self._entry_additive_enabled or self._exit_additive_enabled
         )  # "canonical"
 
-    @staticmethod
     def _set_observation_space(self) -> None:
         """
         Set the observation space


### PR DESCRIPTION
Part 1/9 of the reforcexy-core atomic stack (integrated composition of PRs #120/#121/#162/#163 sliced into ordered, dependency-stacked atomic PRs).

**What:** Rewrites `MyRLEnv` to the fee-aware economic reward contract — `base_factor*(log(reward_liquidation_value)-log(previous_liquidation_value))` computed through an unregistered Freqtrade `LocalTrade` (spot, leverage 1), a causal fill(open[t])/mark(close[t]) observation clock, and economic-ruin-only termination (max-drawdown demoted to a diagnostic field).

**Source units:** #120 u1 (economic reward + LocalTrade helpers), u2 (causal clock), u3 (ruin termination). Merges plan units A01+A02+A03 — #120's single atomic `MyRLEnv` rewrite whose methods cross-reference each other with no atomic sub-history.

**Config:** `base_factor` replaces `win_reward_factor`; `hold_potential_enabled=false`; `exit_potential_mode=canonical`; `identifier -> ReforceXY-PPO-causal-net-log-v1`.

**Base:** `main`. **Verification:** `python -m py_compile` passes; `ruff check --select F` clean. Behavioral validation requires the owner's external RL harness (unavailable here); static checks are the acceptance floor.