### PR TITLE
feat(docker): manage xgboost installation and version

### DIFF
--- a/quickadapter/Dockerfile
+++ b/quickadapter/Dockerfile
@@ -7,6 +7,7 @@ ARG scikit_learn_extra_version=0.3.0
 ARG scikit_image_version=0.26.0
 ARG ngboost_version=0.5.11
 ARG catboost_version=1.2.10
+ARG xgboost_version=3.4.1
 
 USER root
 RUN apt-get update \
@@ -23,7 +24,8 @@ RUN pip install --user --no-cache-dir \
     scikit-learn-extra==${scikit_learn_extra_version} \
     scikit-image==${scikit_image_version} \
     ngboost==${ngboost_version} \
-    catboost==${catboost_version}
+    catboost==${catboost_version} \
+    xgboost==${xgboost_version}
 
 LABEL org.opencontainers.image.source="freqai-strategies" \
       org.opencontainers.image.title="freqtrade-quickadapter" \

--- a/quickadapter/docker-compose.yml
+++ b/quickadapter/docker-compose.yml
@@ -24,6 +24,7 @@ services:
         scikit_image_version: 0.26.0
         ngboost_version: 0.5.11
         catboost_version: 1.2.10
+        xgboost_version: 3.4.1
     restart: unless-stopped
     container_name: freqtrade-quickadapter
     environment:


### PR DESCRIPTION
## Problem

The `freqtradeorg/freqtrade:stable_freqai` base image ships xgboost **3.2.0** while PyPI latest is **3.4.1**. Every other managed dependency (optuna, catboost, ngboost, scikit-image, matplotlib) is pinned as a Dockerfile `ARG` and auto-bumped by renovate; xgboost was the only regressor library left to base-image lag.

## Change

- `quickadapter/Dockerfile`: `ARG xgboost_version=3.4.1` + `xgboost==${xgboost_version}` in the runtime `pip install` (same pattern as `catboost_version`).
- `quickadapter/docker-compose.yml`: matching `xgboost_version` build arg.
- Renovate: no config change needed — the existing custom regex manager (`ARG (\w+)_version` + pypi datasource) picks it up automatically.
- ReforceXY untouched: it does not import xgboost.

## Verification

- QA image rebuilt `--pull`: `import xgboost` → **3.4.1** (was 3.2.0).
- BasedPyright snapshots regenerated with the rebuilt images and byte-identical to the committed ones (242 quickadapter / 159 reforcexy diagnostics) — xgboost 3.4.1 introduces no new diagnostics.
- `ruff check` + `ruff format --check`: pass.