### PR TITLE
feat(docker): manage lightgbm installation and version

### DIFF
--- a/quickadapter/Dockerfile
+++ b/quickadapter/Dockerfile
@@ -8,7 +8,7 @@ ARG scikit_image_version=0.26.0
 ARG ngboost_version=0.5.11
 ARG catboost_version=1.2.10
 ARG xgboost_version=3.4.1
-
+ARG lightgbm_version=4.7.0
 USER root
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential git \
@@ -25,7 +25,8 @@ RUN pip install --user --no-cache-dir \
     scikit-image==${scikit_image_version} \
     ngboost==${ngboost_version} \
     catboost==${catboost_version} \
-    xgboost==${xgboost_version}
+    xgboost==${xgboost_version} \
+    lightgbm==${lightgbm_version}
 
 LABEL org.opencontainers.image.source="freqai-strategies" \
       org.opencontainers.image.title="freqtrade-quickadapter" \

--- a/quickadapter/docker-compose.yml
+++ b/quickadapter/docker-compose.yml
@@ -25,6 +25,7 @@ services:
         ngboost_version: 0.5.11
         catboost_version: 1.2.10
         xgboost_version: 3.4.1
+        lightgbm_version: 4.7.0
     restart: unless-stopped
     container_name: freqtrade-quickadapter
     environment:


### PR DESCRIPTION
Stacked on #248 (xgboost) — same treatment, same rationale: pin lightgbm as a managed build dependency (ARG `lightgbm_version=4.7.0` in the Dockerfile + matching compose build arg + automatic renovate bumps via the existing custom regex manager).

The base image currently ships lightgbm **4.7.0 == PyPI latest**, so no effective version change today — this guarantees the image tracks the latest release independently of future base-image lag (the xgboost case showed a 2-minor-version lag: 3.2.0 vs 3.4.1).

Verification: QA image rebuilt `--pull` → `import lightgbm` = 4.7.0, `import xgboost` = 3.4.1; BasedPyright snapshots regenerated with the rebuilt image and byte-identical (242/159 diagnostics); `ruff check` + `ruff format --check` pass.