### PR TITLE
style(docker): keep blank line after build args

### DIFF
--- a/quickadapter/Dockerfile
+++ b/quickadapter/Dockerfile
@@ -9,6 +9,7 @@ ARG ngboost_version=0.5.11
 ARG catboost_version=1.2.10
 ARG xgboost_version=3.4.1
 ARG lightgbm_version=4.7.0
+
 USER root
 RUN apt-get update \
  && apt-get install -y --no-install-recommends build-essential git \


### PR DESCRIPTION
Restore the blank line between the `ARG` block and `USER root` in `quickadapter/Dockerfile`, lost in the #248/#249 merges (the line was left unstaged when the lightgbm commit was amended during its rebase). No semantic change.